### PR TITLE
fix(xmlenc1): reject nil elements without panicking

### DIFF
--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -287,6 +287,9 @@ func encrypt(ctx context.Context, cfg *encryptConfig, elem *helium.Element, encT
 	if err != nil {
 		return nil, abort(ctx, err)
 	}
+	if elem == nil {
+		return nil, abort(ctx, fmt.Errorf("%w: %v", ErrEncryptionFailed, helium.ErrNilNode))
+	}
 
 	// Serialize the plaintext. Element encrypts the element itself;
 	// Content encrypts its children.

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -334,6 +334,36 @@ func TestEncryptErrors(t *testing.T) {
 	})
 }
 
+func TestEncryptNilElement(t *testing.T) {
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		SessionKey(randKey(t, 32))
+
+	for _, encrypt := range []struct {
+		name string
+		fn   func() (*helium.Element, error)
+	}{
+		{
+			name: "EncryptElement",
+			fn: func() (*helium.Element, error) {
+				return encryptor.EncryptElement(t.Context(), nil)
+			},
+		},
+		{
+			name: "EncryptContent",
+			fn: func() (*helium.Element, error) {
+				return encryptor.EncryptContent(t.Context(), nil)
+			},
+		},
+	} {
+		t.Run(encrypt.name, func(t *testing.T) {
+			_, err := encrypt.fn()
+			require.EqualError(t, err, "xmlenc1: encryption failed: nil node")
+			require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+		})
+	}
+}
+
 func TestEncryptElementPlacement(t *testing.T) {
 	t.Run("preserves sibling order", func(t *testing.T) {
 		for _, tc := range []struct {


### PR DESCRIPTION
- Fixes API-2 from the xmlenc1 production-readiness review.
- EncryptContent now validates nil elements before serialization and returns the package error instead of panicking.
- A focused regression test covers the nil input.
