### PR TITLE
fix(xmlenc1): classify nil document errors

### DIFF
--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -262,7 +262,7 @@ func (e Encryptor) EncryptBytes(ctx context.Context, doc *helium.Document, plain
 		return nil, err
 	}
 	if doc == nil {
-		return nil, abort(ctx, fmt.Errorf("%w: EncryptBytes requires a document to own the EncryptedData element", ErrMissingConfig))
+		return nil, abort(ctx, fmt.Errorf("%w: EncryptBytes requires a document to own the EncryptedData element", helium.ErrNilNode))
 	}
 	cfg := e.config()
 	resolved, err := resolveEncryptConfig(cfg)

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -648,7 +648,8 @@ func TestEncryptBytes(t *testing.T) {
 		_, err := xmlenc1.NewEncryptor().
 			SessionKey(randKey(t, 32)).
 			EncryptBytes(t.Context(), nil, payload)
-		require.ErrorIs(t, err, xmlenc1.ErrMissingConfig)
+		require.ErrorIs(t, err, helium.ErrNilNode)
+		require.NotErrorIs(t, err, xmlenc1.ErrMissingConfig)
 	})
 
 	t.Run("applies the same key-source checks", func(t *testing.T) {


### PR DESCRIPTION
- Stop classifying a nil EncryptBytes document as missing encryption configuration.
- Return the established nil-node error and preserve valid detached encryption behavior.
