### PR TITLE
use constant-time compare for key unwrap integrity

### DIFF
--- a/xmlenc1/keywrap.go
+++ b/xmlenc1/keywrap.go
@@ -2,6 +2,7 @@ package xmlenc1
 
 import (
 	"crypto/aes"
+	"crypto/subtle"
 	"encoding/binary"
 	"fmt"
 )
@@ -146,8 +147,17 @@ func aesKeyUnwrap(kek, ciphertext []byte, keySize int) ([]byte, error) {
 		}
 	}
 
-	// Check integrity
-	if a != defaultIV {
+	// Check integrity in constant time. A is a function of the recipient's
+	// KEK and an attacker-chosen ciphertext, so how many of its leading
+	// bytes match the RFC 3394 IV is information about the KEK, not about
+	// the document, and must not reach the wire as a timing difference.
+	// Go's array equality is not a constant-time primitive: it lowers to a
+	// single 64-bit compare only where the backend can merge loads, and
+	// falls back to a short-circuiting pair of word compares (386) or a
+	// runtime.memequal call (arm, mips, riscv64, wasm) elsewhere.
+	// pkcs7UnpadConstantTime holds this package's other integrity check to
+	// the same rule.
+	if subtle.ConstantTimeCompare(a[:], defaultIV[:]) != 1 {
 		// Wrap in ErrDecryptionFailed so a caller testing only that
 		// sentinel catches a failed key unwrap the same way it catches a
 		// failed RSA key transport, which decryptSessionKey wraps.

--- a/xmlenc1/keywrap_test.go
+++ b/xmlenc1/keywrap_test.go
@@ -261,3 +261,99 @@ func TestKeyWrapSize(t *testing.T) {
 		require.ErrorAs(t, err, &kse)
 	})
 }
+
+// newKeyWrapElem builds an EncryptedData element carrying wrapped as the
+// sole EncryptedKey's CipherValue, wrapping sessionKey-encrypted plaintext
+// under dataAlgorithm. It follows the same construction TestKeyWrapSize's
+// "wrapped key length must match the block algorithm" subtest uses, pulled
+// out to a named helper so TestKeyWrapIntegrityCheck's subtests can share it.
+func newKeyWrapElem(t *testing.T, dataAlgorithm string, sessionKey, wrapped []byte) *helium.Element {
+	t.Helper()
+	cipher, err := xmlenc1.EncryptBytesForTest(dataAlgorithm, sessionKey, []byte("<x>secret</x>"))
+	require.NoError(t, err)
+	doc := mustParseXML(t, `<root/>`)
+	elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: dataAlgorithm},
+		EncryptedKeys: []*xmlenc1.EncryptedKey{{
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
+			CipherValue:      wrapped,
+		}},
+		CipherValue: cipher,
+	})
+	require.NoError(t, err)
+	return elem
+}
+
+// flipLowBit returns a copy of b with bit 0 of the byte at position i
+// flipped, leaving every other byte untouched.
+func flipLowBit(b []byte, i int) []byte {
+	corrupted := make([]byte, len(b))
+	copy(corrupted, b)
+	corrupted[i] ^= 0x01
+	return corrupted
+}
+
+// TestKeyWrapIntegrityCheck exercises aesKeyUnwrap's RFC 3394 integrity
+// check — the comparison of the recovered A register against defaultIV —
+// through the public Decryptor. It pins the current pass/fail/error-message
+// behavior so a refactor of that comparison (e.g. to a constant-time
+// primitive) cannot silently change which wraps are accepted or what a
+// caller sees when one is rejected.
+func TestKeyWrapIntegrityCheck(t *testing.T) {
+	const dataAlgorithm = xmlenc1.AES256GCM // a 32-byte session key
+	kek := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+
+	wrapped, err := xmlenc1.AESKeyWrapForTest(kek, sessionKey)
+	require.NoError(t, err)
+	require.Len(t, wrapped, 40)
+
+	t.Run("the intact wrap still unwraps", func(t *testing.T) {
+		elem := newKeyWrapElem(t, dataAlgorithm, sessionKey, wrapped)
+		nodes, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), elem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+		s, err := helium.WriteString(nodes[0])
+		require.NoError(t, err)
+		require.Contains(t, s, "secret")
+	})
+
+	// Corrupting any one of the 40 wrapped-key wire bytes must be rejected,
+	// and every rejection must look identical to a caller: same sentinel
+	// errors, same error string. A position-dependent message would leak
+	// which byte the unwrap disagreed on.
+	t.Run("every corrupted wrap byte is rejected identically", func(t *testing.T) {
+		var wantErr string
+		for i := range wrapped {
+			elem := newKeyWrapElem(t, dataAlgorithm, sessionKey, flipLowBit(wrapped, i))
+			_, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), elem)
+			require.ErrorIs(t, err, xmlenc1.ErrKeyUnwrapFailed)
+			require.ErrorIs(t, err, xmlenc1.ErrDecryptionFailed)
+			if i == 0 {
+				wantErr = err.Error()
+				continue
+			}
+			require.Equal(t, wantErr, err.Error())
+		}
+	})
+
+	// Wire bytes 0-7 carry the A register the integrity check actually
+	// compares against defaultIV. Covering each of those 8 bytes
+	// individually, including byte 7, is the direct exercise of that
+	// comparison rather than of diffusion through the surrounding rounds.
+	t.Run("a corrupted integrity register is rejected", func(t *testing.T) {
+		var wantErr string
+		for i := range 8 {
+			elem := newKeyWrapElem(t, dataAlgorithm, sessionKey, flipLowBit(wrapped, i))
+			_, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), elem)
+			require.ErrorIs(t, err, xmlenc1.ErrKeyUnwrapFailed)
+			require.ErrorIs(t, err, xmlenc1.ErrDecryptionFailed)
+			if i == 0 {
+				wantErr = err.Error()
+				continue
+			}
+			require.Equal(t, wantErr, err.Error())
+		}
+	})
+}


### PR DESCRIPTION
- defense-in-depth consistency change, no behavior change
- amd64 already lowers array equality to one compare; this covers 386 and non-load-merging backends
- xmldsig1 already holds itself to this same rule for its own integrity check
