### PR TITLE
fix(xmlenc1): correct DigestSHA384 URI

### DIFF
--- a/xmlenc1/constants.go
+++ b/xmlenc1/constants.go
@@ -61,11 +61,22 @@ const (
 const (
 	DigestSHA1   = NamespaceDSig + "sha1"
 	DigestSHA256 = NamespaceXMLEnc + "sha256"
-	DigestSHA384 = NamespaceXMLEnc + "sha384"
-	// DigestSHA384DSigMore is the XMLDSig-more SHA-384 URI.
+	// DigestSHA384 has no identifier in the 2001 xmlenc namespace, unlike
+	// SHA-256 and SHA-512 above: xmlenc-core1 leaves SHA-384 undefined, and
+	// RFC 6931 places it in the xmldsig-more namespace instead. This constant
+	// uses that URI, matching xmldsig1.DigestSHA384.
+	DigestSHA384 = NamespaceDSigMore + "sha384"
+	// DigestSHA384DSigMore is a documented alias of DigestSHA384, kept for
+	// callers that reference it by this name.
 	DigestSHA384DSigMore = NamespaceDSigMore + "sha384"
 	DigestSHA512         = NamespaceXMLEnc + "sha512"
 )
+
+// legacyDigestSHA384XMLEnc is the SHA-384 digest URI this package once wrote
+// in the 2001 xmlenc namespace. No W3C specification defines it, but it is
+// accepted on read for compatibility with documents this package has already
+// emitted; it is never written.
+const legacyDigestSHA384XMLEnc = NamespaceXMLEnc + "sha384"
 
 // MGF algorithm URIs.
 const (

--- a/xmlenc1/constants_test.go
+++ b/xmlenc1/constants_test.go
@@ -1,0 +1,20 @@
+package xmlenc1_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+// SHA-384 has no identifier in the 2001 xmlenc namespace, unlike SHA-256 and
+// SHA-512, so DigestSHA384 must use the xmldsig-more URI: the same one
+// DigestSHA384DSigMore names and the same one xmldsig1.DigestSHA384 already
+// uses.
+func TestDigestSHA384URI(t *testing.T) {
+	const want = "http://www.w3.org/2001/04/xmldsig-more#sha384"
+	require.Equal(t, want, xmlenc1.DigestSHA384)
+	require.Equal(t, xmlenc1.DigestSHA384DSigMore, xmlenc1.DigestSHA384)
+	require.Equal(t, xmldsig1.DigestSHA384, xmlenc1.DigestSHA384)
+}

--- a/xmlenc1/key_agreement.go
+++ b/xmlenc1/key_agreement.go
@@ -372,7 +372,7 @@ func concatKDFHash(uri string) (func() hash.Hash, error) {
 		return sha1.New, nil
 	case DigestSHA256:
 		return sha256.New, nil
-	case DigestSHA384, DigestSHA384DSigMore:
+	case DigestSHA384, legacyDigestSHA384XMLEnc:
 		return sha512.New384, nil
 	case DigestSHA512:
 		return sha512.New, nil

--- a/xmlenc1/key_agreement_encrypt_test.go
+++ b/xmlenc1/key_agreement_encrypt_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"strings"
 	"testing"
 
 	helium "github.com/lestrrat-go/helium"
@@ -202,6 +203,60 @@ func TestEncryptECDHESEmptyDigestDropsOversizedOtherInfo(t *testing.T) {
 	require.Empty(t, kdf.SuppPrivInfo)
 
 	nodes, err := xmlenc1.NewDecryptor().ECPrivateKey(key).Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+}
+
+// SHA-384 has no identifier in the 2001 xmlenc namespace, so a ConcatKDF
+// DigestMethod set to DigestSHA384 must serialize as the xmldsig-more URI,
+// never the legacy xmlenc# one, and still decrypt.
+func TestEncryptECDHESSHA384EmitsXMLDSigMoreDigestURI(t *testing.T) {
+	key := generateECKey(t, elliptic.P256())
+	doc := mustParseXML(t, samlAssertion)
+
+	edElem, err := xmlenc1.NewEncryptor().
+		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
+		RecipientECPublicKey(&key.PublicKey).
+		KeyDerivationParams(&xmlenc1.ConcatKDFParams{DigestMethod: xmlenc1.DigestSHA384}).
+		EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, xml, "http://www.w3.org/2001/04/xmldsig-more#sha384")
+	require.NotContains(t, xml, "http://www.w3.org/2001/04/xmlenc#sha384")
+
+	nodes, err := xmlenc1.NewDecryptor().ECPrivateKey(key).Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+}
+
+// A ConcatKDFParams DigestMethod carrying the legacy xmlenc#sha384 URI this
+// package (or an older version of it) once emitted must still decrypt.
+func TestDecryptECDHESAcceptsLegacyXMLEncSHA384DigestURI(t *testing.T) {
+	key := generateECKey(t, elliptic.P256())
+	doc := mustParseXML(t, samlAssertion)
+
+	_, err := xmlenc1.NewEncryptor().
+		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
+		RecipientECPublicKey(&key.PublicKey).
+		KeyDerivationParams(&xmlenc1.ConcatKDFParams{DigestMethod: xmlenc1.DigestSHA384}).
+		EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, xml, xmlenc1.DigestSHA384)
+
+	legacyDigest := xmlenc1.NamespaceXMLEnc + "sha384"
+	tampered := strings.Replace(xml, xmlenc1.DigestSHA384, legacyDigest, 1)
+	require.NotEqual(t, xml, tampered)
+
+	tdoc := mustParseXML(t, tampered)
+	edNode := findEncryptedData(t, tdoc.DocumentElement())
+	require.NotNil(t, edNode)
+
+	nodes, err := xmlenc1.NewDecryptor().ECPrivateKey(key).Decrypt(t.Context(), edNode)
 	require.NoError(t, err)
 	require.Len(t, nodes, 1)
 }

--- a/xmlenc1/key_agreement_internal_test.go
+++ b/xmlenc1/key_agreement_internal_test.go
@@ -40,14 +40,14 @@ func TestConcatKDFNonByteAlignedOtherInfo(t *testing.T) {
 	require.Equal(t, want[:], got)
 }
 
-func TestConcatKDFSHA384AcceptsXMLDSigMoreURI(t *testing.T) {
+func TestConcatKDFSHA384AcceptsLegacyXMLEncURI(t *testing.T) {
 	sharedSecret := []byte{0x01, 0x02, 0x03, 0x04}
 
 	canonical, err := deriveConcatKDF(sharedSecret, &ConcatKDFParams{DigestMethod: DigestSHA384}, 48)
 	require.NoError(t, err)
-	alias, err := deriveConcatKDF(sharedSecret, &ConcatKDFParams{DigestMethod: DigestSHA384DSigMore}, 48)
+	legacy, err := deriveConcatKDF(sharedSecret, &ConcatKDFParams{DigestMethod: legacyDigestSHA384XMLEnc}, 48)
 	require.NoError(t, err)
-	require.Equal(t, canonical, alias)
+	require.Equal(t, canonical, legacy)
 }
 
 func TestDecryptECDHSessionKeyAllowsOnlyAESKeyWrap(t *testing.T) {

--- a/xmlenc1/keytransport.go
+++ b/xmlenc1/keytransport.go
@@ -86,7 +86,7 @@ func oaepHashes(algorithm, digest, mgf string) (crypto.Hash, crypto.Hash, error)
 		digestHash = crypto.SHA1
 	case DigestSHA256:
 		digestHash = crypto.SHA256
-	case DigestSHA384, DigestSHA384DSigMore:
+	case DigestSHA384, legacyDigestSHA384XMLEnc:
 		digestHash = crypto.SHA384
 	case DigestSHA512:
 		digestHash = crypto.SHA512

--- a/xmlenc1/keytransport_test.go
+++ b/xmlenc1/keytransport_test.go
@@ -69,7 +69,35 @@ func TestRSAOAEP(t *testing.T) {
 		}
 	})
 
-	t.Run("oaep11 sha384 XMLDSig-more compatibility URI after parse", func(t *testing.T) {
+	t.Run("oaep11 sha384 emits the xmldsig-more digest URI", func(t *testing.T) {
+		// SHA-384 has no identifier in the 2001 xmlenc namespace: DigestSHA384
+		// must serialize as the xmldsig-more URI, never the legacy xmlenc# one.
+		key := generateRSAKey(t)
+		doc := mustParseXML(t, samlAssertion)
+
+		encryptor := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256GCM11).
+			KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+			OAEPDigest(xmlenc1.DigestSHA384).
+			OAEPMGF(xmlenc1.MGFSHA1).
+			RecipientPublicKey(&key.PublicKey)
+
+		edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.NoError(t, err)
+
+		xml, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, xml, "http://www.w3.org/2001/04/xmldsig-more#sha384")
+		require.NotContains(t, xml, "http://www.w3.org/2001/04/xmlenc#sha384")
+
+		nodes, err := xmlenc1.NewDecryptor().PrivateKey(key).Decrypt(t.Context(), edElem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+	})
+
+	t.Run("oaep11 sha384 legacy xmlenc digest URI after parse still decrypts", func(t *testing.T) {
+		// A document this package (or an older version of it) emitted with the
+		// legacy xmlenc#sha384 digest URI must still decrypt.
 		key := generateRSAKey(t)
 		doc := mustParseXML(t, samlAssertion)
 
@@ -87,8 +115,8 @@ func TestRSAOAEP(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, xml, xmlenc1.DigestSHA384)
 
-		compatDigest := xmlenc1.DigestSHA384DSigMore
-		tampered := strings.Replace(xml, xmlenc1.DigestSHA384, compatDigest, 1)
+		legacyDigest := xmlenc1.NamespaceXMLEnc + "sha384"
+		tampered := strings.Replace(xml, xmlenc1.DigestSHA384, legacyDigest, 1)
 		require.NotEqual(t, xml, tampered)
 
 		tdoc := mustParseXML(t, tampered)


### PR DESCRIPTION
- `DigestSHA384` pointed at an undefined xmlenc# URI; SHA-384 is xmldsig-more only, matching `xmldsig1.DigestSHA384`.
- Decrypt still accepts the legacy xmlenc# URI on documents this package already emitted.
- Breaking: `DigestSHA384` now emits a different, correct URI; decrypting old and new documents is unaffected.
