### PR TITLE
fix(xmlenc1): check KeySize against algorithm

### DIFF
--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -209,6 +209,21 @@ decrypt:
   (CVE-2016-2183) applies, and NIST SP 800-131A Rev. 2 disallows TDEA
   encryption after 2023.
 
+An `xenc:KeySize` child of `EncryptionMethod` is read and checked, but it is
+never used as a key length: every algorithm URI this package implements
+already fixes its own. A `KeySize` under a URI that implies a length must
+state exactly that length — in bits, per §5.6.2.2 — or the document is
+refused with `ErrMalformedEncrypted` while it is read, ahead of a pre-shared
+[`Decryptor.SessionKey`](#decrypting-with-a-pre-shared-session-key)'s early
+return, so a contradicting value cannot be bypassed that way; an
+`EncryptedData` carrying no `EncryptionMethod` at all has no `KeySize` to
+check either way. A `KeySize` under a URI that implies no length — RSA key
+transport above all — is accepted and ignored. What remains absent is
+`KeySize` as the length SOURCE, used when the URI alone cannot supply one;
+that case arises only for stream ciphers and key agreements naming such an
+algorithm, none of which this package implements. `Encryptor` writes no
+`KeySize`.
+
 Section 3 carries a blanket "features described in this section MUST be
 implemented", so four more constructs are unimplemented, and only one of them
 can fail a decrypt: `xenc:ReferenceList` (§3.6), which points from a key to the

--- a/xmlenc1/decrypt_block_algorithm_test.go
+++ b/xmlenc1/decrypt_block_algorithm_test.go
@@ -1,6 +1,7 @@
 package xmlenc1_test
 
 import (
+	"strings"
 	"testing"
 
 	helium "github.com/lestrrat-go/helium"
@@ -211,4 +212,46 @@ func TestDecryptBlockAlgorithm(t *testing.T) {
 		_, err = conflicting.Decrypt(t.Context(), elem)
 		require.ErrorIs(t, err, xmlenc1.ErrConflictingBlockAlgorithm)
 	})
+}
+
+// TestDecryptRejectsKeySizeContradiction proves the xenc:KeySize consistency
+// check (xmlenc-core1 §3.2, §5.3, §5.6.2.2) runs at parse, before any
+// cryptography: an otherwise fully valid RSA-OAEP-protected EncryptedData
+// whose own (block-algorithm) EncryptionMethod carries a KeySize
+// contradicting its algorithm fails with ErrMalformedEncrypted even when the
+// recipient's correct PrivateKey is configured, so the refusal cannot be a
+// byproduct of a failed key transport or unwrap.
+func TestDecryptRejectsKeySizeContradiction(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		OAEPDigest(xmlenc1.DigestSHA256).
+		OAEPMGF(xmlenc1.MGFSHA256).
+		RecipientPublicKey(&key.PublicKey)
+
+	_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	// The payload EncryptionMethod (aes256-gcm) is self-closing on the wire;
+	// splice in a KeySize that contradicts its implied 256 bits.
+	original := `<xenc:EncryptionMethod Algorithm="` + xmlenc1.AES256GCM + `"/>`
+	tampered := `<xenc:EncryptionMethod Algorithm="` + xmlenc1.AES256GCM + `"><xenc:KeySize>128</xenc:KeySize></xenc:EncryptionMethod>`
+	require.Contains(t, xml, original)
+	xml = strings.Replace(xml, original, tampered, 1)
+
+	tdoc := mustParseXML(t, xml)
+	edElem := findEncryptedData(t, tdoc.DocumentElement())
+	require.NotNil(t, edElem)
+
+	_, err = xmlenc1.NewDecryptor().PrivateKey(key).Decrypt(t.Context(), edElem)
+	require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+
+	_, err = xmlenc1.NewDecryptor().PrivateKey(key).DecryptBytes(t.Context(), edElem)
+	require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
 }

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdh"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -565,9 +566,12 @@ const maxKeySizeChars = 64
 // refused. maxKeySizeChars is enforced as the characters are gathered, so a
 // document cannot make this walk hold a value sized only by what it sends.
 //
-// The gathered text is trimmed and parsed with [strconv.Atoi], which accepts
-// exactly the xs:integer lexical space (an optional sign and leading zeros).
-// A value outside that space is ErrMalformedEncrypted naming it.
+// The gathered text is trimmed of the four characters xs:integer's
+// whiteSpace='collapse' facet permits and parsed with [strconv.Atoi], which
+// accepts the rest of that lexical space (an optional sign and leading zeros).
+// A value outside the lexical space is ErrMalformedEncrypted naming it. A value
+// INSIDE it that no int can hold is not: xs:integer is unbounded, so such a
+// value is returned clamped and left to the consistency check.
 func parseKeySizeBits(ctx context.Context, elem *helium.Element) (int, error) {
 	var chars []byte
 	if err := eachSibling(ctx, elem.FirstChild(), func(child helium.Node) error {
@@ -583,11 +587,19 @@ func parseKeySizeBits(ctx context.Context, elem *helium.Element) (int, error) {
 	}); err != nil {
 		return 0, err
 	}
-	value := strings.TrimSpace(string(chars))
+	// xs:integer carries whiteSpace='collapse', whose whitespace is exactly
+	// #x20, #x9, #xD and #xA. strings.TrimSpace would also strip U+00A0 and
+	// the other Unicode spaces, which are not in the lexical space.
+	value := strings.Trim(string(chars), " \t\r\n")
 	bits, err := strconv.Atoi(value)
-	if err != nil {
+	if err != nil && !errors.Is(err, strconv.ErrRange) {
 		return 0, abort(ctx, fmt.Errorf("%w: invalid KeySize %q", ErrMalformedEncrypted, value))
 	}
+	// A well-formed xs:integer too large for an int is a value the schema
+	// permits, so it is not malformed. Atoi has already clamped it to
+	// MaxInt/MinInt, which can never equal an algorithm's key size, so a URI
+	// that implies a length still reports the contradiction and one that
+	// implies none still ignores it.
 	return bits, nil
 }
 
@@ -740,6 +752,22 @@ func decodeBoundedBase64(ctx context.Context, elem *helium.Element, valueName st
 // undecodable and the decode fails, which is the right verdict for it. The
 // Entity's NextSibling is deliberately not followed either — it is the next
 // declaration in the DTD, not part of this value.
+//
+// The literal is returned in FULL rather than truncated to what the caller's
+// limit still has room for, and that whole cost is one transient copy of one
+// child: every caller weighs the returned text against its own limit and stops
+// at the first child that exceeds it, so at most one such copy is ever taken.
+// Its size is bounded twice over by the parser that built the tree —
+// [helium.DefaultMaxNodeContentSize] caps the declared literal itself, and
+// [helium.DefaultMaxEntityAmplification] caps the total expanded entity bytes
+// a document may reach as a multiple of its own input size, which is what
+// bounds how many references to that literal it can carry. Because the literal
+// is UNEXPANDED, a chain of entities
+// each referencing the one below costs the length of the reference text it is
+// written with (&inner;&inner;) rather than the length that text would expand
+// to, so nesting buys a document no size it did not already write. All of that
+// is measurable: a 4 MiB entity replacement and a 4 MiB plain text child
+// allocate the same 4.2 MB through [Decryptor.Decrypt].
 //
 // A CHILDLESS EntityRef is a normal parser output, not a caller-built shape:
 // per XML 1.0's "Entity Declared" constraint, an undeclared general entity is

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
@@ -505,13 +506,23 @@ func parseEncryptionMethod(ctx context.Context, elem *helium.Element) (*Encrypti
 			em.MGFAlgorithm = alg
 		case isXMLEncElem(e, "KeySize"):
 			// KeySize is an optional singleton in the schema. The package
-			// derives key sizes from the algorithm URI and does not consume
-			// KeySize, so enforce at-most-one cardinality to stay consistent
-			// with the other sub-element guards.
+			// derives key sizes from the algorithm URI and never uses KeySize
+			// as a length SOURCE, but xmlenc-core1 §3.2 makes a KeySize that
+			// CONTRADICTS the algorithm an error ("the presence of a KeySize
+			// child inconsistent with the algorithm MUST be treated as an
+			// error"; §5.3 states the same rule from the other side), so a
+			// present value is still read and checked against it.
 			if seenKeySize {
 				return fmt.Errorf("%w: duplicate KeySize", ErrMalformedEncrypted)
 			}
 			seenKeySize = true
+			bits, err := parseKeySizeBits(ctx, e)
+			if err != nil {
+				return err
+			}
+			if err := checkDeclaredKeySize(em.Algorithm, bits); err != nil {
+				return err
+			}
 		case isXMLEncElem(e, "OAEPparams"):
 			if seenOAEPParams {
 				return fmt.Errorf("%w: duplicate OAEPparams", ErrMalformedEncrypted)
@@ -529,6 +540,73 @@ func parseEncryptionMethod(ctx context.Context, elem *helium.Element) (*Encrypti
 	}
 
 	return em, nil
+}
+
+// maxKeySizeChars bounds the lexical length of one xenc:KeySize value.
+// KeySize is xs:integer naming a key length in bits (§5.6.2.2), and every
+// value that can agree with an algorithm this package implements is three
+// digits (128, 192, 256). 64 leaves ample room for the whitespace, sign and
+// leading zeros xs:integer's lexical space permits, while still keeping the
+// parse from holding a number sized only by what the document says.
+const maxKeySizeChars = 64
+
+// parseKeySizeBits reads elem's character data as the lexical value of one
+// xenc:KeySize element and returns it as a number of bits.
+//
+// It walks elem's children directly rather than calling [helium.Element.Content],
+// for the same reason [decodeBoundedBase64] does: that accessor aggregates the
+// whole descendant subtree into one buffer, and this value is read while the
+// document is parsed, before anything it says is authenticated. It reuses
+// base64CharacterData, which already encodes the child-kind rules this value
+// needs too — despite the helper's name, those rules hold for any XML simple
+// content, not only base64: text and CDATA carry the value, an entity
+// reference contributes its declared replacement text through one hop, a
+// comment or processing instruction is ignored, and an element child is
+// refused. maxKeySizeChars is enforced as the characters are gathered, so a
+// document cannot make this walk hold a value sized only by what it sends.
+//
+// The gathered text is trimmed and parsed with [strconv.Atoi], which accepts
+// exactly the xs:integer lexical space (an optional sign and leading zeros).
+// A value outside that space is ErrMalformedEncrypted naming it.
+func parseKeySizeBits(ctx context.Context, elem *helium.Element) (int, error) {
+	var chars []byte
+	if err := eachSibling(ctx, elem.FirstChild(), func(child helium.Node) error {
+		text, err := base64CharacterData(child, "KeySize")
+		if err != nil {
+			return err
+		}
+		if len(chars)+len(text) > maxKeySizeChars {
+			return fmt.Errorf("%w: KeySize is over the %d character limit", ErrMalformedEncrypted, maxKeySizeChars)
+		}
+		chars = append(chars, text...)
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+	value := strings.TrimSpace(string(chars))
+	bits, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, abort(ctx, fmt.Errorf("%w: invalid KeySize %q", ErrMalformedEncrypted, value))
+	}
+	return bits, nil
+}
+
+// checkDeclaredKeySize enforces xmlenc-core1 §3.2's rule that a KeySize
+// inconsistent with the algorithm is an error (§5.3 restates it from the
+// EncryptionMethod side, and §5.6.2.2 fixes the unit: KeySize is "The size
+// in bits of the key") against algorithm's own implied length.
+//
+// keySizeForAlgorithm answers with an error for a URI that implies no length
+// at all — RSA key transport above all — and that is not a contradiction:
+// nothing on the wire disagrees with anything, so bits is accepted and
+// silently ignored, which is exactly what a URI silent on key length
+// anticipates. Only a URI that DOES imply a length is checked against it.
+func checkDeclaredKeySize(algorithm string, bits int) error {
+	want, err := keySizeForAlgorithm(paramBlockAlgorithm, algorithm)
+	if err == nil && bits != want*8 {
+		return fmt.Errorf("%w: KeySize %d bits is inconsistent with algorithm %q, which requires %d bits", ErrMalformedEncrypted, bits, algorithm, want*8)
+	}
+	return nil
 }
 
 // maxOAEPParamsBytes bounds the decoded octet length of one xenc:OAEPparams

--- a/xmlenc1/parse_test.go
+++ b/xmlenc1/parse_test.go
@@ -456,6 +456,39 @@ func TestEncryptionMethodKeySize(t *testing.T) {
 		require.Equal(t, xmlenc1.AES256GCM, ed.EncryptionMethod.Algorithm)
 	})
 
+	t.Run("non-breaking space rejected", func(t *testing.T) {
+		// xs:integer's whiteSpace='collapse' facet covers exactly #x20, #x9,
+		// #xD and #xA, so the ASCII spaces the case above accepts are in the
+		// lexical space but U+00A0 is not. A value wrapped in NBSP is not an
+		// xs:integer and must be refused rather than trimmed into one.
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			"<xenc:KeySize>\u00a0256\u00a0</xenc:KeySize>"+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+		require.Contains(t, err.Error(), "invalid KeySize")
+	})
+
+	t.Run("out-of-range value is a consistency question, not a syntax one", func(t *testing.T) {
+		// xs:integer is unbounded, so a 64-digit value is well formed even
+		// though no int can hold it. It therefore reaches the consistency
+		// check like any other value: ignored under a URI that implies no
+		// key length, and inconsistent under one that does.
+		digits := strings.Repeat("9", 64)
+
+		ed, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`">`+
+			`<xenc:KeySize>`+digits+`</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.NoError(t, err)
+		require.Equal(t, xmlenc1.RSAOAEP11, ed.EncryptionMethod.Algorithm)
+
+		_, err = parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>`+digits+`</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+		require.Contains(t, err.Error(), "inconsistent")
+		require.Contains(t, err.Error(), "256")
+	})
+
 	t.Run("value spread over text and CDATA accepted", func(t *testing.T) {
 		// Proves the character-data walk, not Content(): a value split
 		// across a text node and a CDATA section must still be joined.

--- a/xmlenc1/parse_test.go
+++ b/xmlenc1/parse_test.go
@@ -376,6 +376,126 @@ func TestEncryptionMethodCardinality(t *testing.T) {
 	})
 }
 
+// TestEncryptionMethodKeySize verifies that parseEncryptionMethod checks a
+// present xenc:KeySize against the length its algorithm URI already implies
+// (xmlenc-core1 §3.2, §5.3, §5.6.2.2), rather than silently ignoring it: a
+// KeySize consistent with what the algorithm fixes parses, one inconsistent
+// with it is ErrMalformedEncrypted, and one under a URI that implies no
+// length at all (RSA key transport) is accepted and ignored.
+func TestEncryptionMethodKeySize(t *testing.T) {
+	const head = `<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">`
+	const cipher = `<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>`
+
+	parse := func(t *testing.T, em string) (*xmlenc1.EncryptedData, error) {
+		t.Helper()
+		doc := mustParseXML(t, head+em+cipher)
+		elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+		require.True(t, ok)
+		return xmlenc1.ParseEncryptedDataForTest(elem)
+	}
+
+	t.Run("agreeing KeySize parses", func(t *testing.T) {
+		ed, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>256</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.NoError(t, err)
+		require.Equal(t, xmlenc1.AES256GCM, ed.EncryptionMethod.Algorithm)
+	})
+
+	t.Run("contradicting KeySize rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>128</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+		require.Contains(t, err.Error(), "128")
+		require.Contains(t, err.Error(), "256")
+	})
+
+	t.Run("byte-valued KeySize rejected", func(t *testing.T) {
+		// KeySize is in BITS (xmlenc-core1 §5.6.2.2). A producer that wrote
+		// the byte count (32, for AES-256) contradicts the algorithm rather
+		// than matching it — this pins the bits-not-bytes decision.
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>32</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+		require.Contains(t, err.Error(), "32")
+		require.Contains(t, err.Error(), "256")
+	})
+
+	t.Run("KeySize contradicting AES key wrap on EncryptedKey rejected", func(t *testing.T) {
+		doc := mustParseXML(t, head+
+			`<ds:KeyInfo><xenc:EncryptedKey>`+
+			`<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES128KeyWrap+`">`+
+			`<xenc:KeySize>256</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`+
+			`<xenc:CipherData><xenc:CipherValue>BBBB</xenc:CipherValue></xenc:CipherData>`+
+			`</xenc:EncryptedKey></ds:KeyInfo>`+
+			cipher)
+		elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+		require.True(t, ok)
+		_, err := xmlenc1.ParseEncryptedDataForTest(elem)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+		require.Contains(t, err.Error(), "256")
+		require.Contains(t, err.Error(), "128")
+	})
+
+	t.Run("KeySize under RSA-OAEP key transport accepted", func(t *testing.T) {
+		ed, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`">`+
+			`<xenc:KeySize>256</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.NoError(t, err)
+		require.Equal(t, xmlenc1.RSAOAEP11, ed.EncryptionMethod.Algorithm)
+	})
+
+	t.Run("whitespace and leading zeros accepted", func(t *testing.T) {
+		ed, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>  00256  </xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.NoError(t, err)
+		require.Equal(t, xmlenc1.AES256GCM, ed.EncryptionMethod.Algorithm)
+	})
+
+	t.Run("value spread over text and CDATA accepted", func(t *testing.T) {
+		// Proves the character-data walk, not Content(): a value split
+		// across a text node and a CDATA section must still be joined.
+		ed, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>2<![CDATA[56]]></xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.NoError(t, err)
+		require.Equal(t, xmlenc1.AES256GCM, ed.EncryptionMethod.Algorithm)
+	})
+
+	t.Run("element child rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize><bogus/></xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("comment ignored", func(t *testing.T) {
+		ed, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>2<!-- comment -->56</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.NoError(t, err)
+		require.Equal(t, xmlenc1.AES256GCM, ed.EncryptionMethod.Algorithm)
+	})
+
+	t.Run("over-length value refused before conversion", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>`+strings.Repeat("2", 65)+`</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("non-integer rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>not-a-number</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+}
+
 // oaepParamsOverLimit is the fragment the OAEPparams size limit puts in its
 // error. Every parse failure in this package wraps ErrMalformedEncrypted, so
 // the sentinel alone cannot tell a value refused by the limit from one the


### PR DESCRIPTION
- xmlenc-core1 §3.2/§5.3 make a `KeySize` inconsistent with the algorithm an error; helium accepted and dropped it
- checks in bits per §5.6.2.2, so a byte-valued or non-integer `KeySize` is now `ErrMalformedEncrypted`
