### PR TITLE
fix(xmlenc1): trim only XML space in ConcatKDF hex

### DIFF
--- a/xmlenc1/key_agreement_test.go
+++ b/xmlenc1/key_agreement_test.go
@@ -91,6 +91,66 @@ func boundaryOtherInfo(algorithmID, partyUInfo int) map[string]string {
 	}
 }
 
+// The ConcatKDF OtherInfo attributes are xs:hexBinary, whose whiteSpace
+// facet is 'collapse' and whose whitespace is exactly #x20, #x9, #xD and
+// #xA. A value wrapped in any other Unicode space survives collapse and is
+// therefore not in the lexical space, so it must be refused rather than
+// trimmed into a well-formed one. Accepting it makes helium read a document a
+// schema-validating peer rejects. U+000B and U+000C are deliberately absent:
+// both are outside XML 1.0's Char production, so the XML parser refuses such a
+// document before xmlenc1 ever sees the attribute.
+func TestParseConcatKDFHexAttributeWhitespace(t *testing.T) {
+	const (
+		attrName   = "PartyUInfo"
+		partyUInfo = "00b9e13a70c35edcb3b66fda86b4898942"
+	)
+	decoded := []byte{0xb9, 0xe1, 0x3a, 0x70, 0xc3, 0x5e, 0xdc, 0xb3, 0xb6, 0x6f, 0xda, 0x86, 0xb4, 0x89, 0x89, 0x42}
+
+	rejected := []struct {
+		name  string
+		value string
+	}{
+		{name: "no-break space", value: "\u00a0" + partyUInfo + "\u00a0"},
+		{name: "next line", value: "\u0085" + partyUInfo + "\u0085"},
+		{name: "em space", value: "\u2003" + partyUInfo + "\u2003"},
+		{name: "ideographic space", value: "\u3000" + partyUInfo + "\u3000"},
+		// A value that is nothing but a non-XML space collapses to itself, not
+		// to the empty string, so it is an INVALID field rather than an absent
+		// one and must not be silently read as omitted.
+		{name: "lone no-break space", value: "\u00a0"},
+	}
+
+	for _, tt := range rejected {
+		t.Run(tt.name+" rejected", func(t *testing.T) {
+			doc := mustParseXML(t, ecdhESDocument(map[string]string{attrName: tt.value}))
+			_, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
+			require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+			require.Contains(t, err.Error(), attrName)
+		})
+	}
+
+	// The two controls pin the accept side: an unwrapped value and one wrapped
+	// in the four characters collapse really does strip must both still parse
+	// to the same field bytes.
+	accepted := []struct {
+		name  string
+		value string
+	}{
+		{name: "plain", value: partyUInfo},
+		{name: "XML whitespace", value: " \t\r\n" + partyUInfo + "\n\r\t "},
+	}
+
+	for _, tt := range accepted {
+		t.Run(tt.name+" accepted", func(t *testing.T) {
+			doc := mustParseXML(t, ecdhESDocument(map[string]string{attrName: tt.value}))
+			ed, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
+			require.NoError(t, err)
+			require.Len(t, ed.EncryptedKeys, 1)
+			require.Equal(t, decoded, ed.EncryptedKeys[0].AgreementMethod.KeyDerivationMethod.ConcatKDF.PartyUInfo)
+		})
+	}
+}
+
 // A remote peer supplies the EncryptedData, and nothing else in xmlenc1 bounds
 // the ConcatKDF OtherInfo fields: the only ceiling is whatever the XML parser
 // happened to allow for an attribute value, which a caller can raise, disable,

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -462,10 +462,13 @@ func parseConcatKDFParams(ctx context.Context, elem *helium.Element) (*ConcatKDF
 
 func parseConcatKDFHexAttribute(elem *helium.Element, name string) ([]byte, uint8, error) {
 	value, ok := elem.GetAttribute(name)
-	if !ok || strings.TrimSpace(value) == "" {
+	// xs:hexBinary carries whiteSpace='collapse', whose whitespace is exactly
+	// #x20, #x9, #xD and #xA. strings.TrimSpace would also strip U+00A0 and
+	// the other Unicode spaces, which are not in the lexical space.
+	if !ok || strings.Trim(value, " \t\r\n") == "" {
 		return nil, 0, nil
 	}
-	value = strings.TrimSpace(value)
+	value = strings.Trim(value, " \t\r\n")
 	// A single field can never be larger than the whole set, so the same
 	// budget rules this attribute out from its hex length alone — before
 	// hex.DecodeString allocates half of it. The set-wide check in


### PR DESCRIPTION
- ConcatKDF's xs:hexBinary attributes accept only the whiteSpace='collapse' set
- interoperability, not security: the trimmed value decoded to the same octets
- matches the collapse-set trim already used for KeySize
