### PR TITLE
gate releases on the xmlenc11 suite

### DIFF
--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -6,10 +6,9 @@ name: Conformance run
 # fails when the suite reports any failures.
 #
 # Invoked by conformance.yml (nightly/manual entrypoint) and by release.yml
-# (the release-gating xslt30, xmldsig2ed, xmldsig11, and merlinxmldsig runs;
-# xmlenc11 is currently manual because its expectation ledger has known gaps;
-# only xslt30 enables slow tests). Kept as a single source of truth so the
-# checkout/fetch/run logic is not duplicated.
+# (the release-gating xslt30, xmldsig2ed, xmldsig11, merlinxmldsig, and
+# xmlenc11 runs; only xslt30 enables slow tests). Kept as a single source of
+# truth so the checkout/fetch/run logic is not duplicated.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -5,8 +5,7 @@ name: Conformance
 # fixture sets and, with the performance-gated slow tests enabled, can take many
 # minutes. The actual checkout/fetch/run logic lives in the reusable
 # conformance-run.yml, shared with the release-gating xslt30, xmldsig2ed,
-# xmldsig11, and merlinxmldsig runs plus the manual xmlenc11 run; only xslt30
-# enables slow tests.
+# xmldsig11, merlinxmldsig, and xmlenc11 runs; only xslt30 enables slow tests.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,15 +62,16 @@ jobs:
           )
           PY
 
-  # Release-gating conformance runs: the full slow XSLT 3.0 suite and all three
-  # XMLDSig suites must pass with zero failures before anything is tagged or
-  # published. Every matrix entry is a required job result.
+  # Release-gating conformance runs: the full slow XSLT 3.0 suite, all three
+  # XMLDSig suites, and the XML Encryption 1.1 suite must pass with zero
+  # failures before anything is tagged or published. Every matrix entry is a
+  # required job result.
   conformance-gate:
     needs: timeline-presence
     strategy:
       fail-fast: false
       matrix:
-        suite: [xslt30, xmldsig2ed, xmldsig11, merlinxmldsig]
+        suite: [xslt30, xmldsig2ed, xmldsig11, merlinxmldsig, xmlenc11]
     permissions:
       contents: read
     uses: ./.github/workflows/conformance-run.yml
@@ -79,7 +80,9 @@ jobs:
       slow: ${{ matrix.suite == 'xslt30' }}
       # Pin the release gate to the certified harness commit. Update this SHA
       # only after a newer harness commit passes the manual Conformance run.
-      harness_ref: 6c987d8fe551efb4a9171fdb5657a922cff442d3
+      # This one is the first to carry the xmlenc11 suite, which the matrix
+      # above gates on, so the two must advance together.
+      harness_ref: 39d9ff5f072cf804e503588958178fc6e71cd32d
 
   release:
     needs: conformance-gate

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,10 +32,10 @@ so a failed conformance run never leaves a public tag or partial release behind.
 4. The `timeline-presence` job checks in seconds that `version` has a row in the
    committed timeline (from step 2). If it does not, the run stops here — fix step
    2 and re-dispatch.
-5. The `conformance-gate` job runs the `xslt30`, `xmldsig2ed`, `xmldsig11`, and
-   `merlinxmldsig` suites against the pinned harness commit; only `xslt30`
-   enables slow tests. If any suite fails, the run stops here — **no tag, no
-   release.**
+5. The `conformance-gate` job runs the `xslt30`, `xmldsig2ed`, `xmldsig11`,
+   `merlinxmldsig`, and `xmlenc11` suites against the pinned harness commit;
+   only `xslt30` enables slow tests. If any suite fails, the run stops here —
+   **no tag, no release.**
 6. On green, the `release` job waits for **environment approval** (the `release`
    environment: maintainer reviewer, restricted to `main`). Approve it in the run.
 7. After approval it creates and pushes the `version` tag, then runs goreleaser
@@ -61,10 +61,10 @@ candidate and superseded by a real-tag re-measure afterwards. See
 ## Conformance gate
 
 A release cannot be tagged/published unless the XSLT 3.0, XMLDSig2Ed, XMLDSig
-1.1, and Merlin XMLDSig conformance suites pass with **0 failures**. The full
-XSLT suite is **release-gating, not
-PR-gating**: the heavyweight W3C conformance suites are never run on ordinary
-pushes or pull requests (they clone large upstream fixture sets and, with the
+1.1, Merlin XMLDSig, and XML Encryption 1.1 conformance suites pass with
+**0 failures**. The full XSLT suite is **release-gating, not PR-gating**: the
+heavyweight W3C conformance suites are never run on ordinary pushes or pull
+requests (they clone large upstream fixture sets and, with the
 performance-gated slow tests enabled, take many minutes), so they must not block
 day-to-day PR CI.
 
@@ -72,10 +72,10 @@ day-to-day PR CI.
 
 `.github/workflows/release.yml`'s `conformance-gate` matrix runs the reusable
 `.github/workflows/conformance-run.yml` for `xslt30`, `xmldsig2ed`, `xmldsig11`,
-and `merlinxmldsig`. Only the XSLT entry sets `slow: true`, which enables
-`HELIUM_SLOW_TESTS=1`. The `release` job declares `needs: conformance-gate` and
-runs *after* every matrix entry, so the tag is created and goreleaser runs only
-on a green set of suites.
+`merlinxmldsig`, and `xmlenc11`. Only the XSLT entry sets `slow: true`, which
+enables `HELIUM_SLOW_TESTS=1`. The `release` job declares
+`needs: conformance-gate` and runs *after* every matrix entry, so the tag is
+created and goreleaser runs only on a green set of suites.
 
 The reusable run gates on the reported failure **count**: after running the
 suite it reads `<testsuites failures="N">` from the JUnit report and fails the
@@ -91,10 +91,10 @@ tests on.
 
 ### Generated suite summaries
 
-The committed suite summaries under `xmldsig1/` are generated feature evidence
-for the helium and harness commits recorded in each file. They do not represent
-release-tag measurements. Release-tag results belong in `CONFORMANCE.md` and
-`tools/conformance-timeline/`.
+The committed suite summaries under `xmldsig1/` and `xmlenc1/` are generated
+feature evidence for the helium and harness commits recorded in each file. They
+do not represent release-tag measurements. Release-tag results belong in
+`CONFORMANCE.md` and `tools/conformance-timeline/`.
 
 ## The pinned release harness
 
@@ -113,7 +113,9 @@ gh api repos/lestrrat-go/helium-w3c-tests/commits/main --jq .sha
 ```
 
 Bump the pin in its own PR. It only advances which tests gate a release; nothing
-else depends on it.
+else depends on it. The one exception is adding a suite to the
+`conformance-gate` matrix: the pinned harness has to already carry that suite,
+so a new matrix entry and the pin bump that supplies it belong in the same PR.
 
 ## Environment approval
 

--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -569,8 +569,10 @@ package implements neither, so there is nothing runnable to add and no skip
 entry to write — a skip would imply a vector is being passed over when none
 exists. The feature's evidence is this package's own tests.
 
-The suite is available through the manual Conformance workflow and is not part
-of the release gate.
+The suite gates releases: `release.yml`'s `conformance-gate` matrix runs it
+against the pinned harness commit, and a release is neither tagged nor published
+unless it reports zero failures. It is also available on demand through the
+manual Conformance workflow.
 
 Run it from `../helium-w3c-tests`:
 


### PR DESCRIPTION
- Make a red XML Encryption 1.1 interop run block a release, the same way the XSLT and XMLDSig suites already do.
- Bump the pinned harness to the first commit carrying that suite, since the new matrix entry cannot run without it.
