### PR TITLE
name the Triple DES exception up front

### DIFF
--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -2,7 +2,10 @@
 
 > **EXPERIMENTAL** — This package is under active development. Its API may change without notice, and it may be moved to a separate repository in the future.
 
-The `xmlenc1` package implements W3C XML Encryption 1.1 for helium documents.
+The `xmlenc1` package implements W3C XML Encryption 1.1 for helium documents,
+except for Triple DES, which it refuses deliberately even though the
+specification marks it REQUIRED. [Conformance scope](#conformance-scope) gives
+the reason, and names every other construct this package does not read.
 
 Import path: `github.com/lestrrat-go/helium/xmlenc1`
 

--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -586,8 +586,8 @@ package implements neither, so there is nothing runnable to add and no skip
 entry to write — a skip would imply a vector is being passed over when none
 exists. The feature's evidence is this package's own tests.
 
-AES-CBC is covered in this package's tests rather than by that suite, against a
-third-party vector. `TestInteropRetrievalMethod` decrypts
+This package's own tests carry the AES-CBC evidence, against a third-party
+vector. `TestInteropRetrievalMethod` decrypts
 `merlin-xmlenc-five/encrypt-element-aes256-cbc-retrieved-kw-aes256.xml` from the
 Apache Santuario corpus end to end, which exercises `aes256-cbc` block
 decryption, `kw-aes256` unwrapping, a same-document `ds:RetrievalMethod`, and

--- a/xmlenc1/cbc_padding_test.go
+++ b/xmlenc1/cbc_padding_test.go
@@ -16,7 +16,7 @@ const cbcPaddingPayload = `<greeting xmlns="urn:example">hello</greeting>`
 // arbitraryPaddedCipherValue builds the CipherValue a conforming third-party
 // implementation emits: AES-CBC over a plaintext padded the way xmlenc-core1
 // §5.2.1 allows, with the octets ahead of the final length octet holding filler
-// rather than a repeat of the length. This package never writes that shape
+// chosen independently of the length. This package never writes that shape
 // itself, so nothing built through Encryptor can stand in for it.
 func arbitraryPaddedCipherValue(t *testing.T, key []byte) []byte {
 	t.Helper()
@@ -82,8 +82,8 @@ func TestCBCPaddingPolicy(t *testing.T) {
 	})
 
 	// Turning the opt-in explicitly off is the same as leaving it unset, so a
-	// caller threading a configuration flag through gets the documented
-	// default rather than a third behavior.
+	// caller threading a configuration flag through gets exactly the
+	// documented default.
 	t.Run("the opt-in set to false matches the default", func(t *testing.T) {
 		key := randKey(t, 32)
 		doc := mustParseXML(t, cbcPaddingPayload)
@@ -143,8 +143,8 @@ func TestCBCPaddingPolicy(t *testing.T) {
 		require.Len(t, nodes, 1)
 	})
 
-	// DecryptBytes shares the block decryption, so it must apply the same rule
-	// as Decrypt rather than having a policy of its own.
+	// DecryptBytes shares the block decryption, so the rule it applies must be
+	// the one Decrypt applies.
 	t.Run("DecryptBytes applies the same rule", func(t *testing.T) {
 		const opaque = "not xml at all"
 

--- a/xmlenc1/export_test.go
+++ b/xmlenc1/export_test.go
@@ -81,7 +81,7 @@ const MaxConcatKDFOtherInfoBytesForTest = maxConcatKDFOtherInfoBytes
 // EncryptCBCArbitraryPaddingForTest AES-CBC encrypts plaintext under key,
 // padding it the way xmlenc-core1 §5.2.1 allows and this package never writes:
 // the final octet names the padding length N, and the N-1 octets ahead of it
-// are all filler rather than a repeat of N. It exists so a test can build the
+// all carry filler chosen independently of N. It exists so a test can build the
 // conforming ciphertext a third-party implementation emits, which is the shape
 // PKCS#7 unpadding refuses.
 //

--- a/xmlenc1/interop_test.go
+++ b/xmlenc1/interop_test.go
@@ -71,9 +71,9 @@ func TestInteropRetrievalMethod(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, xmlenc1.ErrDecryptionFailed)
 
-		// The session key was still reached and unwrapped: only the block
-		// decryption refused, which is what makes this a padding refusal
-		// rather than a key one.
+		// The session key was still reached and unwrapped, so the block
+		// decryption is the only step that refused, which is what identifies
+		// this as a padding refusal.
 		require.NotErrorIs(t, err, xmlenc1.ErrKeyUnwrapFailed)
 		require.NotErrorIs(t, err, xmlenc1.ErrMissingKey)
 	})

--- a/xmlenc1/padding_internal_test.go
+++ b/xmlenc1/padding_internal_test.go
@@ -140,7 +140,7 @@ func TestUnpadConstantTime(t *testing.T) {
 
 // TestUnpadConstantTimeDefaultIsXMLEnc pins the zero value of cbcPadding to the
 // conforming rule, so a decrypt path that forgets to thread the option through
-// stays interoperable rather than silently becoming strict.
+// still accepts what every conforming peer writes.
 func TestUnpadConstantTimeDefaultIsXMLEnc(t *testing.T) {
 	var zero cbcPadding
 	require.Equal(t, cbcPaddingXMLEnc, zero)

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -803,8 +803,8 @@ func (d Decryptor) AllowUnauthenticatedCBC(v bool) Decryptor {
 // under the XML Encryption rule any final octet from 1 to the block size is
 // acceptable, so roughly one in sixteen random forgeries survives unpadding,
 // while under PKCS#7 roughly one in 2^(8N) does. Both numbers describe an
-// unauthenticated mode. Neither closes the padding oracle, whose signal is
-// whether the decrypt succeeded at all rather than which step refused it, and
+// unauthenticated mode. Neither closes the padding oracle, whose signal is the
+// success or failure of the decrypt as a whole, and
 // [Decryptor.AllowUnauthenticatedCBC] states the rest of that reasoning. A
 // caller who wants the ciphertext authenticated wants AES-GCM instead.
 //


### PR DESCRIPTION
- Carry the Triple DES exception into the opening line, so a reader who stops there is not misled.
- State the CBC padding docs positively, dropping the "X rather than Y" construction.
