### PR TITLE
note the Triple DES exception in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ an embedded example.
 | [`stream`](stream/README.md) | Streaming XML writer. | Writes XML directly without building a DOM. |
 | [`xinclude`](xinclude/README.md) | XInclude processing for helium documents. | Supports recursive inclusion and custom resolvers. |
 | [`xmldsig1`](xmldsig1/README.md) | W3C XML Digital Signatures 1.1 over helium documents. | Scoped production support for explicit same-document profiles; external references and XSLT are opt-in advanced features. |
-| [`xmlenc1`](xmlenc1/README.md) | W3C XML Encryption 1.1 over helium documents. | **Experimental**; API may change. |
+| [`xmlenc1`](xmlenc1/README.md) | W3C XML Encryption 1.1 over helium documents, except for Triple DES. | **Experimental**; API may change. Triple DES is refused deliberately, so block encryption and key wrapping are AES only. |
 | [`xpath1`](xpath1/README.md) | XPath 1.0 compilation and evaluation. | Includes convenience helpers like `Find` and `Evaluate`. |
 | [`xpath3`](xpath3/README.md) | XPath 3.1 compilation and evaluation. | Includes a compiler, evaluator, maps, arrays, and HOFs. |
 | [`xpointer`](xpointer/README.md) | XPointer evaluation. | Supports shorthand, `element()`, and XPath-backed schemes. |
@@ -244,7 +244,7 @@ go test -tags cgo,libxml2bench -bench=. -benchmem ./bench/
 
 * **Implemented:** XML/HTML parsing, DOM building, SAX2, XPath 1.0, XPath 3.1, Basic XSLT 3.0, XInclude, C14N, RELAX NG, Schematron, XSD, XML Catalog, streaming XML writer, and `encoding/xml` compatibility (`shim` package).
 * **Scoped production support:** W3C XML Digital Signatures 1.1 (`xmldsig1`) for explicit same-document verification profiles. External references and XSLT are opt-in advanced features with caller-owned resource and execution policy.
-* **Experimental:** XML Encryption 1.1 (`xmlenc1`) — its API may change and may move to a separate repository.
+* **Experimental:** XML Encryption 1.1 (`xmlenc1`), except for Triple DES, which it refuses deliberately even though the specification marks it REQUIRED; block encryption and key wrapping are AES only. Its API may change and may move to a separate repository.
 * **CLI:** the `helium` command provides `lint`, `xpath`, `xslt`, `xsd validate`, `relaxng validate`, and `schematron validate` subcommands.
 
 Some edge cases and parity gaps are still being iterated on; contributions and issue reports are welcome.


### PR DESCRIPTION
- Stop the package table and status list from promising all of XML Encryption 1.1.
- Match the wording `xmlenc1/README.md` already carries.
