### PR TITLE
require RetrievalMethod URIs

### DIFF
--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -112,6 +112,12 @@ forms are the only ones that carry comments through. An `"#id"` that matches mor
 than one element (across the document and any enveloping `Object` content) is
 rejected with `ErrAmbiguousReference`, defending against XML Signature Wrapping.
 
+`ds:RetrievalMethod` requires its `URI` attribute. An absent attribute is
+`ErrInvalidKeyInfo`, including when `LenientKeyInfo(true)` is enabled; a present
+empty value remains the null same-document URI. External RetrievalMethod URIs
+are joined against the effective base of the RetrievalMethod element, including
+any inherited `xml:base`, before the configured resolver receives them.
+
 ### Transforms
 
 The supported transforms are the enveloped-signature transform, the

--- a/xmldsig1/retrieval_method.go
+++ b/xmldsig1/retrieval_method.go
@@ -21,6 +21,7 @@ const maxRetrievalMethodDepth = 5
 const maxRetrievalTransformSteps = 16
 
 type preparedRetrievalMethod struct {
+	uri   string
 	steps []transformStep
 }
 
@@ -108,10 +109,13 @@ func prepareRetrievalMethod(ctx context.Context, cfg *verifierConfig, doc *heliu
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	uri, err := retrievalMethodURI(rm)
+	if err != nil {
+		return err
+	}
 	if depth >= maxRetrievalMethodDepth {
 		return fmt.Errorf("%w: chain exceeds %d links", ErrRetrievalMethodLoop, maxRetrievalMethodDepth)
 	}
-	uri, _ := rm.GetAttribute("URI")
 	typ, _ := rm.GetAttribute("Type")
 
 	if _, seen := visited[uri]; seen {
@@ -138,7 +142,7 @@ func prepareRetrievalMethod(ctx context.Context, cfg *verifierConfig, doc *heliu
 		if _, err := validateTransformSteps(runtime, initialKind, steps); err != nil {
 			return err
 		}
-		state = &preparedRetrievalMethod{steps: steps}
+		state = &preparedRetrievalMethod{uri: uri, steps: steps}
 		prepared[rm] = state
 	}
 
@@ -175,18 +179,16 @@ func processRetrievalMethod(ctx context.Context, budget *verifyBudget, cfg *veri
 	if depth >= maxRetrievalMethodDepth {
 		return fmt.Errorf("%w: chain exceeds %d links", ErrRetrievalMethodLoop, maxRetrievalMethodDepth)
 	}
-	uri, _ := rm.GetAttribute("URI")
-	typ, _ := rm.GetAttribute("Type")
-
-	if _, seen := visited[uri]; seen {
-		return fmt.Errorf("%w: %q revisited", ErrRetrievalMethodLoop, uri)
-	}
-	visited[uri] = struct{}{}
-
 	state, ok := prepared[rm]
 	if !ok {
 		return fmt.Errorf("%w: RetrievalMethod pipeline was not prepared", ErrInvalidKeyInfo)
 	}
+	uri := state.uri
+	if _, seen := visited[uri]; seen {
+		return fmt.Errorf("%w: %q revisited", ErrRetrievalMethodLoop, uri)
+	}
+	visited[uri] = struct{}{}
+	typ, _ := rm.GetAttribute("Type")
 	steps := state.steps
 	_, wholeDoc, includeComments, sameDocument := referenceURIForm(uri)
 	runtime := transformRuntime{
@@ -200,7 +202,7 @@ func processRetrievalMethod(ctx context.Context, budget *verifyBudget, cfg *veri
 	// resolved octets run through the same transform pipeline the external
 	// Reference digest path uses before Type interpretation.
 	if !sameDocument {
-		octets, err := resolveRetrievalOctets(ctx, cfg, doc, uri)
+		octets, err := resolveRetrievalOctets(ctx, cfg, doc, rm, uri)
 		if err != nil {
 			return err
 		}
@@ -288,18 +290,27 @@ func parseRetrievalTransforms(ctx context.Context, rm *helium.Element) ([]transf
 }
 
 // resolveRetrievalOctets dereferences an external RetrievalMethod URI through the
-// configured ReferenceResolver, joining it against the document's base URI first.
+// configured ReferenceResolver, joining it against the RetrievalMethod's
+// effective base URI first.
 // Without a resolver it stays fail-closed with ErrReferenceNotFound, identical to
 // the external-Reference posture, and it inherits the shared 64 MiB resolver cap.
-func resolveRetrievalOctets(ctx context.Context, cfg *verifierConfig, doc *helium.Document, uri string) ([]byte, error) {
+func resolveRetrievalOctets(ctx context.Context, cfg *verifierConfig, doc *helium.Document, rm *helium.Element, uri string) ([]byte, error) {
 	if cfg.referenceResolver == nil {
 		return nil, fmt.Errorf("%w: unsupported RetrievalMethod URI: %s", ErrReferenceNotFound, uri)
 	}
-	joined, err := joinReferenceURI(doc.URL(), uri)
+	joined, err := joinReferenceURI(helium.NodeGetBase(doc, rm), uri)
 	if err != nil {
 		return nil, err
 	}
 	return resolveReferenceOctets(ctx, cfg.referenceResolver, joined)
+}
+
+func retrievalMethodURI(rm *helium.Element) (string, error) {
+	uri, ok := rm.GetAttribute("URI")
+	if !ok {
+		return "", fmt.Errorf("%w: ds:RetrievalMethod has no URI attribute", ErrInvalidKeyInfo)
+	}
+	return uri, nil
 }
 
 // interpretRetrievalOctets interprets externally retrieved octets by the

--- a/xmldsig1/retrieval_method_internal_test.go
+++ b/xmldsig1/retrieval_method_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
@@ -40,6 +41,18 @@ type countingReferenceResolver struct {
 
 func (r *countingReferenceResolver) ResolveReference(_ context.Context, _ string) ([]byte, error) {
 	r.calls.Add(1)
+	return r.octets, nil
+}
+
+type capturingReferenceResolver struct {
+	calls  atomic.Int32
+	octets []byte
+	uri    string
+}
+
+func (r *capturingReferenceResolver) ResolveReference(_ context.Context, uri string) ([]byte, error) {
+	r.calls.Add(1)
+	r.uri = uri
 	return r.octets, nil
 }
 
@@ -99,6 +112,57 @@ func TestResolveRetrievalMethodNoResolverFailsClosed(t *testing.T) {
 	err := resolveRetrievalMethods(t.Context(), newVerifyBudget(cfg), cfg, doc, doc.DocumentElement(), data)
 	require.ErrorIs(t, err, ErrReferenceNotFound)
 	require.Empty(t, data.X509Certificates)
+}
+
+func TestRetrievalMethodRequiresURI(t *testing.T) {
+	resolver := &countingReferenceResolver{}
+	for _, lenient := range []bool{false, true} {
+		t.Run(fmt.Sprintf("lenient=%t", lenient), func(t *testing.T) {
+			doc := mustParse(t, `<ds:KeyInfo xmlns:ds="`+NamespaceDSig+`"><ds:RetrievalMethod Type="`+TypeRawX509Certificate+`"/></ds:KeyInfo>`)
+			cfg := &verifierConfig{
+				lenientKeyInfo:    lenient,
+				referenceResolver: resolver,
+			}
+			data := &KeyInfoData{}
+
+			err := resolveRetrievalMethods(t.Context(), newVerifyBudget(cfg), cfg, doc, doc.DocumentElement(), data)
+			require.ErrorIs(t, err, ErrInvalidKeyInfo)
+			require.Contains(t, err.Error(), "ds:RetrievalMethod has no URI attribute")
+			require.Zero(t, resolver.calls.Load(), "missing URI must fail before resolver use")
+			require.Empty(t, data.X509Certificates)
+		})
+	}
+}
+
+func TestRetrievalMethodEmptyURIIsValid(t *testing.T) {
+	cert, der := selfSignedCert(t)
+	doc := mustParse(t, `<ds:X509Data xmlns:ds="`+NamespaceDSig+`"><ds:X509Certificate>`+
+		base64.StdEncoding.EncodeToString(der)+`</ds:X509Certificate><ds:RetrievalMethod URI="" Type="`+
+		TypeX509Data+`"/></ds:X509Data>`)
+	cfg := &verifierConfig{}
+	data := &KeyInfoData{}
+
+	err := resolveRetrievalMethods(t.Context(), newVerifyBudget(cfg), cfg, doc, doc.DocumentElement(), data)
+	require.NoError(t, err)
+	require.Len(t, data.X509Certificates, 1)
+	require.Equal(t, cert.Raw, data.X509Certificates[0].Raw)
+}
+
+func TestRetrievalMethodUsesEffectiveBase(t *testing.T) {
+	cert, der := selfSignedCert(t)
+	resolver := &capturingReferenceResolver{octets: der}
+	doc := mustParse(t, `<root xmlns:ds="`+NamespaceDSig+`" xml:base="https://example.test/outer/">`+
+		`<ds:KeyInfo xml:base="inner/"><ds:RetrievalMethod URI="cert.der" Type="`+
+		TypeRawX509Certificate+`"/></ds:KeyInfo></root>`)
+	cfg := &verifierConfig{referenceResolver: resolver}
+	data := &KeyInfoData{}
+
+	err := resolveRetrievalMethods(t.Context(), newVerifyBudget(cfg), cfg, doc, doc.DocumentElement().FirstChild().(*helium.Element), data)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), resolver.calls.Load())
+	require.Equal(t, "https://example.test/outer/inner/cert.der", resolver.uri)
+	require.Len(t, data.X509Certificates, 1)
+	require.Equal(t, cert.Raw, data.X509Certificates[0].Raw)
 }
 
 func TestResolveRetrievalMethodsPreflightsBeforeResolver(t *testing.T) {

--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -398,10 +398,13 @@ decided while the document is read, so they precede a pre-shared
 [`Decryptor.SessionKey`](#decrypting-with-a-pre-shared-session-key)'s early
 return: that caller does not decrypt past a reference this package refused.
 
-A `ds:RetrievalMethod` whose `Type` this package does not implement — a
-`#DerivedKey` (§3.5.2), or any type from another specification — is stepped
-over before its URI is looked at, so it costs nothing, cannot fail a decrypt,
-and a pre-shared `SessionKey` decrypts past it. A `Type` of
+A `ds:RetrievalMethod` must carry its `URI` attribute. A missing attribute is
+`ErrMalformedEncrypted`, even when the `Type` is one this package skips and
+even when a pre-shared `SessionKey` is configured. A present empty value is the
+valid null same-document URI. After that presence check, a `Type` this package
+does not implement — a `#DerivedKey` (§3.5.2), or any type from another
+specification — is stepped over before its URI is resolved, so it costs nothing,
+cannot fail a decrypt, and a pre-shared `SessionKey` decrypts past it. A `Type` of
 `#EncryptedKey` naming something that is not an `xenc:EncryptedKey` is a
 contradiction inside the document and fails with `ErrMalformedEncrypted`; a
 reference with no `Type` at all is resolved, and its target used only if it is

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -253,6 +253,11 @@ func retainEncryptedKey(ctx context.Context, elem *helium.Element, ed *encrypted
 // for the several references §3.5.3 permits; it is not a loop guard, and the
 // termination argument does not rest on it.
 func parseRetrievalMethod(ctx context.Context, elem *helium.Element, ed *encryptedData, ps *parseState) error {
+	uri, ok := elem.GetAttribute("URI")
+	if !ok {
+		return abort(ctx, fmt.Errorf("%w: ds:RetrievalMethod has no URI attribute, which the xenc schema requires", ErrMalformedEncrypted))
+	}
+
 	typ, _ := elem.GetAttribute("Type")
 	switch typ {
 	case "", TypeEncryptedKey:
@@ -271,7 +276,6 @@ func parseRetrievalMethod(ctx context.Context, elem *helium.Element, ed *encrypt
 		return nil
 	}
 
-	uri, _ := elem.GetAttribute("URI")
 	target, err := resolveSameDocument(ctx, ps.refs, uri)
 	if err != nil {
 		return abort(ctx, err)

--- a/xmlenc1/reference_test.go
+++ b/xmlenc1/reference_test.go
@@ -74,6 +74,14 @@ func retrievalMethodXML(typ, uri string) string {
 	return `<ds:RetrievalMethod` + typAttr + ` URI="` + uri + `"/>`
 }
 
+func retrievalMethodWithoutURIXML(typ string) string {
+	typAttr := ""
+	if typ != "" {
+		typAttr = ` Type="` + typ + `"`
+	}
+	return `<ds:RetrievalMethod` + typAttr + `/>`
+}
+
 // requireSecret asserts that nodes is the single <secret> element
 // retrievalPlaintext describes, i.e. that the decrypt found the session key
 // the RetrievalMethod pointed at.
@@ -93,6 +101,27 @@ func TestRetrievalMethod(t *testing.T) {
 		t.Helper()
 		return randKey(t, 32), randKey(t, 32)
 	}
+
+	t.Run("a missing URI is malformed before Type skipping or session-key use", func(t *testing.T) {
+		for _, typ := range []string{xmlenc1.TypeEncryptedKey, xmlenc1.NamespaceDSig + "X509Data"} {
+			t.Run(typ, func(t *testing.T) {
+				sessionKey := randKey(t, 32)
+				elem := retrievalDoc(t, sessionKey, retrievalMethodWithoutURIXML(typ), "")
+				_, err := xmlenc1.NewDecryptor().SessionKey(sessionKey).Decrypt(t.Context(), elem)
+				require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+				require.Contains(t, err.Error(), "ds:RetrievalMethod has no URI attribute")
+				require.NotErrorIs(t, err, xmlenc1.ErrReferenceNotFound)
+			})
+		}
+	})
+
+	t.Run("a present empty URI remains valid", func(t *testing.T) {
+		sessionKey := randKey(t, 32)
+		elem := retrievalDoc(t, sessionKey, retrievalMethodXML("", ""), "")
+		nodes, err := xmlenc1.NewDecryptor().SessionKey(sessionKey).Decrypt(t.Context(), elem)
+		require.NoError(t, err)
+		requireSecret(t, nodes)
+	})
 
 	t.Run("a same-document target supplies the session key", func(t *testing.T) {
 		sessionKey, kek := newKeys(t)


### PR DESCRIPTION
- Reject missing RetrievalMethod URI attributes before dereference or Type skipping.
- Resolve external XMLDSig RetrievalMethod URIs against the element's effective `xml:base`.
- Preserve empty-URI and fail-closed behavior with focused regression coverage.
