### PR TITLE
add sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,3 +311,17 @@ Please keep pull requests focused and small enough to review quickly.
 
 For usage questions, design discussion, or "is this approach reasonable?" questions,
 please open a GitHub Discussion first.
+
+# Sponsors
+
+Helium is developed and maintained in the open. Keeping a full XML stack —
+parser, XPath 3.1, XSLT 3.0, XSD, Relax NG, Schematron, and the W3C conformance
+suites that keep them honest — working and up to date is ongoing work.
+
+If this project is useful to you or your company, please consider sponsoring:
+
+[![Sponsor lestrrat](https://img.shields.io/badge/Sponsor-lestrrat-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/lestrrat)
+
+Sponsorship funds continued maintenance, conformance work, and support for the
+people who rely on this library. Both individual and corporate sponsorships are
+welcome.

--- a/README.md
+++ b/README.md
@@ -314,10 +314,6 @@ please open a GitHub Discussion first.
 
 # Sponsors
 
-Helium is developed and maintained in the open. Keeping a full XML stack —
-parser, XPath 3.1, XSLT 3.0, XSD, Relax NG, Schematron, and the W3C conformance
-suites that keep them honest — working and up to date is ongoing work.
-
 If this project is useful to you or your company, please consider sponsoring:
 
 [![Sponsor lestrrat](https://img.shields.io/badge/Sponsor-lestrrat-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/lestrrat)


### PR DESCRIPTION
- Make GitHub Sponsors visible to helium users, not just via the repo's sponsor button.
- Frame sponsorship around ongoing maintenance and W3C conformance work.
