### PR TITLE
use pointer receiver for Element attribute iteration

### DIFF
--- a/element.go
+++ b/element.go
@@ -373,9 +373,9 @@ func (n *Element) Attributes() []*Attribute {
 // If fn returns false, iteration stops early.
 // This avoids the slice allocation of Attributes().
 //
-// attr_test.go covers both full iteration and the early-stop path.
-// All current callers always return true; the early-stop path exists as
-// a natural consequence of the iterator pattern.
+// attr_test.go covers both full iteration and the early-stop path; the
+// nine production call sites all return true, so attr_test.go is the
+// early-stop path's only exercise.
 //
 // The loop walks the properties chain via NextAttribute() and asserts
 // nothing: the chain is attribute-only by construction (field typed

--- a/element.go
+++ b/element.go
@@ -360,7 +360,7 @@ func (n *Element) spliceOutAttribute(p *Attribute) {
 // property order. The returned slice is a snapshot: appending to or reordering
 // it does not affect the element, though the *Attribute elements still point at
 // the live attribute nodes. Use ForEachAttribute to avoid the slice allocation.
-func (n Element) Attributes() []*Attribute {
+func (n *Element) Attributes() []*Attribute {
 	attrs := []*Attribute{}
 	for attr := n.properties; attr != nil; attr = attr.NextAttribute() {
 		attrs = append(attrs, attr)
@@ -373,15 +373,14 @@ func (n Element) Attributes() []*Attribute {
 // If fn returns false, iteration stops early.
 // This avoids the slice allocation of Attributes().
 //
-// No dedicated unit tests: iteration order and early-stop semantics
-// are exercised transitively by XPath attribute-axis and doc-order tests.
+// attr_test.go covers both full iteration and the early-stop path.
 // All current callers always return true; the early-stop path exists as
 // a natural consequence of the iterator pattern.
 //
-// The unchecked type assertion on NextSibling is safe: the properties
-// chain is attribute-only by construction (field typed *Attribute,
-// only *Attribute nodes are ever linked in).
-func (n Element) ForEachAttribute(fn func(*Attribute) bool) {
+// The loop walks the properties chain via NextAttribute() and asserts
+// nothing: the chain is attribute-only by construction (field typed
+// *Attribute, only *Attribute nodes are ever linked in).
+func (n *Element) ForEachAttribute(fn func(*Attribute) bool) {
 	for attr := n.properties; attr != nil; attr = attr.NextAttribute() {
 		if !fn(attr) {
 			return


### PR DESCRIPTION
- avoid copying the 224-byte Element struct on every Attributes()/ForEachAttribute() call
- correct ForEachAttribute's doc comment, which described tests and code that don't match reality
- fixes #1426, about -5% on `xpath1.BenchmarkEvaluateAttributePath`, no change in allocs/op
