### PR TITLE
make stream.Writer ns lookup O(1) not O(depth)

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -52,6 +52,14 @@ type elementEntry struct {
 type nsEntry struct {
 	prefix string
 	uri    string
+
+	// prevURI/prevHad record the binding this declaration shadowed, so
+	// popNSScope can restore w.nsBind[prefix] when the scope closes.
+	// prevHad is false when the prefix was unbound before this
+	// declaration, in which case popNSScope deletes it instead of
+	// restoring prevURI.
+	prevURI string
+	prevHad bool
 }
 
 // nsScope holds namespace declarations for one element level.
@@ -65,7 +73,11 @@ type nsScope struct {
 // Writer is not safe for concurrent use by multiple goroutines.
 //
 // The zero value of Writer is not ready to use because it has no output
-// destination. Construct a Writer with NewWriter.
+// destination. Construct a Writer with NewWriter. The fluent configuration
+// methods (Indent, QuoteChar, XMLVersion) must be called before any write:
+// a copy taken after writing begins shares its namespace-binding map with
+// the original, so declarations made through one copy become visible to
+// the other.
 //
 // (libxml2: xmlTextWriter)
 type Writer struct {
@@ -76,15 +88,16 @@ type Writer struct {
 	state         writerState
 	elemStack     []elementEntry
 	nsStack       []nsScope
-	stateStack    []writerState // for comment/PI/CDATA nesting
-	err           error         // sticky error
-	depth         int           // current element nesting depth (for indentation)
-	hasOutput     bool          // true after first output has been written
-	wroteNL       bool          // true after EndComment/EndPI wrote trailing \n (suppresses writeIndent's \n)
-	commentDash   bool          // true if the current comment body ends with '-' (would form '--->' on close)
-	piQuestion    bool          // true if the current PI body ends with '?' (would form '?>' across writes)
-	cdataBrackets int           // count (0,1,2) of trailing ']' in the current CDATA body, to detect ']]>' across writes
-	xml11         bool          // true when serializing XML 1.1: restricted control chars are emitted as decimal character references instead of being rejected
+	nsBind        map[string]string // current in-scope binding per prefix; absent = unbound, present "" = explicitly undeclared (xmlns="")
+	stateStack    []writerState     // for comment/PI/CDATA nesting
+	err           error             // sticky error
+	depth         int               // current element nesting depth (for indentation)
+	hasOutput     bool              // true after first output has been written
+	wroteNL       bool              // true after EndComment/EndPI wrote trailing \n (suppresses writeIndent's \n)
+	commentDash   bool              // true if the current comment body ends with '-' (would form '--->' on close)
+	piQuestion    bool              // true if the current PI body ends with '?' (would form '?>' across writes)
+	cdataBrackets int               // count (0,1,2) of trailing ']' in the current CDATA body, to detect ']]>' across writes
+	xml11         bool              // true when serializing XML 1.1: restricted control chars are emitted as decimal character references instead of being rejected
 }
 
 // NewWriter creates a Writer that writes to w. Configure the Writer
@@ -400,30 +413,20 @@ func (w *Writer) emitPendingNS() {
 	scope.emitted = len(scope.decls)
 }
 
-// lookupNS checks if the prefix is already bound to the given URI in
-// the current namespace stack.
+// lookupNS reports whether the prefix's current in-scope binding is uri.
+// An inner rebinding shadows an outer one, so this reports false once a
+// closer scope has rebound the prefix to a different URI even if an
+// ancestor scope still declares uri.
 func (w *Writer) lookupNS(prefix, uri string) bool {
-	for _, v := range slices.Backward(w.nsStack) {
-		for _, ns := range v.decls {
-			if ns.prefix == prefix {
-				return ns.uri == uri
-			}
-		}
-	}
-	return false
+	cur, ok := w.nsBind[prefix]
+	return ok && cur == uri
 }
 
 // hasDefaultNSInScope returns true if any ancestor has declared a
 // non-empty default namespace (xmlns="...") that is still in scope.
 func (w *Writer) hasDefaultNSInScope() bool {
-	for _, v := range slices.Backward(w.nsStack) {
-		for _, ns := range v.decls {
-			if ns.prefix == "" {
-				return ns.uri != ""
-			}
-		}
-	}
-	return false
+	cur, ok := w.nsBind[""]
+	return ok && cur != ""
 }
 
 // declareNS adds a namespace declaration to the current element scope
@@ -442,7 +445,31 @@ func (w *Writer) declareNS(prefix, uri string) {
 			return // already declared at this level
 		}
 	}
-	scope.decls = append(scope.decls, nsEntry{prefix: prefix, uri: uri})
+	if w.nsBind == nil {
+		w.nsBind = make(map[string]string)
+	}
+	prev, had := w.nsBind[prefix]
+	scope.decls = append(scope.decls, nsEntry{prefix: prefix, uri: uri, prevURI: prev, prevHad: had})
+	w.nsBind[prefix] = uri
+}
+
+// popNSScope closes the innermost namespace scope, restoring each
+// prefix it declared to the binding that scope's declarations shadowed.
+// Declarations are undone in reverse order, matching the LIFO scope
+// exit that StartElement/EndElement enforce.
+func (w *Writer) popNSScope() {
+	if len(w.nsStack) == 0 {
+		return
+	}
+	scope := w.nsStack[len(w.nsStack)-1]
+	for _, ns := range slices.Backward(scope.decls) {
+		if ns.prevHad {
+			w.nsBind[ns.prefix] = ns.prevURI
+			continue
+		}
+		delete(w.nsBind, ns.prefix)
+	}
+	w.nsStack = w.nsStack[:len(w.nsStack)-1]
 }
 
 // validateNSParts validates the prefix and local name supplied to a
@@ -935,9 +962,7 @@ func (w *Writer) EndElement() error {
 	}
 
 	// Pop namespace scope
-	if len(w.nsStack) > 0 {
-		w.nsStack = w.nsStack[:len(w.nsStack)-1]
-	}
+	w.popNSScope()
 
 	// Restore state
 	if len(w.elemStack) > 0 {
@@ -980,9 +1005,7 @@ func (w *Writer) FullEndElement() error {
 	w.writeByte('>')
 
 	// Pop namespace scope
-	if len(w.nsStack) > 0 {
-		w.nsStack = w.nsStack[:len(w.nsStack)-1]
-	}
+	w.popNSScope()
 
 	if len(w.elemStack) > 0 {
 		w.state = stateText

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -68,16 +68,30 @@ type nsScope struct {
 	emitted int // number of decls already emitted (indices < emitted are done)
 }
 
+// nsBindings is the prefix -> URI index for the declarations currently in
+// scope: a prefix is absent when it is unbound, and present with an empty
+// URI when it has been explicitly undeclared (xmlns=""). seq is the index's
+// revision counter, bumped by whichever Writer last changed it. See
+// Writer.ownNSBind for why the revision matters.
+type nsBindings struct {
+	m   map[string]string
+	seq uint64
+}
+
 // Writer writes XML incrementally to an io.Writer.
 //
 // Writer is not safe for concurrent use by multiple goroutines.
 //
 // The zero value of Writer is not ready to use because it has no output
 // destination. Construct a Writer with NewWriter. The fluent configuration
-// methods (Indent, QuoteChar, XMLVersion) must be called before any write:
-// a copy taken after writing begins shares its namespace-binding map with
-// the original, so declarations made through one copy become visible to
-// the other.
+// methods (Indent, QuoteChar, XMLVersion) return copies and are meant to be
+// called before any write. A copy taken after writing has begun resolves
+// namespace prefixes against the scopes it has open itself, independently of
+// the Writer it was copied from. The two copies still write to the same
+// destination, and they still share the backing storage of their element and
+// namespace scope stacks, so writing through both of them after the copy
+// interleaves their output and can overwrite scopes one of them still has
+// open.
 //
 // (libxml2: xmlTextWriter)
 type Writer struct {
@@ -88,16 +102,17 @@ type Writer struct {
 	state         writerState
 	elemStack     []elementEntry
 	nsStack       []nsScope
-	nsBind        map[string]string // current in-scope binding per prefix; absent = unbound, present "" = explicitly undeclared (xmlns="")
-	stateStack    []writerState     // for comment/PI/CDATA nesting
-	err           error             // sticky error
-	depth         int               // current element nesting depth (for indentation)
-	hasOutput     bool              // true after first output has been written
-	wroteNL       bool              // true after EndComment/EndPI wrote trailing \n (suppresses writeIndent's \n)
-	commentDash   bool              // true if the current comment body ends with '-' (would form '--->' on close)
-	piQuestion    bool              // true if the current PI body ends with '?' (would form '?>' across writes)
-	cdataBrackets int               // count (0,1,2) of trailing ']' in the current CDATA body, to detect ']]>' across writes
-	xml11         bool              // true when serializing XML 1.1: restricted control chars are emitted as decimal character references instead of being rejected
+	nsBind        *nsBindings   // in-scope prefix -> URI index; a Writer copy shares it until either copy changes it (ownNSBind)
+	nsSeq         uint64        // revision of nsBind this Writer wrote; it owns nsBind while nsSeq == nsBind.seq
+	stateStack    []writerState // for comment/PI/CDATA nesting
+	err           error         // sticky error
+	depth         int           // current element nesting depth (for indentation)
+	hasOutput     bool          // true after first output has been written
+	wroteNL       bool          // true after EndComment/EndPI wrote trailing \n (suppresses writeIndent's \n)
+	commentDash   bool          // true if the current comment body ends with '-' (would form '--->' on close)
+	piQuestion    bool          // true if the current PI body ends with '?' (would form '?>' across writes)
+	cdataBrackets int           // count (0,1,2) of trailing ']' in the current CDATA body, to detect ']]>' across writes
+	xml11         bool          // true when serializing XML 1.1: restricted control chars are emitted as decimal character references instead of being rejected
 }
 
 // NewWriter creates a Writer that writes to w. Configure the Writer
@@ -418,15 +433,56 @@ func (w *Writer) emitPendingNS() {
 // closer scope has rebound the prefix to a different URI even if an
 // ancestor scope still declares uri.
 func (w *Writer) lookupNS(prefix, uri string) bool {
-	cur, ok := w.nsBind[prefix]
+	cur, ok := w.ownNSBind()[prefix]
 	return ok && cur == uri
 }
 
 // hasDefaultNSInScope returns true if any ancestor has declared a
 // non-empty default namespace (xmlns="...") that is still in scope.
 func (w *Writer) hasDefaultNSInScope() bool {
-	cur, ok := w.nsBind[""]
+	cur, ok := w.ownNSBind()[""]
 	return ok && cur != ""
+}
+
+// ownNSBind returns the prefix -> URI index for w's open scopes, making w
+// its exclusive owner first.
+//
+// Writer is a value type, so w2 := w1 produces two Writers that point at one
+// nsBindings while each pushes and pops its own nsStack. Only one of them may
+// go on mutating that shared index. nsSeq records the revision this Writer
+// last wrote and nsBindings.seq the revision the index now holds; the two
+// differ exactly when another copy has changed the index since this copy was
+// taken, and that copy's bindings say nothing about this Writer's scopes. w
+// then rebuilds a private index from its own nsStack, which is the
+// authoritative record of the declarations it has open: visiting the scopes
+// outermost-first leaves each prefix bound by its innermost declaration,
+// which is the binding a scan from the innermost scope outward would report.
+//
+// Reads do not claim ownership, so a copy that only reads keeps using the
+// shared index for as long as nobody changes it. Two copies that alternate
+// declarations each rebuild on their turn; that is correctness-first, and the
+// common case of a single writer never rebuilds at all.
+func (w *Writer) ownNSBind() map[string]string {
+	if w.nsBind != nil && w.nsBind.seq == w.nsSeq {
+		return w.nsBind.m
+	}
+	m := make(map[string]string)
+	for _, scope := range w.nsStack {
+		for _, ns := range scope.decls {
+			m[ns.prefix] = ns.uri
+		}
+	}
+	w.nsBind = &nsBindings{m: m, seq: 1}
+	w.nsSeq = 1
+	return m
+}
+
+// revNSBind records that w has just changed its namespace-binding index, so
+// that any other Writer copy still pointing at that index rebuilds its own
+// before reading it again.
+func (w *Writer) revNSBind() {
+	w.nsBind.seq++
+	w.nsSeq = w.nsBind.seq
 }
 
 // declareNS adds a namespace declaration to the current element scope
@@ -445,12 +501,11 @@ func (w *Writer) declareNS(prefix, uri string) {
 			return // already declared at this level
 		}
 	}
-	if w.nsBind == nil {
-		w.nsBind = make(map[string]string)
-	}
-	prev, had := w.nsBind[prefix]
+	m := w.ownNSBind()
+	prev, had := m[prefix]
 	scope.decls = append(scope.decls, nsEntry{prefix: prefix, uri: uri, prevURI: prev, prevHad: had})
-	w.nsBind[prefix] = uri
+	m[prefix] = uri
+	w.revNSBind()
 }
 
 // popNSScope closes the innermost namespace scope, restoring each
@@ -462,12 +517,16 @@ func (w *Writer) popNSScope() {
 		return
 	}
 	scope := w.nsStack[len(w.nsStack)-1]
-	for _, ns := range slices.Backward(scope.decls) {
-		if ns.prevHad {
-			w.nsBind[ns.prefix] = ns.prevURI
-			continue
+	if len(scope.decls) > 0 {
+		m := w.ownNSBind()
+		for _, ns := range slices.Backward(scope.decls) {
+			if ns.prevHad {
+				m[ns.prefix] = ns.prevURI
+				continue
+			}
+			delete(m, ns.prefix)
 		}
-		delete(w.nsBind, ns.prefix)
+		w.revNSBind()
 	}
 	w.nsStack = w.nsStack[:len(w.nsStack)-1]
 }

--- a/stream/stream_bench_test.go
+++ b/stream/stream_bench_test.go
@@ -13,6 +13,14 @@ import (
 // lookupNS and hasDefaultNSInScope walk the entire open-scope stack on every
 // namespaced write, so this workload is quadratic in depth unless namespace
 // lookups are backed by a current-binding map instead of a stack scan.
+//
+// The attribute prefix "a" is what drives that scan deep. declareNS returns
+// without recording anything when the prefix is already bound to the same
+// URI, so a -> urn:attr is declared once, in the outermost scope, and every
+// WriteAttributeNS below it scans every open scope to reach that one entry.
+// The element prefix "p" on its own would not show the cost: each level
+// rebinds p to a fresh URI in its own scope, which a scan from the innermost
+// scope outward finds in constant work.
 func BenchmarkStartElementNSDepth(b *testing.B) {
 	for _, depth := range []int{500, 1000, 2000, 4000} {
 		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {

--- a/stream/stream_bench_test.go
+++ b/stream/stream_bench_test.go
@@ -1,0 +1,38 @@
+package stream_test
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/lestrrat-go/helium/stream"
+)
+
+// BenchmarkStartElementNSDepth measures StartElementNS/EndElement cost as a
+// function of nesting depth, with each level declaring its own namespace URI.
+// lookupNS and hasDefaultNSInScope walk the entire open-scope stack on every
+// namespaced write, so this workload is quadratic in depth unless namespace
+// lookups are backed by a current-binding map instead of a stack scan.
+func BenchmarkStartElementNSDepth(b *testing.B) {
+	for _, depth := range []int{500, 1000, 2000, 4000} {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			for range b.N {
+				w := stream.NewWriter(io.Discard)
+				for d := range depth {
+					uri := fmt.Sprintf("urn:level-%d", d)
+					if err := w.StartElementNS("p", "e", uri); err != nil {
+						b.Fatal(err)
+					}
+					if err := w.WriteAttributeNS("a", "k", "urn:attr", "v"); err != nil {
+						b.Fatal(err)
+					}
+				}
+				for range depth {
+					if err := w.EndElement(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -378,6 +378,49 @@ func TestDefaultNamespaceUndeclarationRestoredAfterScopeExit(t *testing.T) {
 	require.Equal(t, `<root xmlns="urn:A"><c1 xmlns=""><g1/></c1><c2 xmlns=""/></root>`, buf.String())
 }
 
+// TestCopiedWriterHasIndependentNamespaceBindings pins the namespace
+// behavior of a Writer value copied mid-document. Writer is a value type
+// whose fluent methods return copies, so w2 := w1 is a shape the API
+// invites, and each copy must resolve prefixes against the scopes it has
+// open itself. Both copies share one destination, so each case asserts only
+// the output the copy appended after mark.
+func TestCopiedWriterHasIndependentNamespaceBindings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("copy does not see the original's later rebinding", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w1 := stream.NewWriter(&buf)
+		require.NoError(t, w1.StartElementNS("p", "root", "urn:A"))
+		require.NoError(t, w1.WriteElementNS("p", "anchor", "urn:A", ""))
+		w2 := w1 // copied while p is bound to urn:A
+		// w1 rebinds p to urn:B in a scope that w2 does not have open.
+		require.NoError(t, w1.StartElementNS("p", "c1", "urn:B"))
+		mark := buf.Len()
+		// p is still bound to urn:A for w2, so p:c2 needs no declaration.
+		require.NoError(t, w2.StartElementNS("p", "c2", "urn:A"))
+		require.NoError(t, w2.EndElement())
+		require.Equal(t, `<p:c2/>`, buf.String()[mark:])
+	})
+
+	t.Run("copy declares a prefix only the original has bound", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w1 := stream.NewWriter(&buf)
+		require.NoError(t, w1.StartElementNS("q", "root", "urn:Q"))
+		require.NoError(t, w1.WriteElementNS("q", "anchor", "urn:Q", ""))
+		w2 := w1 // copied while p is unbound
+		// w1 binds p in a scope that w2 does not have open.
+		require.NoError(t, w1.StartElementNS("p", "c1", "urn:A"))
+		mark := buf.Len()
+		// p is unbound in every scope w2 has open, so omitting the
+		// declaration here would leave p:c2 with an undeclared prefix.
+		require.NoError(t, w2.StartElementNS("p", "c2", "urn:A"))
+		require.NoError(t, w2.EndElement())
+		require.Equal(t, `<p:c2 xmlns:p="urn:A"/>`, buf.String()[mark:])
+	})
+}
+
 func TestStartAttributeNSRejectsSameScopeConflict(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -350,6 +350,34 @@ func TestNamespaceNSRejectsReservedMisuse(t *testing.T) {
 	})
 }
 
+func TestNamespaceShadowRestoredAfterScopeExit(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElementNS("p", "root", "urn:A"))
+	require.NoError(t, w.StartElementNS("p", "c1", "urn:B"))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.StartElementNS("p", "c2", "urn:A"))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.EndElement())
+	require.Equal(t, `<p:root xmlns:p="urn:A"><p:c1 xmlns:p="urn:B"/><p:c2/></p:root>`, buf.String())
+}
+
+func TestDefaultNamespaceUndeclarationRestoredAfterScopeExit(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElementNS("", "root", "urn:A"))
+	require.NoError(t, w.StartElementNS("", "c1", ""))
+	require.NoError(t, w.StartElementNS("", "g1", ""))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.StartElementNS("", "c2", ""))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.EndElement())
+	require.Equal(t, `<root xmlns="urn:A"><c1 xmlns=""><g1/></c1><c2 xmlns=""/></root>`, buf.String())
+}
+
 func TestStartAttributeNSRejectsSameScopeConflict(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer


### PR DESCRIPTION
- namespace lookups scanned the whole open-scope stack per element/attribute, making deeply nested output quadratic
- track current bindings in a map with an undo log restored on scope exit, keeping output byte-identical
