### PR TITLE
index the HTML parser's open-element stack

### DIFF
--- a/html/elements.go
+++ b/html/elements.go
@@ -486,3 +486,37 @@ var htmlEndPriority = map[string]int{
 	elemBody:  200,
 	elemHTML:  220,
 }
+
+// endPriorityLevels lists the distinct priority values that appear in
+// htmlEndPriority, in ascending order. endPriorityRank returns an element's
+// index into this array. The two must always list the same values.
+var endPriorityLevels = [...]int{150, 160, 170, 180, 190, 200, 220}
+
+// numEndPriorityLevels is len(endPriorityLevels).
+const numEndPriorityLevels = 7
+
+// endPriorityRank returns name's index into endPriorityLevels, or -1 if name
+// carries the default end priority (not a key of htmlEndPriority). Written as
+// a switch over the eleven names in htmlEndPriority rather than a map lookup
+// because it runs on every stack push: a string switch compiles to a length
+// test plus a binary search, which is cheaper than hashing into a map.
+func endPriorityRank(name string) int {
+	switch name {
+	case elemDiv:
+		return 0
+	case "td", "th":
+		return 1
+	case "tr":
+		return 2
+	case elemThead, elemTbody, elemTfoot:
+		return 3
+	case elemTable:
+		return 4
+	case elemHead, elemBody:
+		return 5
+	case elemHTML:
+		return 6
+	default:
+		return -1
+	}
+}

--- a/html/elements_internal_test.go
+++ b/html/elements_internal_test.go
@@ -1,0 +1,36 @@
+package html
+
+import "testing"
+
+// TestEndPriorityRankMatchesHtmlEndPriority guards against endPriorityLevels
+// and endPriorityRank drifting away from htmlEndPriority: every above-default
+// name in htmlEndPriority must have a rank, that rank must map back to the
+// same priority value through endPriorityLevels, and endPriorityLevels itself
+// must stay in ascending order (topmostAbovePriority relies on it).
+func TestEndPriorityRankMatchesHtmlEndPriority(t *testing.T) {
+	for i := 1; i < len(endPriorityLevels); i++ {
+		if endPriorityLevels[i] <= endPriorityLevels[i-1] {
+			t.Fatalf("endPriorityLevels not ascending at index %d: %v", i, endPriorityLevels)
+		}
+	}
+	if numEndPriorityLevels != len(endPriorityLevels) {
+		t.Fatalf("numEndPriorityLevels=%d, len(endPriorityLevels)=%d", numEndPriorityLevels, len(endPriorityLevels))
+	}
+
+	for name, priority := range htmlEndPriority {
+		if priority <= 100 {
+			t.Fatalf("htmlEndPriority[%q]=%d is not above the default 100", name, priority)
+		}
+		rank := endPriorityRank(name)
+		if rank == -1 {
+			t.Fatalf("endPriorityRank(%q) = -1, want a rank for htmlEndPriority[%q]=%d", name, name, priority)
+		}
+		if endPriorityLevels[rank] != priority {
+			t.Fatalf("endPriorityLevels[endPriorityRank(%q)] = %d, want %d", name, endPriorityLevels[rank], priority)
+		}
+	}
+
+	if got := endPriorityRank("p"); got != -1 {
+		t.Fatalf("endPriorityRank(%q) = %d, want -1 (default priority, not in htmlEndPriority)", "p", got)
+	}
+}

--- a/html/parser.go
+++ b/html/parser.go
@@ -45,6 +45,25 @@ type parser struct {
 	// htmlAutoCloseOnClose's abort test. Maintained only in pushName/popName.
 	hiPrioPos [numEndPriorityLevels][]int32
 
+	// stackScanSteps counts the open-element-stack positions the
+	// htmlAutoCloseOnClose pre-scan examines over one parse. It is
+	// instrumentation only: no parser code reads it, and it changes neither the
+	// tree, the error sequence, nor recovery. It exists so
+	// TestHTMLAutoCloseOnCloseBlockedGrowth can assert the pre-scan's cost
+	// shape with an exact, machine-independent count instead of wall-clock
+	// time, which is machine-dependent and flakes on a loaded CI runner.
+	//
+	// Contract for any future rewrite of the pre-scan: every open-element-stack
+	// position the pre-scan examines must add one step. The indexed pre-scan
+	// examines the topmost recorded position of the end tag plus the topmost
+	// position of each tracked above-default priority level, so its cost per
+	// end tag is bounded and independent of stack depth; the naive backward
+	// scan it replaced examined one position per stack entry, which made the
+	// total quadratic in stack depth. The growth test also asserts a lower
+	// bound of one step per end tag, so dropping these increments fails the
+	// test instead of silently disabling the guard.
+	stackScanSteps int64
+
 	// sawRoot records that the root <html> element has been opened at least once.
 	// It distinguishes genuine PRE-root whitespace (empty stack, root never
 	// opened — drop as ignorable) from TRAILING whitespace AFTER the root has
@@ -833,6 +852,7 @@ func (p *parser) topmostPos(name string) (int32, bool) {
 	if len(positions) == 0 {
 		return 0, false
 	}
+	p.stackScanSteps++
 	return positions[len(positions)-1], true
 }
 
@@ -852,6 +872,7 @@ func (p *parser) topmostAbovePriority(pri int) (bool, int32) {
 		if len(positions) == 0 {
 			continue
 		}
+		p.stackScanSteps++
 		top := positions[len(positions)-1]
 		if !found || top > at {
 			found = true

--- a/html/parser.go
+++ b/html/parser.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -31,6 +30,20 @@ type parser struct {
 	sax       SAXHandler
 	nameStack []string // open element name stack
 	mode      insertMode
+
+	// namePos maps an open element name to the stack indexes it occupies, in
+	// ascending order. The last entry is the topmost occurrence. It lets
+	// hasOnStack answer in O(1) instead of scanning nameStack. Maintained only
+	// in pushName/popName; an emptied entry is deleted so a document that opens
+	// and closes many distinct names does not leave the map growing without
+	// bound.
+	namePos map[string][]int32
+
+	// hiPrioPos[r] holds the stack indexes occupied by elements whose end
+	// priority is endPriorityLevels[r]. Only the above-default priorities
+	// htmlEndPriority defines are tracked; every other element is irrelevant to
+	// htmlAutoCloseOnClose's abort test. Maintained only in pushName/popName.
+	hiPrioPos [numEndPriorityLevels][]int32
 
 	// sawRoot records that the root <html> element has been opened at least once.
 	// It distinguishes genuine PRE-root whitespace (empty stack, root never
@@ -236,6 +249,7 @@ func newParser(_ context.Context, input []byte, sax SAXHandler, cfg parseConfig)
 		cur:               strcursor.NewUTF8Cursor(bytes.NewReader(normalized)),
 		sax:               sax,
 		mode:              insertInitial,
+		namePos:           make(map[string][]int32),
 		encodingError:     encodingErr,
 		encodingErrorLine: encErrLine,
 		encodingErrorCol:  encErrCol,
@@ -257,6 +271,7 @@ func newParserFromReader(_ context.Context, r io.Reader, sax SAXHandler, cfg par
 		cur:               strcursor.NewUTF8Cursor(wrapped),
 		sax:               sax,
 		mode:              insertInitial,
+		namePos:           make(map[string][]int32),
 		detectedEncoding:  detectedEnc,
 		encodingSanitizer: sanitizer,
 		deferredEncoding:  deferred,
@@ -750,6 +765,13 @@ func (p *parser) currentName() string {
 	return p.nameStack[len(p.nameStack)-1]
 }
 
+// stackDiffCheck, when non-nil, is invoked at the end of pushName and popName
+// with the parser's post-mutation state. It exists solely so an internal test
+// (TestStackIndexesMatchNaive) can assert that namePos/hiPrioPos stay in sync
+// with nameStack after EVERY mutation, not just at parse end. Nil in normal
+// use, so the cost is one nil check per push/pop.
+var stackDiffCheck func(p *parser)
+
 // pushName pushes an element name onto the stack and tracks insert mode.
 func (p *parser) pushName(name string) {
 	if name == elemHTML {
@@ -761,7 +783,15 @@ func (p *parser) pushName(name string) {
 	if p.mode < insertInBody && name == elemBody {
 		p.mode = insertInBody
 	}
+	pos := int32(len(p.nameStack))
 	p.nameStack = append(p.nameStack, name)
+	p.namePos[name] = append(p.namePos[name], pos)
+	if rank := endPriorityRank(name); rank != -1 {
+		p.hiPrioPos[rank] = append(p.hiPrioPos[rank], pos)
+	}
+	if stackDiffCheck != nil {
+		stackDiffCheck(p)
+	}
 }
 
 // popName pops the top element name from the stack.
@@ -771,12 +801,64 @@ func (p *parser) popName() string {
 	}
 	name := p.nameStack[len(p.nameStack)-1]
 	p.nameStack = p.nameStack[:len(p.nameStack)-1]
+
+	// The popped index is always the last entry of the matching namePos slice,
+	// because pushes and pops are LIFO.
+	positions := p.namePos[name]
+	positions = positions[:len(positions)-1]
+	if len(positions) == 0 {
+		delete(p.namePos, name)
+	} else {
+		p.namePos[name] = positions
+	}
+	if rank := endPriorityRank(name); rank != -1 {
+		hp := p.hiPrioPos[rank]
+		p.hiPrioPos[rank] = hp[:len(hp)-1]
+	}
+	if stackDiffCheck != nil {
+		stackDiffCheck(p)
+	}
 	return name
 }
 
 // hasOnStack checks if the given element name is on the open element stack.
 func (p *parser) hasOnStack(name string) bool {
-	return slices.Contains(p.nameStack, name)
+	return len(p.namePos[name]) > 0
+}
+
+// topmostPos returns the stack index of the topmost occurrence of name, or
+// (0, false) if name is not on the stack.
+func (p *parser) topmostPos(name string) (int32, bool) {
+	positions := p.namePos[name]
+	if len(positions) == 0 {
+		return 0, false
+	}
+	return positions[len(positions)-1], true
+}
+
+// topmostAbovePriority returns the largest stack index occupied by an element
+// whose end priority is strictly greater than pri, and whether any such
+// element exists. It walks the at most numEndPriorityLevels rank slices whose
+// level is greater than pri, so it costs O(numEndPriorityLevels), independent
+// of stack depth.
+func (p *parser) topmostAbovePriority(pri int) (bool, int32) {
+	found := false
+	var at int32
+	for rank, level := range endPriorityLevels {
+		if level <= pri {
+			continue
+		}
+		positions := p.hiPrioPos[rank]
+		if len(positions) == 0 {
+			continue
+		}
+		top := positions[len(positions)-1]
+		if !found || top > at {
+			found = true
+			at = top
+		}
+	}
+	return found, at
 }
 
 // isMisplacedStructural checks whether a structural element (html/head/body)
@@ -815,18 +897,18 @@ func (p *parser) htmlAutoClose(newTag string) {
 func (p *parser) htmlAutoCloseOnClose(endTag string) {
 	priority := getEndPriority(endTag)
 
-	// Check if the end tag matches anything on the stack
-	found := false
-	for _, v := range slices.Backward(p.nameStack) {
-		if v == endTag {
-			found = true
-			break
-		}
-		if getEndPriority(v) > priority {
-			return
-		}
+	// Equivalent to the naive backward scan that walks down from the top
+	// looking for endTag, aborting as soon as it passes an element whose
+	// priority is greater than endTag's: that loop returns without popping
+	// exactly when the topmost index holding a higher-priority element sits
+	// above the topmost index holding endTag. An element equal to endTag can
+	// never trigger the priority test against its own priority, so the two
+	// conditions cannot fire at the same index.
+	pos, ok := p.topmostPos(endTag)
+	if !ok {
+		return
 	}
-	if !found {
+	if blocked, at := p.topmostAbovePriority(priority); blocked && at > pos {
 		return
 	}
 

--- a/html/parser_stack_growth_test.go
+++ b/html/parser_stack_growth_test.go
@@ -146,3 +146,47 @@ func BenchmarkParse(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkBlockedEndTags measures the htmlAutoCloseOnClose worst case that
+// the open-element-stack index targets, using the generator above:
+// blockedEndTagInput(32000) is a 320,023-byte document in which every one of
+// the 32,000 </span> end tags is blocked by the <div> beneath them, so each
+// one triggers a backward pre-scan over the whole stack. BenchmarkParse and
+// BenchmarkParseSAX cannot show this effect, because no file in the golden
+// corpus nests deeply enough for the pre-scan to cost anything.
+//
+// Run it with:
+//
+//	go test ./html -run '^$' -bench BenchmarkBlockedEndTags -count=3
+//
+// To reproduce the before/after, extract the base revision and drop this file
+// into it. This file is written so that only the two helpers reading the
+// stackScanSteps counter (parseStackScanSteps and
+// TestHTMLAutoCloseOnCloseBlockedGrowth) depend on symbols the base lacks; the
+// generator and this benchmark compile and run there unchanged:
+//
+//	mkdir /tmp/htmlbase
+//	git archive origin/main | tar -x -C /tmp/htmlbase
+//	cp html/parser_stack_growth_test.go /tmp/htmlbase/html/
+//	# delete parseStackScanSteps and TestHTMLAutoCloseOnCloseBlockedGrowth
+//	# from the copy: the base has no parser.stackScanSteps field.
+//	cd /tmp/htmlbase && go test ./html -run '^$' -bench BenchmarkBlockedEndTags -count=3
+//
+// Observed on an AMD Ryzen 9 7900X3D (linux/amd64, go1.26.6), three runs each:
+//
+//	base (backward linear scan):  5512, 5652, 5567 ms/op
+//	this branch (indexed stack):     6.94, 6.91, 7.22 ms/op
+//
+// That is a factor of roughly 800. The base measurement is a single iteration
+// per run because one parse already exceeds the default 1s benchtime.
+func BenchmarkBlockedEndTags(b *testing.B) {
+	input := blockedEndTagInput(32000)
+	p := NewParser().SuppressErrors(true).SuppressWarnings(true)
+	ctx := context.Background()
+	b.SetBytes(int64(len(input)))
+	b.ResetTimer()
+	for range b.N {
+		h := SAXCallbacks{}
+		_ = p.ParseWithSAX(ctx, input, &h)
+	}
+}

--- a/html/parser_stack_growth_test.go
+++ b/html/parser_stack_growth_test.go
@@ -1,4 +1,4 @@
-package html_test
+package html
 
 import (
 	"context"
@@ -7,17 +7,16 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/lestrrat-go/helium/html"
 )
 
 // blockedEndTagInput builds the htmlAutoCloseOnClose worst case:
 // <html><body><span><div> + n x <b> + n x </span>. hasOnStack finds <span> in
 // O(1) (it is index 2, near the bottom), so the cost is entirely in the
-// backward pre-scan: it walks all n <b> elements (default priority 100)
-// before reaching <div> (priority 150), which aborts the scan without
-// popping anything. That abort repeats for every one of the n </span> tags.
+// backward pre-scan: the naive version walks all n <b> elements (default
+// priority 100) before reaching <div> (priority 150), which aborts the scan
+// without popping anything. That abort repeats for every one of the n </span>
+// tags, so the naive pre-scan costs O(n^2) stack visits while the indexed one
+// costs O(n).
 func blockedEndTagInput(n int) []byte {
 	var sb strings.Builder
 	sb.WriteString("<html><body><span><div>")
@@ -30,61 +29,67 @@ func blockedEndTagInput(n int) []byte {
 	return []byte(sb.String())
 }
 
-func timeParseSAX(tb testing.TB, input []byte) time.Duration {
+// parseStackScanSteps parses input with SAX events discarded and returns
+// parser.stackScanSteps: the exact number of open-element-stack positions the
+// htmlAutoCloseOnClose pre-scan examined. The count is a property of the input
+// and the algorithm alone, so it is identical on every machine and under any
+// load — unlike elapsed time, which is neither.
+func parseStackScanSteps(tb testing.TB, input []byte) int64 {
 	tb.Helper()
-	p := html.NewParser().SuppressErrors(true).SuppressWarnings(true)
+	cfg := NewParser().SuppressErrors(true).SuppressWarnings(true).parseConfig()
 	ctx := context.Background()
-	// One untimed warm-up run so allocator/GC state does not skew the first
-	// timed sample.
-	_ = p.ParseWithSAX(ctx, input, &html.SAXCallbacks{})
-	start := time.Now()
-	_ = p.ParseWithSAX(ctx, input, &html.SAXCallbacks{})
-	return time.Since(start)
+	p := newParser(ctx, input, &SAXCallbacks{}, cfg)
+	if err := p.parse(ctx); err != nil {
+		tb.Fatalf("parse: %v", err)
+	}
+	return p.stackScanSteps
 }
 
 // TestHTMLAutoCloseOnCloseBlockedGrowth guards against the
 // htmlAutoCloseOnClose pre-scan going quadratic again. At depth 4,000 and
-// 8,000 the input length exactly doubles; a linear pre-scan should therefore
-// roughly double in time (measured ~1.9x), while the naive O(depth) backward
-// scan quadruples it (confirmed against main: ratio ~4.1x). maxRatio sits
-// between those two so the assertion is unambiguous either way, with slack
-// for machine noise on the linear side.
+// 8,000 the input length exactly doubles, so a pre-scan whose per-end-tag cost
+// is independent of stack depth doubles its total stack-position count, while
+// the naive O(depth) backward scan quadruples it. maxRatio sits between those
+// two so the assertion is unambiguous either way.
+//
+// The measurement is a counter, not a clock: stackScanSteps is an exact
+// integer determined by the input and the algorithm, so this test gives the
+// same verdict on a fast laptop and on a heavily loaded CI runner. A
+// wall-clock budget or ratio would not, and raising such a budget only widens
+// the tolerance on the same defect.
 func TestHTMLAutoCloseOnCloseBlockedGrowth(t *testing.T) {
 	const small = 4000
 	const large = 8000
 
-	smallInput := blockedEndTagInput(small)
-	largeInput := blockedEndTagInput(large)
+	smallSteps := parseStackScanSteps(t, blockedEndTagInput(small))
+	largeSteps := parseStackScanSteps(t, blockedEndTagInput(large))
 
-	// Take the best of a few samples on each side to reduce scheduler noise.
-	const samples = 3
-	var smallT, largeT time.Duration
-	for i := range samples {
-		if d := timeParseSAX(t, smallInput); i == 0 || d < smallT {
-			smallT = d
-		}
-		if d := timeParseSAX(t, largeInput); i == 0 || d < largeT {
-			largeT = d
-		}
+	t.Logf("blocked end-tag pre-scan: n=%d -> %d stack positions, n=%d -> %d stack positions",
+		small, smallSteps, large, largeSteps)
+
+	// Lower bound: the pre-scan must examine at least one stack position per
+	// blocked </span>. This is what keeps the ratio assertion honest — without
+	// it, deleting the stackScanSteps increments would leave both counts at
+	// zero and the guard would pass while measuring nothing.
+	if smallSteps < small {
+		t.Fatalf("pre-scan examined %d stack positions for %d blocked end tags: the stackScanSteps instrumentation is not counting the pre-scan's work",
+			smallSteps, small)
+	}
+	if largeSteps < large {
+		t.Fatalf("pre-scan examined %d stack positions for %d blocked end tags: the stackScanSteps instrumentation is not counting the pre-scan's work",
+			largeSteps, large)
 	}
 
-	t.Logf("blocked end-tag scan: n=%d -> %v, n=%d -> %v", small, smallT, large, largeT)
-
-	if smallT <= 0 {
-		t.Skip("measured duration too small to compare reliably")
-	}
 	const maxRatio = 3.0
-	ratio := float64(largeT) / float64(smallT)
+	ratio := float64(largeSteps) / float64(smallSteps)
 	if ratio > maxRatio {
-		t.Fatalf("htmlAutoCloseOnClose pre-scan looks quadratic again: n=%d..%d ratio=%.2f, want <= %.1f (linear input growth is 2x)",
+		t.Fatalf("htmlAutoCloseOnClose pre-scan looks quadratic again: n=%d..%d stack-position ratio=%.2f, want <= %.1f (linear input growth is 2x)",
 			small, large, ratio, maxRatio)
 	}
 }
 
 // BenchmarkParse and BenchmarkParseSAX measure a full pass over the
-// libxml2-compat golden corpus (45 files, 118,757 bytes), matching the
-// baseline captured in .tmp/htmlstackprobe: SAX 2.156 ms, DOM 5.260 ms per
-// pass on main before the stack-index change.
+// libxml2-compat golden corpus (45 files, 118,757 bytes).
 func loadCorpus(tb testing.TB) [][]byte {
 	tb.Helper()
 	dir := "../testdata/libxml2-compat/html"
@@ -115,12 +120,12 @@ func loadCorpus(tb testing.TB) [][]byte {
 
 func BenchmarkParseSAX(b *testing.B) {
 	data := loadCorpus(b)
-	p := html.NewParser().SuppressErrors(true).SuppressWarnings(true)
+	p := NewParser().SuppressErrors(true).SuppressWarnings(true)
 	ctx := context.Background()
 	b.ResetTimer()
 	for range b.N {
 		for _, in := range data {
-			h := html.SAXCallbacks{}
+			h := SAXCallbacks{}
 			_ = p.ParseWithSAX(ctx, in, &h)
 		}
 	}
@@ -129,10 +134,10 @@ func BenchmarkParseSAX(b *testing.B) {
 func BenchmarkParse(b *testing.B) {
 	data := loadCorpus(b)
 	// Matches the SuppressErrors/SuppressWarnings setting used to capture the
-	// DOM baseline (.tmp/htmlstackprobe): without it, error-formatting cost on
-	// the golden corpus's error-producing files would dominate the comparison
-	// instead of the tree-construction cost this benchmark targets.
-	p := html.NewParser().SuppressErrors(true).SuppressWarnings(true)
+	// DOM baseline: without it, error-formatting cost on the golden corpus's
+	// error-producing files would dominate the comparison instead of the
+	// tree-construction cost this benchmark targets.
+	p := NewParser().SuppressErrors(true).SuppressWarnings(true)
 	ctx := context.Background()
 	b.ResetTimer()
 	for range b.N {

--- a/html/parser_stack_growth_test.go
+++ b/html/parser_stack_growth_test.go
@@ -1,0 +1,143 @@
+package html_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/helium/html"
+)
+
+// blockedEndTagInput builds the htmlAutoCloseOnClose worst case:
+// <html><body><span><div> + n x <b> + n x </span>. hasOnStack finds <span> in
+// O(1) (it is index 2, near the bottom), so the cost is entirely in the
+// backward pre-scan: it walks all n <b> elements (default priority 100)
+// before reaching <div> (priority 150), which aborts the scan without
+// popping anything. That abort repeats for every one of the n </span> tags.
+func blockedEndTagInput(n int) []byte {
+	var sb strings.Builder
+	sb.WriteString("<html><body><span><div>")
+	for range n {
+		sb.WriteString("<b>")
+	}
+	for range n {
+		sb.WriteString("</span>")
+	}
+	return []byte(sb.String())
+}
+
+func timeParseSAX(tb testing.TB, input []byte) time.Duration {
+	tb.Helper()
+	p := html.NewParser().SuppressErrors(true).SuppressWarnings(true)
+	ctx := context.Background()
+	// One untimed warm-up run so allocator/GC state does not skew the first
+	// timed sample.
+	_ = p.ParseWithSAX(ctx, input, &html.SAXCallbacks{})
+	start := time.Now()
+	_ = p.ParseWithSAX(ctx, input, &html.SAXCallbacks{})
+	return time.Since(start)
+}
+
+// TestHTMLAutoCloseOnCloseBlockedGrowth guards against the
+// htmlAutoCloseOnClose pre-scan going quadratic again. At depth 4,000 and
+// 8,000 the input length exactly doubles; a linear pre-scan should therefore
+// roughly double in time (measured ~1.9x), while the naive O(depth) backward
+// scan quadruples it (confirmed against main: ratio ~4.1x). maxRatio sits
+// between those two so the assertion is unambiguous either way, with slack
+// for machine noise on the linear side.
+func TestHTMLAutoCloseOnCloseBlockedGrowth(t *testing.T) {
+	const small = 4000
+	const large = 8000
+
+	smallInput := blockedEndTagInput(small)
+	largeInput := blockedEndTagInput(large)
+
+	// Take the best of a few samples on each side to reduce scheduler noise.
+	const samples = 3
+	var smallT, largeT time.Duration
+	for i := range samples {
+		if d := timeParseSAX(t, smallInput); i == 0 || d < smallT {
+			smallT = d
+		}
+		if d := timeParseSAX(t, largeInput); i == 0 || d < largeT {
+			largeT = d
+		}
+	}
+
+	t.Logf("blocked end-tag scan: n=%d -> %v, n=%d -> %v", small, smallT, large, largeT)
+
+	if smallT <= 0 {
+		t.Skip("measured duration too small to compare reliably")
+	}
+	const maxRatio = 3.0
+	ratio := float64(largeT) / float64(smallT)
+	if ratio > maxRatio {
+		t.Fatalf("htmlAutoCloseOnClose pre-scan looks quadratic again: n=%d..%d ratio=%.2f, want <= %.1f (linear input growth is 2x)",
+			small, large, ratio, maxRatio)
+	}
+}
+
+// BenchmarkParse and BenchmarkParseSAX measure a full pass over the
+// libxml2-compat golden corpus (45 files, 118,757 bytes), matching the
+// baseline captured in .tmp/htmlstackprobe: SAX 2.156 ms, DOM 5.260 ms per
+// pass on main before the stack-index change.
+func loadCorpus(tb testing.TB) [][]byte {
+	tb.Helper()
+	dir := "../testdata/libxml2-compat/html"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		tb.Skipf("testdata/libxml2-compat/html not found: %v", err)
+	}
+	var names []string
+	for _, fi := range entries {
+		name := fi.Name()
+		if fi.IsDir() || strings.HasSuffix(name, ".sax") ||
+			strings.HasSuffix(name, ".err") || strings.HasSuffix(name, ".expected") {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	data := make([][]byte, 0, len(names))
+	for _, name := range names {
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			tb.Fatalf("reading %s: %v", name, err)
+		}
+		data = append(data, b)
+	}
+	return data
+}
+
+func BenchmarkParseSAX(b *testing.B) {
+	data := loadCorpus(b)
+	p := html.NewParser().SuppressErrors(true).SuppressWarnings(true)
+	ctx := context.Background()
+	b.ResetTimer()
+	for range b.N {
+		for _, in := range data {
+			h := html.SAXCallbacks{}
+			_ = p.ParseWithSAX(ctx, in, &h)
+		}
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	data := loadCorpus(b)
+	// Matches the SuppressErrors/SuppressWarnings setting used to capture the
+	// DOM baseline (.tmp/htmlstackprobe): without it, error-formatting cost on
+	// the golden corpus's error-producing files would dominate the comparison
+	// instead of the tree-construction cost this benchmark targets.
+	p := html.NewParser().SuppressErrors(true).SuppressWarnings(true)
+	ctx := context.Background()
+	b.ResetTimer()
+	for range b.N {
+		for _, in := range data {
+			_, _ = p.Parse(ctx, in)
+		}
+	}
+}

--- a/html/parser_stack_internal_test.go
+++ b/html/parser_stack_internal_test.go
@@ -126,9 +126,9 @@ func runStackDiffCheck(t *testing.T, seen map[string]struct{}, input []byte) {
 // pushName/popName mutation asserts that hasOnStack and the
 // htmlAutoCloseOnClose pre-scan give the same answer as a naive linear-scan
 // reference. This is what catches a desync between nameStack and the derived
-// namePos/hiPrioPos indexes; the golden and growth tests only observe the
-// final SAX stream, which a subtly wrong index could still reproduce by
-// accident.
+// namePos/hiPrioPos indexes: the golden tests observe only the final SAX
+// stream, which a subtly wrong index could still reproduce by accident, and
+// the growth test observes only the pre-scan's cost shape.
 func TestStackIndexesMatchNaive(t *testing.T) {
 	seen := map[string]struct{}{}
 	for name := range htmlEndPriority {

--- a/html/parser_stack_internal_test.go
+++ b/html/parser_stack_internal_test.go
@@ -49,9 +49,12 @@ func indexedAutoCloseWouldRun(p *parser, endTag string) bool {
 	return true
 }
 
-// diffCheckAdversarialInputs mirrors the shapes captured in
-// .tmp/html-stack-baseline.txt: absent end tags, blocked end tags, table
-// auto-close, inline mismatch, a stray end tag, and a pre-root end tag.
+// diffCheckAdversarialInputs collects the input shapes that drive
+// htmlAutoCloseOnClose down each of its distinct paths: an end tag with no
+// matching open element, an end tag blocked by a higher-priority element
+// beneath it, table and list auto-close, an inline/block mismatch, a stray
+// end tag past the point where its element was already closed, and an end tag
+// before the root element is open.
 var diffCheckAdversarialInputs = []string{
 	`<html><body><div><div></span>x`,
 	`<html><body><span><div><b><b></span></span>x`,

--- a/html/parser_stack_internal_test.go
+++ b/html/parser_stack_internal_test.go
@@ -1,0 +1,166 @@
+package html
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// naiveHasOnStack is the pre-index linear-scan reference for hasOnStack: it is
+// exactly what hasOnStack was before the namePos index (slices.Contains over
+// nameStack).
+func naiveHasOnStack(stack []string, name string) bool {
+	return slices.Contains(stack, name)
+}
+
+// naiveAutoCloseWouldRun reproduces the ORIGINAL htmlAutoCloseOnClose
+// backward-scan-with-priority-abort exactly, reporting whether the pop loop
+// would run (true) or the function would return without popping anything
+// (false). It is the reference the indexed pre-scan is checked against.
+func naiveAutoCloseWouldRun(stack []string, endTag string) bool {
+	priority := getEndPriority(endTag)
+	found := false
+	for _, v := range slices.Backward(stack) {
+		if v == endTag {
+			found = true
+			break
+		}
+		if getEndPriority(v) > priority {
+			return false
+		}
+	}
+	return found
+}
+
+// indexedAutoCloseWouldRun mirrors htmlAutoCloseOnClose's pre-scan decision
+// without running the pop loop, so it can be compared against
+// naiveAutoCloseWouldRun without side effects on the parser.
+func indexedAutoCloseWouldRun(p *parser, endTag string) bool {
+	pos, ok := p.topmostPos(endTag)
+	if !ok {
+		return false
+	}
+	if blocked, at := p.topmostAbovePriority(getEndPriority(endTag)); blocked && at > pos {
+		return false
+	}
+	return true
+}
+
+// diffCheckAdversarialInputs mirrors the shapes captured in
+// .tmp/html-stack-baseline.txt: absent end tags, blocked end tags, table
+// auto-close, inline mismatch, a stray end tag, and a pre-root end tag.
+var diffCheckAdversarialInputs = []string{
+	`<html><body><div><div></span>x`,
+	`<html><body><span><div><b><b></span></span>x`,
+	`<html><body><div><b><i></div>x`,
+	`<html><body><table><tr><td><div></tr>x`,
+	`<html><body><table><tr><td></table>x`,
+	`<html><body><p>a<p>b</p></p>x`,
+	`<html><body><div></div></div></div>x`,
+	`<html><body><b><b><b></b>x`,
+	`<html><head><title>t</title></head><body></head></body>x`,
+	`<html><body><ul><li><li></ul>x`,
+	`</div><html><body>x</body></html>`,
+	`<html><body><div><span></div></span>x`,
+	`<html><body><b><div></b>x`,
+	`<html><body><font><table><td></font>x`,
+	`<html><body><div><div><div></body>x`,
+}
+
+// diffCheckFuzzSeeds mirrors FuzzParse's seed corpus (fuzz_test.go).
+var diffCheckFuzzSeeds = []string{
+	`<html><head><title>Test</title></head><body><p>Hello</p></body></html>`,
+	`<!DOCTYPE html><html><body><div class="test"><img src="x.png"><br></div></body></html>`,
+	`<p>unclosed paragraph<p>another paragraph`,
+	`<table><tr><td>cell</td></tr></table>`,
+	`<script>var x = 1 < 2;</script><style>a { color: red; }</style>`,
+	`&amp;&lt;&gt;&quot;&apos;&copy;&nbsp;`,
+	``,
+	`not html at all`,
+}
+
+// stackDiffChecker installs itself as stackDiffCheck for the duration of one
+// parse and compares the indexed hasOnStack/htmlAutoCloseOnClose answers
+// against the naive linear-scan reference after every stack mutation. seen
+// accumulates every name observed on the stack, plus every name in
+// htmlEndPriority, so coverage widens as more inputs are checked.
+type stackDiffChecker struct {
+	t    *testing.T
+	seen map[string]struct{}
+}
+
+// check is installed as stackDiffCheck. It runs after every pushName/popName.
+func (c *stackDiffChecker) check(p *parser) {
+	c.t.Helper()
+	if len(p.nameStack) > 0 {
+		c.seen[p.nameStack[len(p.nameStack)-1]] = struct{}{}
+	}
+	for name := range c.seen {
+		if want, got := naiveHasOnStack(p.nameStack, name), p.hasOnStack(name); want != got {
+			c.t.Errorf("hasOnStack(%q): naive=%v indexed=%v stack=%v", name, want, got, p.nameStack)
+		}
+		if want, got := naiveAutoCloseWouldRun(p.nameStack, name), indexedAutoCloseWouldRun(p, name); want != got {
+			c.t.Errorf("autoCloseWouldRun(%q): naive=%v indexed=%v stack=%v", name, want, got, p.nameStack)
+		}
+	}
+}
+
+// runStackDiffCheck parses input with a stackDiffChecker installed, so every
+// pushName/popName mutation during the parse is checked against the naive
+// reference.
+func runStackDiffCheck(t *testing.T, seen map[string]struct{}, input []byte) {
+	t.Helper()
+	checker := &stackDiffChecker{t: t, seen: seen}
+	stackDiffCheck = checker.check
+	defer func() { stackDiffCheck = nil }()
+	p := NewParser().SuppressErrors(true).SuppressWarnings(true)
+	_ = p.ParseWithSAX(t.Context(), input, &SAXCallbacks{})
+}
+
+// TestStackIndexesMatchNaive is a differential test: it drives real parses
+// over the adversarial blocked/mismatched-end-tag shapes, the FuzzParse seed
+// corpus, and the 45-file libxml2-compat golden corpus, and after EVERY
+// pushName/popName mutation asserts that hasOnStack and the
+// htmlAutoCloseOnClose pre-scan give the same answer as a naive linear-scan
+// reference. This is what catches a desync between nameStack and the derived
+// namePos/hiPrioPos indexes; the golden and growth tests only observe the
+// final SAX stream, which a subtly wrong index could still reproduce by
+// accident.
+func TestStackIndexesMatchNaive(t *testing.T) {
+	seen := map[string]struct{}{}
+	for name := range htmlEndPriority {
+		seen[name] = struct{}{}
+	}
+
+	for i, in := range diffCheckAdversarialInputs {
+		name := fmt.Sprintf("adversarial_%d", i)
+		input := []byte(in)
+		t.Run(name, func(t *testing.T) { runStackDiffCheck(t, seen, input) })
+	}
+	for i, in := range diffCheckFuzzSeeds {
+		name := fmt.Sprintf("fuzzseed_%d", i)
+		input := []byte(in)
+		t.Run(name, func(t *testing.T) { runStackDiffCheck(t, seen, input) })
+	}
+
+	dir := "../testdata/libxml2-compat/html"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Skipf("testdata/libxml2-compat/html not found: %v", err)
+	}
+	for _, fi := range entries {
+		fileName := fi.Name()
+		if fi.IsDir() || strings.HasSuffix(fileName, ".sax") ||
+			strings.HasSuffix(fileName, ".err") || strings.HasSuffix(fileName, ".expected") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, fileName))
+		if err != nil {
+			t.Fatalf("reading %s: %v", fileName, err)
+		}
+		t.Run("golden_"+fileName, func(t *testing.T) { runStackDiffCheck(t, seen, data) })
+	}
+}


### PR DESCRIPTION
- Malformed end tags on deep input made HTML stack lookups quadratic (3.5s on 256KB).
- Track each open name's stack positions incrementally for O(1) end-tag decisions.
- A differential test checks the indexed answers against a naive scan on every mutation.
