### PR TITLE
memoize keyref subtree key-table gathering

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -305,11 +305,19 @@ permits reluctant quantifiers and `(?:…)`. Stray-hyphen character-class ranges
      map[QName]*idcTable` and resolves the occurrence's keyrefs against it after
      every key/unique on the occurrence is evaluated, so a keyref declared before
      its key still resolves) PLUS key/unique tables that PROPAGATE UP from the
-     host's DESCENDANT subtree (`collectSubtreeKeyTable` walks the host's children
-     recursively, gathering — via `idcHostDecl` per descendant — every key/unique of
-     the referenced QName and merging their key-sequences; descendant evaluation is
-     done under `suppressDepth` so cvc field/key-missing diagnostics are reported
-     only once, by that descendant's own pass-2 walk). So a key on a CHILD element
+     host's DESCENDANT subtree (`collectSubtreeKeyTable` delegates to
+     `appendSubtreeKeys`, which walks the host's children recursively, gathering —
+     via `idcHostDecl` per descendant — every key/unique of the referenced QName
+     and appending their key-sequences into a single accumulator as it descends,
+     rather than building and copying a table at each level). Each descendant
+     OCCURRENCE's evaluation (`gatherIDCTable`) is memoized on
+     `validationContext.idcGathered`, keyed by `idcOccurrenceKey{elem, idc}` (the
+     element POINTER, so two occurrences of the same declaration are evaluated
+     independently), so a descendant reachable from several nested keyref hosts is
+     evaluated at most once per run. The memo is confined to this suppressed
+     gathering path: evaluation runs under `suppressDepth` so cvc field/key-missing
+     diagnostics are reported only once, by that descendant's own unsuppressed
+     pass-2 walk, never by the cached gathering call. So a key on a CHILD element
      satisfies a keyref on an ancestor host (bug322411). A keyref whose referenced
      key/unique is declared OUTSIDE the host's subtree — on a SIBLING, or on a
      different occurrence of a repeating host — resolves against an EMPTY key space →

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -498,6 +498,14 @@ type validationContext struct {
 	// source metadata.
 	allowXSD10LegacyGMonthInstance bool
 	idcDocOrder                    *ixpath.DocOrderCache
+	// idcGathered memoizes collectSubtreeKeyTable's per-occurrence key/unique
+	// evaluations, keyed by the descendant ELEMENT OCCURRENCE (not declaration),
+	// since two occurrences of the same key/unique declaration hold different
+	// values. It is per-run (created fresh by newValidationContext, dropped when
+	// Validate returns) and never invalidated during the run, matching the
+	// document-must-not-mutate assumption idcDocOrder/actualElemType/
+	// assessedElemType/skipContentNodes already make. See gatherIDCTable.
+	idcGathered map[idcOccurrenceKey]*idcTable
 	// edcType is the complex type whose content model is currently being matched.
 	// It is set (and restored) by validateContentByType, so the wildcard
 	// Element-Declarations-Consistent check (validateWildcardElementConsistent) can

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -155,6 +155,20 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 // keys.
 func (vc *validationContext) collectSubtreeKeyTable(ctx context.Context, host *helium.Element, referQN QName) *idcTable {
 	var merged *idcTable
+	vc.appendSubtreeKeys(ctx, host, referQN, &merged)
+	return merged
+}
+
+// appendSubtreeKeys walks host's descendants in DFS order and appends every
+// matching key/unique constraint's key-sequences into the single *merged
+// accumulator, instead of collectSubtreeKeyTable's former level-by-level
+// build-then-copy-upward merge (each level allocated its own *idcTable and the
+// caller re-copied its keys into the parent's, making a nested keyref chain of
+// depth D pay a Θ(D²) copy at every one of its D ancestor hosts). Appending
+// into one accumulator as the walk descends keeps the total copy work linear
+// in the number of contributing key-sequences. DFS order, and therefore key
+// order, is unchanged.
+func (vc *validationContext) appendSubtreeKeys(ctx context.Context, host *helium.Element, referQN QName, merged **idcTable) {
 	for child := range helium.Children(host) {
 		if child.Type() != helium.ElementNode {
 			continue
@@ -169,32 +183,59 @@ func (vc *validationContext) collectSubtreeKeyTable(ctx context.Context, host *h
 				if idc.Kind == IDCKeyRef || idc.QName != referQN {
 					continue
 				}
-				ev := xpath1.NewEvaluator().AdditionalNamespaces(idc.Namespaces)
-				// Suppress diagnostics during gathering: this descendant constraint is
-				// ALSO evaluated by its own pass-2 walk, which is the canonical place
-				// any cvc field/key-missing error is reported. Without suppression those
-				// would be double-reported. We only need the key-sequence VALUES here.
-				vc.suppressDepth++
-				table, err := vc.evaluateIDC(ctx, ev, ce, decl, idc)
-				vc.suppressDepth--
-				if err != nil {
+				table := vc.gatherIDCTable(ctx, ce, decl, idc)
+				if table == nil {
 					continue
 				}
-				if merged == nil {
-					merged = &idcTable{idc: idc}
+				if *merged == nil {
+					*merged = &idcTable{idc: idc}
 				}
-				merged.keys = append(merged.keys, table.keys...)
+				(*merged).keys = append((*merged).keys, table.keys...)
 			}
 		}
 		// Recurse so a constraint declared deeper in the subtree also propagates up.
-		if sub := vc.collectSubtreeKeyTable(ctx, ce, referQN); sub != nil {
-			if merged == nil {
-				merged = &idcTable{idc: sub.idc}
-			}
-			merged.keys = append(merged.keys, sub.keys...)
-		}
+		vc.appendSubtreeKeys(ctx, ce, referQN, merged)
 	}
-	return merged
+}
+
+// idcOccurrenceKey identifies one evaluation of one identity-constraint
+// declaration on one element OCCURRENCE (not declaration): two occurrences of
+// the same xs:key/xs:unique declaration (e.g. two repeated "items" elements)
+// hold different values, so the memo must key on the element pointer, never
+// the declaration alone.
+type idcOccurrenceKey struct {
+	elem *helium.Element
+	idc  *IDConstraint
+}
+
+// gatherIDCTable evaluates a descendant key/unique constraint for use by
+// collectSubtreeKeyTable's ancestor keyref gathering, memoizing the result per
+// idcOccurrenceKey on vc.idcGathered so a descendant occurrence reachable from
+// several nested keyref hosts is evaluated at most once per run. Returns nil
+// when evaluation fails (cached as nil, distinguished from "not yet gathered"
+// by the two-value map read).
+//
+// Suppress diagnostics during gathering: this descendant constraint is ALSO
+// evaluated by its own pass-2 walk, which is the canonical place any cvc
+// field/key-missing error is reported. Without suppression those would be
+// double-reported. We only need the key-sequence VALUES here.
+func (vc *validationContext) gatherIDCTable(ctx context.Context, ce *helium.Element, decl *ElementDecl, idc *IDConstraint) *idcTable {
+	key := idcOccurrenceKey{elem: ce, idc: idc}
+	if cached, ok := vc.idcGathered[key]; ok {
+		return cached
+	}
+	ev := xpath1.NewEvaluator().AdditionalNamespaces(idc.Namespaces)
+	vc.suppressDepth++
+	table, err := vc.evaluateIDC(ctx, ev, ce, decl, idc)
+	vc.suppressDepth--
+	if err != nil {
+		table = nil
+	}
+	if vc.idcGathered == nil {
+		vc.idcGathered = make(map[idcOccurrenceKey]*idcTable)
+	}
+	vc.idcGathered[key] = table
+	return table
 }
 
 // idcHostDecl returns the declaration whose identity constraints apply to an

--- a/xsd/validate_idc_bench_test.go
+++ b/xsd/validate_idc_bench_test.go
@@ -1,0 +1,100 @@
+package xsd_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// nestedKeyrefSchema declares a keyref ("ItemRef") on "node" that refers to a
+// key ("ItemUnique") declared on the CHILD "items" element. "node" nests a
+// child "node", so a keyref host at depth D must gather the key table from
+// every descendant occurrence in its subtree, and every ancestor host repeats
+// that gathering over the same descendants.
+const nestedKeyrefSchema = `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="items">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" type="xs:string" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="ItemUnique">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="."/>
+    </xs:unique>
+  </xs:element>
+  <xs:element name="node">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="items"/>
+        <xs:element name="ref" type="xs:string"/>
+        <xs:element ref="node" minOccurs="0"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:keyref name="ItemRef" refer="ItemUnique">
+      <xs:selector xpath="ref"/>
+      <xs:field xpath="."/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+
+// nestedKeyrefItemsBlock returns a k-item <items> block used at every nesting
+// level of nestedKeyrefDoc.
+func nestedKeyrefItemsBlock(k int) string {
+	var b strings.Builder
+	b.WriteString("<items>")
+	for i := range k {
+		fmt.Fprintf(&b, "<item>v%d</item>", i)
+	}
+	b.WriteString("</items>")
+	return b.String()
+}
+
+// nestedKeyrefDoc builds a "node" chain depth levels deep, each level carrying
+// its own k-item <items> block and a <ref> that resolves against the innermost
+// level's key (v0 is present at every level).
+func nestedKeyrefDoc(depth, k int) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?>`)
+	blk := nestedKeyrefItemsBlock(k)
+	for range depth {
+		b.WriteString("<node>")
+		b.WriteString(blk)
+		b.WriteString("<ref>v0</ref>")
+	}
+	for range depth {
+		b.WriteString("</node>")
+	}
+	return b.String()
+}
+
+// BenchmarkIDCKeyrefNestedSubtree measures xsd.Validator.Validate over a
+// document whose keyref hosts nest, so collectSubtreeKeyTable's descendant
+// key-table gathering repeats at every ancestor level (xsd/validate_idc.go).
+// Depths were chosen to keep the benchmark runnable while still exposing the
+// super-linear growth: doubling depth should roughly double the per-op time
+// after the fix, not multiply it ~7x as the unfixed cubic gathering does.
+func BenchmarkIDCKeyrefNestedSubtree(b *testing.B) {
+	sdoc, err := helium.NewParser().Parse(b.Context(), []byte(nestedKeyrefSchema))
+	require.NoError(b, err)
+	schema, err := xsd.NewCompiler().Compile(b.Context(), sdoc)
+	require.NoError(b, err)
+
+	for _, depth := range []int{100, 400} {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			idoc, err := helium.NewParser().MaxDepth(-1).Parse(b.Context(), []byte(nestedKeyrefDoc(depth, 5)))
+			require.NoError(b, err)
+			v := xsd.NewValidator(schema)
+
+			b.ResetTimer()
+			for range b.N {
+				require.NoError(b, v.Validate(b.Context(), idoc))
+			}
+		})
+	}
+}

--- a/xsd/validate_idc_subtree_test.go
+++ b/xsd/validate_idc_subtree_test.go
@@ -1,0 +1,94 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIDCSubtreeKeyGatherReportsAbsentFieldOnce pins the diagnostic contract
+// collectSubtreeKeyTable's descendant key-table gathering must not break: a
+// descendant xs:key's own "absent field" error is reported exactly once, no
+// matter how many ancestor keyref hosts gather that same descendant occurrence
+// out of their own subtree.
+//
+// "outer" and "inner" are both "node" elements with a keyref referring to
+// "ItemKey", declared on the single "items" descendant nested under "inner".
+// Because "inner" is itself a descendant of "outer", BOTH hosts' subtree scans
+// reach the very same "items" occurrence and its ItemKey constraint: outer's
+// keyref gathers it directly, and inner's keyref gathers it again. That
+// gathering is deliberately suppressed (it exists only to collect key-sequence
+// VALUES for keyref resolution) — the canonical report comes from "items"'s own
+// pass-2 walk, which runs unsuppressed exactly once. A cache that leaks a
+// suppressed evaluation into the reporting path would double the message; a
+// cache that swallows the real pass-2 evaluation would drop it. Either is a
+// regression this test catches.
+func TestIDCSubtreeKeyGatherReportsAbsentFieldOnce(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="items">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="ItemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@id"/>
+    </xs:key>
+  </xs:element>
+  <xs:element name="node">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="items" minOccurs="0"/>
+        <xs:element name="ref" type="xs:string"/>
+        <xs:element ref="node" minOccurs="0"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:keyref name="ItemRef" refer="ItemKey">
+      <xs:selector xpath="ref"/>
+      <xs:field xpath="."/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+
+	// "outer" declares no items of its own, so its keyref must gather ItemKey
+	// from its subtree, which includes "inner". "inner" ALSO declares no items
+	// of its own directly (items lives one level further down), so its keyref
+	// gathers the SAME "items" occurrence out of its own (smaller) subtree.
+	// One <item> is missing @id, which is an absent xs:key field.
+	const instanceXML = `<node>
+  <ref>a</ref>
+  <node>
+    <items>
+      <item id="a"/>
+      <item/>
+    </items>
+    <ref>a</ref>
+  </node>
+</node>`
+
+	sdoc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	schema, err := xsd.NewCompiler().Compile(t.Context(), sdoc)
+	require.NoError(t, err)
+
+	idoc, err := helium.NewParser().Parse(t.Context(), []byte(instanceXML))
+	require.NoError(t, err)
+
+	var errs string
+	verr := validateWithOutput(t, xsd.NewValidator(schema), idoc, &errs)
+	require.Error(t, verr, "expected the absent xs:key field to fail validation")
+
+	const wantMessage = "Not all fields of key identity-constraint 'ItemKey' evaluate to a node."
+	require.Equal(t, 1, strings.Count(errs, wantMessage),
+		"expected %q exactly once in %q", wantMessage, errs)
+}


### PR DESCRIPTION
- fix cubic-time descendant key-table gathering for nested keyref hosts
- add a per-occurrence evaluation memo and a single accumulator instead of level-by-level merging
- add a benchmark and a characterization test pinning the single-report diagnostic contract
