### PR TITLE
share validState.seq instead of copying it

### DIFF
--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -109,6 +109,7 @@ bug that prompted it.
 | `c14n_test.go` | c14n | C14N golden file tests |
 | `xsd_test.go` | xsd | Schema validation golden tests |
 | `relaxng_test.go` | relaxng | RELAX NG golden tests |
+| `group_backtrack_differential_test.go` | relaxng | Flag-gated group-backtracking differential harness |
 | `schematron_test.go` | schematron | Schematron golden tests |
 | `utf8cursor_test.go` | internal/strcursor | UTF-8 cursor boundary/normalization and ASCII QName scanner regression coverage |
 
@@ -176,6 +177,27 @@ Run specific test subsets via env vars:
 | `HELIUM_XMLSCHEMA_TEST_FILES` | XSD validation tests |
 | `HELIUM_RELAXNG_TEST_FILES` | RELAX NG tests |
 | `HELIUM_SCHEMATRON_TEST_FILES` | Schematron tests |
+
+## Differential Harnesses
+
+`relaxng/group_backtrack_differential_test.go` compares two revisions on
+accept/reject decisions AND exact error text. It prints one line per case
+(identity, verdict, quoted error text) for the golden RELAX NG schema
+cross-product and for seeded random group grammars, so the same file run on two
+checkouts produces two outputs that can be diffed. It uses only the exported
+API, so it can be copied into an older checkout unchanged.
+
+| Flag | Meaning |
+|------|---------|
+| `-relaxng.differential.out=PATH` | Write the record to PATH. Absent: run a small subset, discard the output |
+| `-relaxng.differential.cases=N` | Randomized grammars (default 20000; `0` runs the golden cross-product only) |
+| `-relaxng.differential.seed=N` | Seed for the randomized grammars (default 1) |
+
+Without flags an ordinary `go test ./relaxng` run walks every eighth golden
+schema plus 200 random grammars in about half a second, and
+`TestGroupBacktrackDifferentialDeterministic` checks that two runs of that
+subset agree byte for byte. The recorded procedure and result for the current
+run live in the header comment of `relaxng/group_backtrack_test.go`.
 
 ## Build Tags
 

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -189,15 +189,18 @@ API, so it can be copied into an older checkout unchanged.
 
 | Flag | Meaning |
 |------|---------|
-| `-relaxng.differential.out=PATH` | Write the record to PATH. Absent: run a small subset, discard the output |
-| `-relaxng.differential.cases=N` | Randomized grammars (default 20000; `0` runs the golden cross-product only) |
+| `-relaxng.differential.out=PATH` | Write the record to PATH. Absent: discard the output and, unless `cases=0`, run a small subset |
+| `-relaxng.differential.cases=N` | Randomized grammars (default 20000; `0` runs the golden cross-product only, with or without `out`) |
 | `-relaxng.differential.seed=N` | Seed for the randomized grammars (default 1) |
 
 Without flags an ordinary `go test ./relaxng` run walks every eighth golden
 schema plus 200 random grammars in about half a second, and
 `TestGroupBacktrackDifferentialDeterministic` checks that two runs of that
-subset agree byte for byte. The recorded procedure and result for the current
-run live in the header comment of `relaxng/group_backtrack_test.go`.
+subset agree byte for byte. The reduced subset is what the absent `out` flag
+selects for the default case count; `cases=0` turns the randomized half off and
+walks the full golden cross-product either way. The recorded procedure and
+result for the current run live in the header comment of
+`relaxng/group_backtrack_test.go`.
 
 ## Build Tags
 

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -632,7 +632,10 @@ Pattern-matching engine with backtracking:
 When mandatory group child fails:
 1. Check if element was consumed (structural vs content error)
 2. For each previous flexible child (zeroOrMore/oneOrMore/optional) from nearest to furthest:
-   - Try iteration counts from minimum upward to greedy count
+   - Ascend iteration counts one repetition at a time from a saved boundary
+     (`groupBound`) up to the greedy count, via `advanceFlexibleContent` /
+     `advanceFlexibleNaive`, instead of replaying every repetition from scratch
+     for each candidate count
    - Re-validate remaining children via the group routine (`validateGroupChildren` /
      `validateGroupSeq`) so flexible members in the retry range can themselves
      backtrack — this recovers groups with 2+ flexible members that must each
@@ -648,7 +651,15 @@ node + sequence length, packed `attrUsed`, `suppressDepth>0`, content-vs-naive
 discriminator). A hit reproduces the original call's effect exactly — resulting
 position, attribute usage, appended errors, return value — so memoization is sound
 (no valid document rejected) while collapsing the fan-out to polynomial. Regression
-guard: `TestMultiFlexibleGroupBacktrackingNotExponential`.
+guard: `TestMultiFlexibleGroupBacktrackingNotExponential`. `validState.seq` is only
+ever re-sliced from the front, never written through, so every snapshot taken
+during backtracking — `clone()`, `saveGroupBound`, and the memo entries stored
+here — shares the sibling slice's backing array instead of copying it; only
+`attrUsed` is deep-copied, because that slice is mutated in place. `seqEqual`
+exploits the same fact with an O(1) identity check (equal length plus an
+identical first-element pointer) before falling back to an element-by-element
+comparison. Regression guard for the allocation this avoids:
+`TestGroupBacktrackAllocationBound`.
 
 Two parallel implementations share this strategy. `validateGroupContent` +
 `backtrackGroupFlexible` runs inside element bodies (threads attrs/attrUsed and

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -659,7 +659,13 @@ here — shares the sibling slice's backing array instead of copying it; only
 exploits the same fact with an O(1) identity check (equal length plus an
 identical first-element pointer) before falling back to an element-by-element
 comparison. Regression guard for the allocation this avoids:
-`TestGroupBacktrackAllocationBound`.
+`TestGroupBacktrackAllocationBound`. Accept/reject evidence that these snapshot
+and backtracking mechanics decide no document differently and word no diagnostic
+differently comes from `relaxng/group_backtrack_differential_test.go`, a
+flag-gated differential harness that emits one verdict-plus-error-text line per
+case for the golden schema cross-product and for seeded random group grammars;
+the recorded procedure and result live in the header comment of
+`relaxng/group_backtrack_test.go`.
 
 Two parallel implementations share this strategy. `validateGroupContent` +
 `backtrackGroupFlexible` runs inside element bodies (threads attrs/attrUsed and

--- a/relaxng/group_backtrack_bench_test.go
+++ b/relaxng/group_backtrack_bench_test.go
@@ -67,25 +67,42 @@ func benchDoc(b *testing.B, n int) *helium.Document {
 //	go test ./relaxng -run none -bench BenchmarkGroupBacktrack -benchmem
 //
 // Baseline procedure. This file uses no symbol introduced by this change, so
-// it runs unmodified on the base revision:
+// it runs unmodified on the base revision. Resolve the base at run time and
+// archive the same object you name as the base: this branch is rebased as main
+// moves, so no hardcoded hash stays correct.
 //
-//	git archive origin/main | tar -x -C <scratch>
+//	BASE=$(git merge-base HEAD origin/main)
+//	mkdir -p <scratch>
+//	git archive "$BASE" | tar -x -C <scratch>
 //	cp relaxng/group_backtrack_bench_test.go <scratch>/relaxng/
 //	go test -C <scratch> ./relaxng -run none -bench BenchmarkGroupBacktrack -benchmem -benchtime=1x
 //
 // Use a small -benchtime on the base side: one iteration of the first workload
 // takes seconds and allocates over 20 GB.
 //
-// Measured on linux/amd64, go1.26.6, AMD Ryzen 9 7900X3D, against base
-// ec7cf3f4 (-benchtime=1x on the base side, default -benchtime on this side):
+// B/op and allocs/op are the evidence this change rests on. They are what the
+// change actually removes, and unlike wall clock they do reproduce: across runs
+// the base figures hold to within about 0.1% and the figures on this side to
+// within a few bytes. Measured against the merge base of this branch with
+// origin/main, -benchtime=1x on the base side and the default -benchtime here:
 //
 //	flexible group backtracking, 1600 children
-//	  base: 4341622568 ns/op  23166291560 B/op  1298591 allocs/op
-//	  here:    1090871 ns/op       975732 B/op    11242 allocs/op
+//	  base: 23166291560 B/op  1298591 allocs/op   (~23 GB, ~1.3M allocations)
+//	  here:      975732 B/op    11242 allocs/op   (~976 KB, ~11K allocations)
 //
 //	plain zeroOrMore, 16000 children
-//	  base:  586837773 ns/op   2108558320 B/op    16052 allocs/op
-//	  here:    1450759 ns/op      1190274 B/op       21 allocs/op
+//	  base:  2108558320 B/op    16052 allocs/op   (~2.1 GB)
+//	  here:     1190274 B/op       21 allocs/op   (~1.2 MB)
+//
+// Wall clock is indicative only. On linux/amd64, go1.26.6, AMD Ryzen 9 7900X3D:
+//
+//	flexible group backtracking, 1600 children:  base ~4.3 s/op, here ~1.1 ms/op
+//	plain zeroOrMore, 16000 children:            base ~590 ms/op, here ~1.5 ms/op
+//
+// ns/op is machine-dependent, and a spread of roughly +/-20% across machines and
+// across runs on one machine is expected, so read these as orders of magnitude
+// and not as figures to reproduce digit for digit. The recorded run took its
+// base side at ec7cf3f4, which was the merge base at the time.
 func BenchmarkGroupBacktrack(b *testing.B) {
 	b.Run("flexible group backtracking", func(b *testing.B) {
 		const m = 1600

--- a/relaxng/group_backtrack_bench_test.go
+++ b/relaxng/group_backtrack_bench_test.go
@@ -1,0 +1,123 @@
+package relaxng_test
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// benchElementA is the single `<element name="a"><empty/></element>` pattern
+// both benchmark workloads repeat.
+const benchElementA = `<element name="a"><empty/></element>`
+
+// benchGrammar compiles a RELAX NG grammar from a string, failing the
+// benchmark on any compile error. It deliberately duplicates compileGrammar
+// instead of calling it: compileGrammar takes a *testing.T, and this file must
+// stay self-contained so it can be dropped verbatim into a base-revision
+// checkout (see the BenchmarkGroupBacktrack doc comment).
+func benchGrammar(b *testing.B, schema string) *relaxng.Grammar {
+	b.Helper()
+
+	doc, err := helium.NewParser().Parse(b.Context(), []byte(schema))
+	require.NoError(b, err)
+
+	grammar, err := relaxng.NewCompiler().Compile(b.Context(), doc)
+	require.NoError(b, err)
+
+	return grammar
+}
+
+// benchDoc parses `<root>` with n `<a/>` children.
+func benchDoc(b *testing.B, n int) *helium.Document {
+	b.Helper()
+
+	var src strings.Builder
+	src.WriteString(`<root>`)
+	for range n {
+		src.WriteString(`<a/>`)
+	}
+	src.WriteString(`</root>`)
+
+	doc, err := helium.NewParser().Parse(b.Context(), []byte(src.String()))
+	require.NoError(b, err)
+
+	return doc
+}
+
+// BenchmarkGroupBacktrack measures the two validation workloads this change
+// targets, so the before/after figures are recorded rather than merely
+// asserted against the coarse ceiling in TestGroupBacktrackAllocationBound.
+//
+// "flexible group backtracking" drives backtrackGroupFlexible: a group of a
+// greedy zeroOrMore followed by a mandatory member, over 1600 children. The
+// backtracker replays the same child range many times, so a per-repetition
+// deep copy of the remaining sibling slice compounds quadratically.
+// "plain zeroOrMore, no backtracking" drives the ordinary repetition path over
+// 16000 children, where every repetition step used to copy the whole remaining
+// tail once.
+//
+// Grammar compilation and document parsing sit outside the timed region: only
+// Validate is measured.
+//
+// Run with:
+//
+//	go test ./relaxng -run none -bench BenchmarkGroupBacktrack -benchmem
+//
+// Baseline procedure. This file uses no symbol introduced by this change, so
+// it runs unmodified on the base revision:
+//
+//	git archive origin/main | tar -x -C <scratch>
+//	cp relaxng/group_backtrack_bench_test.go <scratch>/relaxng/
+//	go test -C <scratch> ./relaxng -run none -bench BenchmarkGroupBacktrack -benchmem -benchtime=1x
+//
+// Use a small -benchtime on the base side: one iteration of the first workload
+// takes seconds and allocates over 20 GB.
+//
+// Measured on linux/amd64, go1.26.6, AMD Ryzen 9 7900X3D, against base
+// ec7cf3f4 (-benchtime=1x on the base side, default -benchtime on this side):
+//
+//	flexible group backtracking, 1600 children
+//	  base: 4341622568 ns/op  23166291560 B/op  1298591 allocs/op
+//	  here:    1090871 ns/op       975732 B/op    11242 allocs/op
+//
+//	plain zeroOrMore, 16000 children
+//	  base:  586837773 ns/op   2108558320 B/op    16052 allocs/op
+//	  here:    1450759 ns/op      1190274 B/op       21 allocs/op
+func BenchmarkGroupBacktrack(b *testing.B) {
+	b.Run("flexible group backtracking", func(b *testing.B) {
+		const m = 1600
+		grammar := benchGrammar(b, `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start><element name="root"><group>`+
+			`<zeroOrMore>`+benchElementA+`</zeroOrMore>`+benchElementA+`</group></element></start></grammar>`)
+		doc := benchDoc(b, m)
+		validator := relaxng.NewValidator(grammar)
+		ctx := b.Context()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			if err := validator.Validate(ctx, doc); err != nil {
+				b.Fatalf("failed to validate group(zeroOrMore(a), a) over %d elements: %s", m, err)
+			}
+		}
+	})
+
+	b.Run("plain zeroOrMore, no backtracking", func(b *testing.B) {
+		const m = 16000
+		grammar := benchGrammar(b, `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start><element name="root">`+
+			`<zeroOrMore>`+benchElementA+`</zeroOrMore></element></start></grammar>`)
+		doc := benchDoc(b, m)
+		validator := relaxng.NewValidator(grammar)
+		ctx := b.Context()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			if err := validator.Validate(ctx, doc); err != nil {
+				b.Fatalf("failed to validate zeroOrMore(a) over %d elements: %s", m, err)
+			}
+		}
+	})
+}

--- a/relaxng/group_backtrack_differential_test.go
+++ b/relaxng/group_backtrack_differential_test.go
@@ -32,17 +32,18 @@ import (
 
 var (
 	diffOut = flag.String("relaxng.differential.out", "",
-		"write the group-backtracking differential record to this file; empty runs a small smoke subset and discards the output")
+		"write the group-backtracking differential record to this file; empty discards the output and, unless -relaxng.differential.cases=0 asks for the golden cross-product, runs a small smoke subset")
 	diffCases = flag.Int("relaxng.differential.cases", 20000,
-		"number of randomized group grammars for the differential record")
+		"number of randomized group grammars for the differential record; 0 runs the golden cross-product only")
 	diffSeed = flag.Int64("relaxng.differential.seed", 1,
 		"seed for the randomized group grammars")
 )
 
 // diffSmokeCases and diffSmokeStride shrink the run when no output file is
-// requested: every diffSmokeStride'th golden schema and diffSmokeCases random
-// grammars, small enough for an ordinary `go test ./relaxng` run. A smoke run
-// proves the harness still builds and runs; it is not the record.
+// requested and randomized cases were not turned off: every diffSmokeStride'th
+// golden schema and diffSmokeCases random grammars, small enough for an
+// ordinary `go test ./relaxng` run. A smoke run proves the harness still builds
+// and runs; it is not the record.
 const (
 	diffSmokeCases  = 200
 	diffSmokeStride = 8
@@ -66,8 +67,13 @@ func TestGroupBacktrackDifferential(t *testing.T) {
 	stride := 1
 	out := io.Discard
 	if *diffOut == "" {
-		cases = diffSmokeCases
-		stride = diffSmokeStride
+		// -relaxng.differential.cases=0 means the golden cross-product and
+		// nothing else, whether or not a record is being written, so the smoke
+		// reduction does not apply to it.
+		if cases != 0 {
+			cases = diffSmokeCases
+			stride = diffSmokeStride
+		}
 	} else {
 		f, err := os.Create(*diffOut)
 		require.NoError(t, err)

--- a/relaxng/group_backtrack_differential_test.go
+++ b/relaxng/group_backtrack_differential_test.go
@@ -1,0 +1,319 @@
+package relaxng_test
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// The differential harness behind the accept/reject safety record at the top of
+// group_backtrack_test.go. It emits one deterministic line per case — the case
+// identity, the verdict, and the exact error text — so the same file can be run
+// on two revisions and the two outputs diffed. Comparing error text and not
+// just the verdict is what makes the diff meaningful: a silently reworded
+// diagnostic would otherwise pass unnoticed.
+//
+// Apart from two long-standing helpers in relaxng_test.go (testdataBase and
+// partitionCompileErrors) the file touches only the exported API, so it can be
+// dropped into an older checkout unchanged. See group_backtrack_test.go for the
+// recorded procedure and result.
+
+var (
+	diffOut = flag.String("relaxng.differential.out", "",
+		"write the group-backtracking differential record to this file; empty runs a small smoke subset and discards the output")
+	diffCases = flag.Int("relaxng.differential.cases", 20000,
+		"number of randomized group grammars for the differential record")
+	diffSeed = flag.Int64("relaxng.differential.seed", 1,
+		"seed for the randomized group grammars")
+)
+
+// diffSmokeCases and diffSmokeStride shrink the run when no output file is
+// requested: every diffSmokeStride'th golden schema and diffSmokeCases random
+// grammars, small enough for an ordinary `go test ./relaxng` run. A smoke run
+// proves the harness still builds and runs; it is not the record.
+const (
+	diffSmokeCases  = 200
+	diffSmokeStride = 8
+)
+
+// diffCorpusDir holds the golden RELAX NG schemas and instances used as the
+// first differential corpus.
+const diffCorpusDir = testdataBase + "/test"
+
+// diffRandomLabel is the instance label every randomized case validates under.
+// It is constant so two cases that fail the same way produce byte-identical
+// error text.
+const diffRandomLabel = "instance.xml"
+
+// diffAlphabet is the element-name pool the randomized grammars and instances
+// draw from. Keeping it tiny makes accepts and rejects both common.
+var diffAlphabet = []string{"a", "b", "c"}
+
+func TestGroupBacktrackDifferential(t *testing.T) {
+	cases := *diffCases
+	stride := 1
+	out := io.Discard
+	if *diffOut == "" {
+		cases = diffSmokeCases
+		stride = diffSmokeStride
+	} else {
+		f, err := os.Create(*diffOut)
+		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
+		w := bufio.NewWriter(f)
+		defer func() { _ = w.Flush() }()
+		out = w
+	}
+
+	corpusLines, valid, invalid := diffRunCorpus(t, out, stride)
+	t.Logf("corpus: %d lines (%d VALID, %d INVALID)", corpusLines, valid, invalid)
+
+	randomLines, valid, invalid, texts := diffRunRandom(t, out, cases, *diffSeed)
+	t.Logf("random: %d lines (%d VALID, %d INVALID, %d distinct error texts)", randomLines, valid, invalid, texts)
+}
+
+// TestGroupBacktrackDifferentialDeterministic proves the harness output is
+// reproducible, which is what makes a zero-line diff between two revisions
+// meaningful: two runs of the same corpus in the same binary must be
+// byte-identical.
+func TestGroupBacktrackDifferentialDeterministic(t *testing.T) {
+	var first, second strings.Builder
+	diffRunCorpus(t, &first, diffSmokeStride*4)
+	diffRunRandom(t, &first, diffSmokeCases, 1)
+	diffRunCorpus(t, &second, diffSmokeStride*4)
+	diffRunRandom(t, &second, diffSmokeCases, 1)
+	require.NotEmpty(t, first.String())
+	require.Equal(t, first.String(), second.String(), "differential harness output must be deterministic")
+}
+
+// diffRunCorpus validates every stride'th golden schema against every golden
+// instance in the same directory, emitting one line per pair.
+func diffRunCorpus(t *testing.T, out io.Writer, stride int) (lines, valid, invalid int) {
+	t.Helper()
+
+	entries, err := os.ReadDir(diffCorpusDir)
+	require.NoError(t, err)
+
+	var schemas, instances []string
+	for _, e := range entries {
+		switch {
+		case e.IsDir():
+		case strings.HasSuffix(e.Name(), ".rng"):
+			schemas = append(schemas, e.Name())
+		case strings.HasSuffix(e.Name(), ".xml"):
+			instances = append(instances, e.Name())
+		}
+	}
+	sort.Strings(schemas)
+	sort.Strings(instances)
+	require.NotEmpty(t, schemas)
+	require.NotEmpty(t, instances)
+
+	// The instance bytes are cached but re-parsed for every pair, so no
+	// validation can observe a tree another validation touched.
+	raw := make([][]byte, len(instances))
+	for i, name := range instances {
+		data, err := os.ReadFile(filepath.Join(diffCorpusDir, name))
+		require.NoError(t, err)
+		raw[i] = data
+	}
+
+	for si, rng := range schemas {
+		if si%stride != 0 {
+			continue
+		}
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		grammar, err := relaxng.NewCompiler().
+			FS(helium.PermissiveFS()).
+			Label(rng).
+			ErrorHandler(collector).
+			CompileFile(t.Context(), filepath.Join(diffCorpusDir, rng))
+		_ = collector.Close()
+		_, compileErrors := partitionCompileErrors(collector.Errors())
+		if err != nil || compileErrors != "" {
+			text := compileErrors
+			if err != nil {
+				text = err.Error() + "|" + compileErrors
+			}
+			fmt.Fprintf(out, "corpus\t%s\t-\tSCHEMA-ERROR\t%q\n", rng, text)
+			lines++
+			continue
+		}
+
+		for i, xml := range instances {
+			doc, err := helium.NewParser().Parse(t.Context(), raw[i])
+			if err != nil {
+				fmt.Fprintf(out, "corpus\t%s\t%s\tPARSE-ERROR\t%q\n", rng, xml, err.Error())
+				lines++
+				continue
+			}
+			verdict, text := diffValidate(t, grammar, doc, xml)
+			fmt.Fprintf(out, "corpus\t%s\t%s\t%s\t%q\n", rng, xml, verdict, text)
+			lines++
+			if verdict == "VALID" {
+				valid++
+				continue
+			}
+			invalid++
+		}
+	}
+	return lines, valid, invalid
+}
+
+// diffRunRandom generates seeded random group grammars with matching instances
+// and emits one line per case.
+func diffRunRandom(t *testing.T, out io.Writer, cases int, seed int64) (lines, valid, invalid, texts int) {
+	t.Helper()
+
+	// An explicit source, not the global one: the sequence must be identical
+	// on every revision the harness is run against.
+	rnd := rand.New(rand.NewSource(seed))
+	seen := make(map[string]struct{})
+
+	for i := range cases {
+		schema, instance := diffRandomCase(rnd)
+
+		schemaDoc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+		require.NoError(t, err, "case %d: generated schema must parse: %s", i, schema)
+
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		grammar, err := relaxng.NewCompiler().ErrorHandler(collector).Compile(t.Context(), schemaDoc)
+		_ = collector.Close()
+		_, compileErrors := partitionCompileErrors(collector.Errors())
+		if err != nil || compileErrors != "" {
+			text := compileErrors
+			if err != nil {
+				text = err.Error() + "|" + compileErrors
+			}
+			fmt.Fprintf(out, "random\t%d\t%d\tSCHEMA-ERROR\t%q\n", seed, i, text)
+			lines++
+			continue
+		}
+
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(instance))
+		require.NoError(t, err, "case %d: generated instance must parse: %s", i, instance)
+
+		verdict, text := diffValidate(t, grammar, doc, diffRandomLabel)
+		fmt.Fprintf(out, "random\t%d\t%d\t%s\t%q\n", seed, i, verdict, text)
+		lines++
+		if verdict == "VALID" {
+			valid++
+			continue
+		}
+		invalid++
+		if _, ok := seen[text]; !ok {
+			seen[text] = struct{}{}
+			texts++
+		}
+	}
+	return lines, valid, invalid, texts
+}
+
+// diffValidate validates one document against one grammar and returns the
+// verdict plus the exact concatenated error text.
+func diffValidate(t *testing.T, grammar *relaxng.Grammar, doc *helium.Document, label string) (verdict, text string) {
+	t.Helper()
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	err := relaxng.NewValidator(grammar).Label(label).ErrorHandler(collector).Validate(t.Context(), doc)
+	_ = collector.Close()
+	if err == nil {
+		return "VALID", ""
+	}
+
+	var b strings.Builder
+	for _, ve := range collector.Errors() {
+		b.WriteString(ve.Error())
+	}
+	if !errors.Is(err, relaxng.ErrValidationFailed) {
+		return "ERROR", err.Error() + "|" + b.String()
+	}
+	return "INVALID", b.String()
+}
+
+// diffRandomCase builds one seeded random grammar and a matching instance. It
+// rotates through three shapes; shape 0 is a bare <group> under <start>, the
+// only shape that reaches the naive backtracker.
+func diffRandomCase(rnd *rand.Rand) (schema, instance string) {
+	const header = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">`
+	members := diffRandomMembers(rnd)
+
+	switch rnd.Intn(3) {
+	case 0:
+		// Bare <group> under <start>: matches the single top-level element.
+		schema = header + `<start><group>` + members + `</group></start></grammar>`
+		instance = "<" + diffAlphabet[rnd.Intn(len(diffAlphabet))] + "/>"
+	case 1:
+		// Group as element content.
+		schema = header + `<start><element name="root"><group>` + members +
+			`</group></element></start></grammar>`
+		instance = diffRandomInstance(rnd)
+	default:
+		// Nested groups as element content.
+		schema = header + `<start><element name="root"><group><group>` + members +
+			`</group>` + diffRandomMembers(rnd) + `</group></element></start></grammar>`
+		instance = diffRandomInstance(rnd)
+	}
+	return schema, instance
+}
+
+// diffRandomMembers builds two to four group members.
+func diffRandomMembers(rnd *rand.Rand) string {
+	var b strings.Builder
+	for range 2 + rnd.Intn(3) {
+		b.WriteString(diffRandomMember(rnd))
+	}
+	return b.String()
+}
+
+// diffRandomMember wraps a random pattern in a random repetition operator.
+func diffRandomMember(rnd *rand.Rand) string {
+	inner := diffRandomPattern(rnd)
+	switch rnd.Intn(4) {
+	case 0:
+		return inner
+	case 1:
+		return `<zeroOrMore>` + inner + `</zeroOrMore>`
+	case 2:
+		return `<oneOrMore>` + inner + `</oneOrMore>`
+	default:
+		return `<optional>` + inner + `</optional>`
+	}
+}
+
+// diffRandomPattern builds either a single empty element or a choice of two.
+func diffRandomPattern(rnd *rand.Rand) string {
+	one := diffElementPattern(rnd)
+	if rnd.Intn(4) != 0 {
+		return one
+	}
+	return `<choice>` + one + diffElementPattern(rnd) + `</choice>`
+}
+
+// diffElementPattern builds one empty element pattern from the alphabet.
+func diffElementPattern(rnd *rand.Rand) string {
+	return `<element name="` + diffAlphabet[rnd.Intn(len(diffAlphabet))] + `"><empty/></element>`
+}
+
+// diffRandomInstance builds a <root> with zero to five random empty children.
+func diffRandomInstance(rnd *rand.Rand) string {
+	var b strings.Builder
+	b.WriteString(`<root>`)
+	for range rnd.Intn(6) {
+		b.WriteString("<" + diffAlphabet[rnd.Intn(len(diffAlphabet))] + "/>")
+	}
+	b.WriteString(`</root>`)
+	return b.String()
+}

--- a/relaxng/group_backtrack_test.go
+++ b/relaxng/group_backtrack_test.go
@@ -11,6 +11,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Accept/reject safety evidence for sharing validState.seq instead of copying
+// it. The differential harness that produced these figures is throwaway
+// scaffolding and is deliberately NOT checked in; this record exists so it can
+// be reconstructed.
+//
+// Procedure. Extract the base revision (`git archive 918a7d79 | tar -x -C
+// <scratch>`) and the change (`git archive 96d48bbe | tar -x -C <scratch2>`),
+// drop the SAME throwaway differential test into `relaxng/` in both, run both,
+// and diff the two outputs. The test prints one line per case: the case
+// identity, the verdict (VALID/INVALID), and, when invalid, the exact error
+// text. Comparing error text and not just the verdict is what makes the diff
+// meaningful — a silently reworded diagnostic would otherwise pass unnoticed.
+//
+// Corpus 1, the golden cross-product. Every schema in
+// testdata/libxml2-compat/relaxng/test validated against every instance in the
+// same directory: 105 schemas x 163 instances = 17,115 pairs. Diff: 0 lines
+// (16,588 INVALID, 527 VALID).
+//
+// Corpus 2, randomized group grammars. 20,000 seeded random grammars over
+// three shapes, including a bare <group> under <start>, which is the only shape
+// that reaches the naive backtracker. Diff: 0 lines (18,113 INVALID, 1,887
+// VALID, spanning 926 distinct error texts).
+//
+// Coverage under both corpora together: backtrackGroupFlexible 100%,
+// advanceFlexibleContent 100%, backtrackGroupNaive 100%, advanceFlexibleNaive
+// 88.9%. Both halves of the corpus are load-bearing: the golden cross-product
+// alone leaves the naive backtracker nearly untouched (backtrackGroupNaive
+// 19.4%, advanceFlexibleNaive 0%), because no golden schema puts a bare <group>
+// under <start>. Only the randomized set exercises that path.
+//
+// `go test -race ./relaxng` passes on both revisions.
+
 // manyChildrenDoc builds `<root>` with n `<a/>` children.
 func manyChildrenDoc(n int) string {
 	var d strings.Builder

--- a/relaxng/group_backtrack_test.go
+++ b/relaxng/group_backtrack_test.go
@@ -1,6 +1,7 @@
 package relaxng_test
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,17 @@ import (
 	"github.com/lestrrat-go/helium/relaxng"
 	"github.com/stretchr/testify/require"
 )
+
+// manyChildrenDoc builds `<root>` with n `<a/>` children.
+func manyChildrenDoc(n int) string {
+	var d strings.Builder
+	d.WriteString(`<root>`)
+	for range n {
+		d.WriteString(`<a/>`)
+	}
+	d.WriteString(`</root>`)
+	return d.String()
+}
 
 // compileGrammar compiles a RELAX NG grammar from a string, failing the test on
 // any compile error.
@@ -224,4 +236,52 @@ func TestMultiFlexibleGroupBacktrackingNotExponential(t *testing.T) {
 
 	require.NoError(t, verr, "group(zeroOrMore(a) x%d, a) over %d elements should validate", N, M)
 	require.Less(t, elapsed, 5*time.Second, "validation must not be exponential (took %s)", elapsed)
+}
+
+// TestGroupBacktrackAllocationBound guards against validState.clone() and its
+// callers deep-copying the whole remaining sibling slice on every repetition.
+// That copy makes both the flexible-group backtracker and the ordinary,
+// no-backtracking zeroOrMore path allocate quadratically or worse in child
+// count. Allocated bytes are asserted rather than wall time: bytes are
+// deterministic across machines and CI load, wall time is not.
+func TestGroupBacktrackAllocationBound(t *testing.T) {
+	a := `<element name="a"><empty/></element>`
+
+	t.Run("flexible group backtracking", func(t *testing.T) {
+		const m = 1600
+		schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start><element name="root"><group>` +
+			`<zeroOrMore>` + a + `</zeroOrMore>` + a + `</group></element></start></grammar>`
+		grammar := compileGrammar(t, schema)
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(manyChildrenDoc(m)))
+		require.NoError(t, err)
+
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+		runtime.ReadMemStats(&after)
+		require.NoError(t, verr, "group(zeroOrMore(a), a) over %d elements should validate", m)
+
+		delta := after.TotalAlloc - before.TotalAlloc
+		require.Less(t, delta, uint64(100<<20),
+			"validating group(zeroOrMore(a), a) over %d elements allocated %d bytes, want under 100 MB", m, delta)
+	})
+
+	t.Run("plain zeroOrMore, no backtracking", func(t *testing.T) {
+		const m = 16000
+		schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start><element name="root">` +
+			`<zeroOrMore>` + a + `</zeroOrMore></element></start></grammar>`
+		grammar := compileGrammar(t, schema)
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(manyChildrenDoc(m)))
+		require.NoError(t, err)
+
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+		runtime.ReadMemStats(&after)
+		require.NoError(t, verr, "zeroOrMore(a) over %d elements should validate", m)
+
+		delta := after.TotalAlloc - before.TotalAlloc
+		require.Less(t, delta, uint64(100<<20),
+			"validating zeroOrMore(a) over %d elements allocated %d bytes, want under 100 MB", m, delta)
+	})
 }

--- a/relaxng/group_backtrack_test.go
+++ b/relaxng/group_backtrack_test.go
@@ -21,13 +21,17 @@ import (
 // the diff meaningful — a silently reworded diagnostic would otherwise pass
 // unnoticed.
 //
-// Procedure. From a checkout of this branch (perf-relaxng-group-backtrack),
-// against base 4ead44b5, the merge base with main:
+// Procedure. Run it from a checkout of this branch
+// (perf-relaxng-group-backtrack) against the merge base of this branch with
+// origin/main. Resolve that base at run time and archive the same object you
+// name as the base: this branch is rebased as main moves, so no hardcoded hash
+// stays correct.
 //
+//	BASE=$(git merge-base HEAD origin/main)
 //	go test ./relaxng -run '^TestGroupBacktrackDifferential$' -timeout 30m \
 //	    -relaxng.differential.out=/tmp/head.txt
 //	mkdir -p /tmp/base
-//	git archive 4ead44b5 | tar -x -C /tmp/base
+//	git archive "$BASE" | tar -x -C /tmp/base
 //	cp relaxng/group_backtrack_differential_test.go /tmp/base/relaxng/
 //	go -C /tmp/base test ./relaxng -run '^TestGroupBacktrackDifferential$' \
 //	    -timeout 30m -relaxng.differential.out=/tmp/base.txt

--- a/relaxng/group_backtrack_test.go
+++ b/relaxng/group_backtrack_test.go
@@ -12,34 +12,60 @@ import (
 )
 
 // Accept/reject safety evidence for sharing validState.seq instead of copying
-// it. The differential harness that produced these figures is throwaway
-// scaffolding and is deliberately NOT checked in; this record exists so it can
-// be reconstructed.
+// it. The harness that produced these figures is checked in as
+// group_backtrack_differential_test.go. Apart from two long-standing helpers in
+// relaxng_test.go it touches only the exported API, so the same file runs
+// unchanged on an older checkout, and it prints one line per
+// case: the case identity, the verdict (VALID/INVALID/SCHEMA-ERROR), and the
+// exact error text. Comparing error text and not just the verdict is what makes
+// the diff meaningful — a silently reworded diagnostic would otherwise pass
+// unnoticed.
 //
-// Procedure. Extract the base revision (`git archive 918a7d79 | tar -x -C
-// <scratch>`) and the change (`git archive 96d48bbe | tar -x -C <scratch2>`),
-// drop the SAME throwaway differential test into `relaxng/` in both, run both,
-// and diff the two outputs. The test prints one line per case: the case
-// identity, the verdict (VALID/INVALID), and, when invalid, the exact error
-// text. Comparing error text and not just the verdict is what makes the diff
-// meaningful — a silently reworded diagnostic would otherwise pass unnoticed.
+// Procedure. From a checkout of this branch (perf-relaxng-group-backtrack),
+// against base 4ead44b5, the merge base with main:
+//
+//	go test ./relaxng -run '^TestGroupBacktrackDifferential$' -timeout 30m \
+//	    -relaxng.differential.out=/tmp/head.txt
+//	mkdir -p /tmp/base
+//	git archive 4ead44b5 | tar -x -C /tmp/base
+//	cp relaxng/group_backtrack_differential_test.go /tmp/base/relaxng/
+//	go -C /tmp/base test ./relaxng -run '^TestGroupBacktrackDifferential$' \
+//	    -timeout 30m -relaxng.differential.out=/tmp/base.txt
+//	diff /tmp/base.txt /tmp/head.txt
+//
+// Result: the diff is empty and both files hash to sha256
+// 1389c877613206c349dc2c4ebeddce2e4d36ab3df92bb3bd972a738b562c8498. Each run
+// takes well under a minute and writes 36,143 lines.
 //
 // Corpus 1, the golden cross-product. Every schema in
 // testdata/libxml2-compat/relaxng/test validated against every instance in the
-// same directory: 105 schemas x 163 instances = 17,115 pairs. Diff: 0 lines
-// (16,588 INVALID, 527 VALID).
+// same directory. 6 of the 105 schemas do not compile and are recorded once
+// each as SCHEMA-ERROR, leaving 99 schemas x 163 instances = 16,137 validated
+// pairs, 16,143 lines in all: 527 VALID, 15,610 INVALID.
 //
-// Corpus 2, randomized group grammars. 20,000 seeded random grammars over
-// three shapes, including a bare <group> under <start>, which is the only shape
-// that reaches the naive backtracker. Diff: 0 lines (18,113 INVALID, 1,887
-// VALID, spanning 926 distinct error texts).
+// Corpus 2, randomized group grammars. 20,000 seeded random grammars (seed 1)
+// over three shapes, including a bare <group> under <start>, which is the only
+// shape that reaches the naive backtracker: 2,889 VALID, 17,111 INVALID
+// spanning 184 distinct error texts.
 //
-// Coverage under both corpora together: backtrackGroupFlexible 100%,
+// 13,451 of the 32,721 INVALID lines carry diagnostic text. The rest are
+// failures the validator reports only through the returned error without
+// emitting anything to the error handler, which is identical on both
+// revisions.
+//
+// Coverage under both corpora together (add -coverprofile to either command
+// above, then `go tool cover -func`): backtrackGroupFlexible 100%,
 // advanceFlexibleContent 100%, backtrackGroupNaive 100%, advanceFlexibleNaive
 // 88.9%. Both halves of the corpus are load-bearing: the golden cross-product
-// alone leaves the naive backtracker nearly untouched (backtrackGroupNaive
-// 19.4%, advanceFlexibleNaive 0%), because no golden schema puts a bare <group>
-// under <start>. Only the randomized set exercises that path.
+// alone (add -relaxng.differential.cases=0) leaves the naive backtracker nearly
+// untouched (backtrackGroupNaive 19.4%, advanceFlexibleNaive 0%), because no
+// golden schema puts a bare <group> under <start>. Only the randomized set
+// exercises that path.
+//
+// An ordinary `go test ./relaxng` run needs no flags: the harness then walks
+// every eighth golden schema and 200 random grammars, discards the output, and
+// TestGroupBacktrackDifferentialDeterministic checks that two runs of that
+// subset agree byte for byte.
 //
 // `go test -race ./relaxng` passes on both revisions.
 

--- a/relaxng/interleave_repeat_test.go
+++ b/relaxng/interleave_repeat_test.go
@@ -80,8 +80,6 @@ func TestInterleaveRepeatableMemberGroup(t *testing.T) {
 // regression would also fail to finish within `go test -timeout`, so it is
 // caught regardless of this assertion.)
 func TestInterleaveRepeatableMemberGroupNotExponential(t *testing.T) {
-	t.Parallel()
-
 	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start>` +
 		`<element name="root"><interleave>` +
 		`<zeroOrMore><group>` +
@@ -93,7 +91,8 @@ func TestInterleaveRepeatableMemberGroupNotExponential(t *testing.T) {
 	grammar := compileGrammar(t, schema)
 
 	// validateN builds a <root> of n interleaved a/c/b triples, validates it
-	// (which must succeed), and returns how long validation took.
+	// repeatedly, and returns the total validation time. Batching the runs keeps
+	// the timing window above the clock resolution on platforms such as Windows.
 	validateN := func(n int) time.Duration {
 		var docStr strings.Builder
 		docStr.WriteString(`<root>`)
@@ -104,10 +103,13 @@ func TestInterleaveRepeatableMemberGroupNotExponential(t *testing.T) {
 		doc, err := helium.NewParser().Parse(t.Context(), []byte(docStr.String()))
 		require.NoError(t, err)
 
+		const repetitions = 8
 		start := time.Now()
-		verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+		for range repetitions {
+			verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+			require.NoError(t, verr, "interleave of %d group(a,b) pairs with c must validate", n)
+		}
 		elapsed := time.Since(start)
-		require.NoError(t, verr, "interleave of %d group(a,b) pairs with c must validate", n)
 		return elapsed
 	}
 

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -61,7 +61,7 @@ type groupMemoEntry struct {
 }
 
 func (e *groupMemoEntry) apply(state *validState, attrUsed []bool, v *validator) int {
-	state.seq = append([]helium.Node(nil), e.seq...)
+	state.seq = e.seq
 	if attrUsed != nil {
 		copy(attrUsed, e.attrUsed)
 	}
@@ -160,13 +160,21 @@ func validateDocument(ctx context.Context, doc *helium.Document, grammar *Gramma
 
 // validState tracks the current position during validation.
 type validState struct {
+	// seq is only ever re-sliced from the front (state.seq[1:] / skipIgnored)
+	// and never written through, so it is a suffix of one per-element base
+	// array. Every snapshot below (clone, saveGroupBound, groupMemoEntry) shares
+	// that backing array instead of copying it. Do NOT add a write through this
+	// slice (state.seq[i] = ... or an append that grows in place) without
+	// re-copying everywhere a snapshot is taken — doing so would silently
+	// corrupt every outstanding snapshot and memo entry.
 	seq []helium.Node // remaining siblings to validate
 }
 
 func (s *validState) clone() *validState {
-	return &validState{
-		seq: append([]helium.Node(nil), s.seq...),
-	}
+	// state.seq is only ever re-sliced from the front (state.seq[1:] /
+	// skipIgnored) and never written through, so a snapshot can share the
+	// backing array instead of copying it.
+	return &validState{seq: s.seq}
 }
 
 // validatePattern validates a pattern against the current state.
@@ -835,7 +843,7 @@ func (v *validator) validateGroupChildren(children []*pattern, elem *helium.Elem
 		}
 		v.groupMemo[key] = &groupMemoEntry{
 			result:   result,
-			seq:      append([]helium.Node(nil), state.seq...),
+			seq:      state.seq,
 			attrUsed: append([]bool(nil), attrUsed...),
 			errs:     append([]error(nil), v.pendingErrors[errBase:]...),
 		}
@@ -953,25 +961,12 @@ func (v *validator) backtrackGroupFlexible(children []*pattern, failIdx int,
 		}
 		var best *btSuccess
 
-		for iter := minIter; ; iter++ {
-			bounds[j].restore(state, attrUsed, v)
-
-			// Run 'iter' iterations of the flexible child.
-			iterOK := true
-			for range iter {
-				savedSt := state.clone()
-				v.suppressDepth++
-				ret := v.validateContentPat(content, elem, attrs, attrUsed, state)
-				v.suppressDepth--
-				if ret != 0 || seqEqual(state.seq, savedSt.seq) {
-					iterOK = false
-					break
-				}
-			}
-			if !iterOK {
-				break // Can't match 'iter' times
-			}
-
+		// Walk the iteration counts upward incrementally: cur is the boundary
+		// after the current count, and one more repetition advances it. Replaying
+		// every repetition from bounds[j] for each count would be quadratic in
+		// the greedy count.
+		cur, curOK := v.advanceFlexibleContent(content, elem, attrs, attrUsed, state, bounds[j], minIter)
+		for curOK {
 			// Check if we've reached the same state as the greedy pass.
 			if seqEqual(state.seq, bounds[j+1].state.seq) &&
 				boolSliceEqual(attrUsed, bounds[j+1].attrUsed) {
@@ -998,6 +993,8 @@ func (v *validator) backtrackGroupFlexible(children []*pattern, failIdx int,
 			// Restore errors from before retry so failed attempts don't leak errors.
 			v.pendingErrors = v.pendingErrors[:retryLen]
 			v.valid = retryValid
+
+			cur, curOK = v.advanceFlexibleContent(content, elem, attrs, attrUsed, state, cur, 1)
 		}
 
 		if best != nil {
@@ -1012,6 +1009,42 @@ func (v *validator) backtrackGroupFlexible(children []*pattern, failIdx int,
 		bounds[j].restore(state, attrUsed, v)
 	}
 	return false
+}
+
+// advanceFlexibleContent restores the given boundary and runs n more repetitions
+// of a flexible group child's content from it, returning the boundary that
+// follows them. It reports false when a repetition fails or consumes nothing,
+// which caps the iteration count the backtracker may request. On failure the
+// caller's state is left mid-attempt, exactly as the inline replay left it.
+func (v *validator) advanceFlexibleContent(content *pattern, elem *helium.Element,
+	attrs []*helium.Attribute, attrUsed []bool, state *validState, from groupBound, n int) (groupBound, bool) {
+	from.restore(state, attrUsed, v)
+	for range n {
+		before := state.seq
+		v.suppressDepth++
+		ret := v.validateContentPat(content, elem, attrs, attrUsed, state)
+		v.suppressDepth--
+		if ret != 0 || seqEqual(state.seq, before) {
+			return groupBound{}, false
+		}
+	}
+	return saveGroupBound(state, attrUsed, len(v.pendingErrors), v.valid), true
+}
+
+// advanceFlexibleNaive is advanceFlexibleContent for the naive group path, which
+// carries no attribute or element-content context.
+func (v *validator) advanceFlexibleNaive(content *pattern, state *validState, from groupBound, n int) (groupBound, bool) {
+	from.restore(state, nil, v)
+	for range n {
+		before := state.seq
+		v.suppressDepth++
+		ret := v.validatePattern(content, state)
+		v.suppressDepth--
+		if ret != 0 || seqEqual(state.seq, before) {
+			return groupBound{}, false
+		}
+	}
+	return saveGroupBound(state, nil, len(v.pendingErrors), v.valid), true
 }
 
 // isKnownChildElement checks if an element name/ns appears as a child element
@@ -1524,7 +1557,7 @@ func (v *validator) validateGroupSeq(children []*pattern, state *validState) int
 		}
 		v.groupMemo[key] = &groupMemoEntry{
 			result: result,
-			seq:    append([]helium.Node(nil), state.seq...),
+			seq:    state.seq,
 			errs:   append([]error(nil), v.pendingErrors[errBase:]...),
 		}
 	}
@@ -1599,24 +1632,10 @@ func (v *validator) backtrackGroupNaive(children []*pattern, failIdx int,
 		var bestErrLen int
 		var bestValid bool
 
-		for iter := minIter; ; iter++ {
-			bounds[j].restore(state, nil, v)
-
-			iterOK := true
-			for range iter {
-				savedSt := state.clone()
-				v.suppressDepth++
-				ret := v.validatePattern(content, state)
-				v.suppressDepth--
-				if ret != 0 || seqEqual(state.seq, savedSt.seq) {
-					iterOK = false
-					break
-				}
-			}
-			if !iterOK {
-				break
-			}
-
+		// Walk the iteration counts upward incrementally (see
+		// backtrackGroupFlexible): cur is the boundary after the current count.
+		cur, curOK := v.advanceFlexibleNaive(content, state, bounds[j], minIter)
+		for curOK {
 			// Stop once we reach the greedy consumption level — that is the
 			// state that already failed.
 			if seqEqual(state.seq, bounds[j+1].state.seq) {
@@ -1637,6 +1656,8 @@ func (v *validator) backtrackGroupNaive(children []*pattern, failIdx int,
 			}
 			v.pendingErrors = v.pendingErrors[:retryLen]
 			v.valid = retryValid
+
+			cur, curOK = v.advanceFlexibleNaive(content, state, cur, 1)
 		}
 
 		if bestState != nil {
@@ -2575,6 +2596,13 @@ func boolSliceEqual(a, b []bool) bool {
 func seqEqual(a, b []helium.Node) bool {
 	if len(a) != len(b) {
 		return false
+	}
+	// Sequences in one content scope are suffixes of the same backing array,
+	// so equal length plus an identical first element settles it in O(1). This
+	// is a fast path only: when it does not apply, the loop below still walks
+	// the full slice and returns the same answer it always did.
+	if len(a) == 0 || &a[0] == &b[0] {
+		return true
 	}
 	for i := range a {
 		if a[i] != b[i] {


### PR DESCRIPTION
- group backtracking was cubic (quadratic for plain zeroOrMore) from deep-copying the sibling slice on every snapshot
- snapshots now share that slice since it is only ever re-sliced from the front, never written through
- the backtracker advances one repetition at a time from a saved boundary instead of replaying every prefix
