### PR TITLE
use t.TempDir for TestRedefine scratch dir

### DIFF
--- a/xsd/xsd_test.go
+++ b/xsd/xsd_test.go
@@ -598,13 +598,7 @@ func TestMultipleAttributeErrors(t *testing.T) {
 
 func TestRedefine(t *testing.T) {
 	t.Parallel()
-	tmpDir := filepath.Join("..", ".tmp", "redefine-test")
-	require.NoError(t, os.MkdirAll(tmpDir, 0o750)) //nolint:gosec // test temp directory
-	t.Cleanup(func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Logf("failed to remove temp dir %s: %v", tmpDir, err)
-		}
-	})
+	tmpDir := t.TempDir()
 
 	writeFile := func(t *testing.T, name, content string) string {
 		t.Helper()


### PR DESCRIPTION
- `TestRedefine` wrote scratch files to `../.tmp`, outside the module.
- That broke `go test ./xsd` from a worktree or read-only checkout.
- `t.TempDir()` fixes it; assertions and fixtures are unchanged.
