### PR TITLE
resolve append tails the child list reaches

### DIFF
--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -244,7 +244,8 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   and is rejected with a `%w`-wrapped `ErrInvalidOperation`. A non-attribute child takes the ordinary
   child-list path (a `*Document` accepts multiple element children — it is an XDM document node, not a
   well-formed-document constraint; single-root enforcement lives in `SetDocumentElement`, mirroring libxml2's
-  `xmlDocSetRootElement`).
+  `xmlDocSetRootElement`). Re-adding the exact ordinary-child node already stored as this parent's foreign
+  `firstChild` or `lastChild` is a successful no-op; the node remains linked to its real owner's chain.
 - `addSibling(node, sibling)` — append to end of siblings. The tree an append leaves behind is always the one
   the plain `NextSibling()` walk from the anchor produces, INCLUDING every `parent.lastChild` write, which is
   unconditional exactly as it is in that walk. What changes is how the append point is REACHED: the generic
@@ -271,13 +272,16 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   quadratic over N appends. A parent holding a `firstChild` with NO `lastChild` — the shape
   `Document.stringToNodeList` leaves behind on an entity referenced from an attribute value — does not reach
   the empty-parent branch of `addChild`/`appendFastChild`, because `resolveOwnedTail` walks that child list and
-  returns its true tail, so the append joins the list instead of overwriting `firstChild`; neither does a
-  parent whose `firstChild` claims someone else, which keeps its list too. The guarded paths therefore detach
-  no child from a chain it goes on claiming, and create no claim of their own. A `*Document` parent is NOT
-  declined by type: a document's child list is an ordinary sibling chain that an append walks exactly like any
-  other. A document IS the one parent safe API hands such a claimant, through `CopyExtSubset`, which gives the
-  copied EXTERNAL subset the destination document as its parent and then leaves it reachable only through
-  `ExtSubset`, never from the child list, so an append through that subset records a tail off the child list.
+  returns its true tail, so the append joins the list instead of overwriting `firstChild`. A parent whose
+  `firstChild` claims someone else has no owned tail: `resolveOwnedTail` returns nil, so appending a different
+  node replaces that foreign pointer without changing the foreign owner's chain. Re-adding the stored foreign
+  endpoint itself is a no-op before auto-unlink, so it also leaves both links unchanged. The guarded paths
+  therefore detach no child from a chain it goes on claiming, and create no claim of their own. A `*Document`
+  parent is NOT declined by type: a document's child list is an ordinary sibling chain that an append walks
+  exactly like any other. A document IS the one parent safe API hands such a claimant, through `CopyExtSubset`,
+  which gives the copied EXTERNAL subset the destination document as its parent and then leaves it reachable
+  only through `ExtSubset`, never from the child list, so an append through that subset records a tail off the
+  child list.
   That is a CONDITION, not a type, and `Document.offChainChildClaim` (`document.go`, set by `CopyExtSubset`)
   records it on that document as the claimed PARENT, so it declines only for appends onto the document node
   itself and never for the elements that document owns. (`CreateInternalSubset` also gives a `DTD` the document
@@ -318,7 +322,9 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   the reference receives a child. A stale owned record is repaired rather than followed: the
   `CopyExtSubset` shape has no reachable first child, and the `stringToNodeList` shape has an owned child list
   but no recorded tail. The `CreateReference` shape has only a foreign first child, so the new owned list
-  replaces the reference's pointer to that shared Entity without changing the DTD chain.
+  replaces the reference's pointer to that shared Entity without changing the DTD chain. Re-adding that same
+  stored Entity is handled before resolution as a successful no-op, leaving the Entity on the DTD chain and
+  as the reference's foreign child.
   `TestAddChildResolvesAnOwnedTail` (`node_owned_tail_test.go`) pins all four reachable shapes, and
   `TestAddSiblingOffChainParentClaim`, `TestAddSiblingCopiedExternalSubsetClaim` and
   `TestAddSiblingCorruptShapesMatchWalk` (`node_sibling_test.go`) pin the sibling side; every expectation in
@@ -444,8 +450,10 @@ stops within a small multiple of the cycle length, so on a corrupt sibling list 
 the stack more than once — harmless, since the popped-node visited set deduplicates the extra pushes on pop,
 and termination is unconditional either way. The childless-cur fast path (the parser hot path appends fresh
 leaves) skips the search entirely, so plain parsing is unaffected; it only runs for a subtree/entity-ref
-insertion. addChild/addSibling auto-unlink an already-linked incoming node before relinking so it never lives
-in two places; rejection leaves the tree untouched. The shared guard + auto-unlink is factored into
+insertion. `addChild`/`addSibling` auto-unlink an already-linked incoming node before relinking so it never
+lives in two places. `addChild` instead returns a successful no-op when the incoming node is already stored as
+the parent's foreign first or last child, because unlinking it would damage its real owner's chain. Rejection
+leaves the tree untouched. The shared guard + auto-unlink is factored into
 `addChildPreflight`/`addSiblingPreflight`. Leaf `AddChild`/`AddSibling` overrides that take a content-merge
 fast path (Text, Comment, and ProcessingInstruction — whose `AddChild` merges a Text/CDATA operand's content
 into the PI data string) run the matching preflight BEFORE merging, so

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -305,28 +305,26 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   because the `properties` membership test already costs that walk. A node can claim a parent without being a
   member of that parent's child list — `CopyExtSubset`'s copied external subset, or a package-private
   `unsafeSetParent` write. An append through such a node records its own result as the parent's `lastChild`,
-  moving that record off the child list. All three append entry points then land at the end of the REACHABLE
-  children: `AddSibling` walks from its anchor, and `AddChild`, `appendFastChild` and `appendCopiedChild` reach
-  the same node through `resolveOwnedTail` (`node.go`). It returns nil ONLY when `parent.firstChild` is nil,
-  whatever `lastChild` records, so the empty-parent branch of its callers — the one that OVERWRITES
-  `firstChild` — is reachable only for a parent that is genuinely empty and can never discard a child list. It
-  trusts the record when that node claims this parent, has no `next`, AND this parent holds no off-chain claim
-  (the same signal `tailJumpTarget` declines on, read through `holdsOffChainChildClaim`); otherwise it walks
-  the child list under a `siblingCycleGuard` to the last node still claiming the parent, and when NOTHING on
-  that list claims the parent it returns the list's head instead, so the append joins the existing children
-  rather than replacing them. The node about to be appended is excluded from that head fallback: the callers
-  unlink it first, so a `firstChild` that IS the operand leaves a list of one node with nothing to preserve,
-  and returning it would build a self-link. That is what keeps an append in the same place whichever entry
-  point the caller used, and it is why a stale record is repaired rather than followed: trusting `lastChild`
-  alone loses the reachable list when `firstChild` is nil (the `CopyExtSubset` shape), discards it when
-  `lastChild` is nil (the `stringToNodeList` shape), and discards it again when `firstChild` claims another
-  parent (the `CreateReference` shape, where the shared `Entity` keeps the `DTD`).
+  moving that record off the child list. `AddSibling` walks from its anchor, while `AddChild`,
+  `appendFastChild` and `appendCopiedChild` resolve the last OWNED child through `resolveOwnedTail`
+  (`node.go`). The resolver trusts the recorded tail when that node claims this parent, has no `next`, AND
+  this parent holds no off-chain claim (the same signal `tailJumpTarget` declines on, read through
+  `holdsOffChainChildClaim`); otherwise it walks the child list under a `siblingCycleGuard` to the last node
+  still claiming the parent. It returns nil when `parent.firstChild` is nil OR when the first child is foreign
+  and no owned tail exists. The callers then install the appended node as a new owned child list. They NEVER
+  use a foreign head as an `AddSibling` anchor: an entity reference's shared `Entity` child keeps the `DTD` as
+  its parent, so the Entity's sibling links belong to the DTD declaration list and must remain unchanged when
+  the reference receives a child. A stale owned record is repaired rather than followed: the
+  `CopyExtSubset` shape has no reachable first child, and the `stringToNodeList` shape has an owned child list
+  but no recorded tail. The `CreateReference` shape has only a foreign first child, so the new owned list
+  replaces the reference's pointer to that shared Entity without changing the DTD chain.
   `TestAddChildResolvesAnOwnedTail` (`node_owned_tail_test.go`) pins all four reachable shapes, and
   `TestAddSiblingOffChainParentClaim`, `TestAddSiblingCopiedExternalSubsetClaim` and
   `TestAddSiblingCorruptShapesMatchWalk` (`node_sibling_test.go`) pin the sibling side; every expectation in
   the last of those holds for the walk-only implementation too, which is what makes it a differential check.
-  `TestAppendKeepsAForeignChildList` (`node_sibling_internal_test.go`) pins the same survival rule on nodes no
-  document owns. The raw setters record NOTHING, so a tree corrupted through them is outside this agreement —
+  `TestAppendReplacesAForeignChildList` (`node_sibling_internal_test.go`) pins the same ownership boundary on
+  nodes no document owns. The raw setters record NOTHING, so a tree corrupted through them is outside this
+  agreement —
   they already document the tree as inconsistent afterwards, and no importer and no production path can reach
   them.
 - `replaceNode(old, new)` — swap in same position. Attribute-aware: replacing an `Attribute` updates the

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -263,37 +263,33 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   chain. NO local read can establish (2): two trees can have pointer-identical neighborhoods around `parent` and
   `lastChild` and differ only in a `next` pointer an unbounded distance forward from `firstChild`. It holds
   instead as an INVARIANT of the guarded paths, each of which moves `lastChild` only to a node it has just
-  linked onto the chain, so what is checked is that this document holds no node claiming a parent it is not a
-  child of: `Document.offChainClaims` (`document.go`). `noteOrphanedChildClaim` records the one such claim the
-  GUARDED paths create. A parent holding a `firstChild` with NO `lastChild` — the shape
-  `Document.stringToNodeList` leaves behind on an entity referenced from an attribute value — no longer reaches
+  linked onto the chain, so what is checked is that THIS parent has not been handed a child claiming it from
+  off its child list, through `holdsOffChainChildClaim` (`node.go`). The record is per-PARENT: the parent whose
+  chain is at stake is the only one whose `lastChild` a claimant can invalidate, so a claim on one parent must
+  never cost every other parent in the same document its O(1) resolution — reading it from the owning document
+  makes one claim anywhere turn every later append in that document into a full child-list walk, which is
+  quadratic over N appends. A parent holding a `firstChild` with NO `lastChild` — the shape
+  `Document.stringToNodeList` leaves behind on an entity referenced from an attribute value — does not reach
   the empty-parent branch of `addChild`/`appendFastChild`, because `resolveOwnedTail` walks that child list and
-  returns its true tail, so the append joins the list instead of overwriting `firstChild`. An append through
-  that detached child then moves the parent's recorded tail off the child list. Recording the claim at the
-  moment it is created is what keeps the later append byte-identical to the walk. Each claim is recorded on the
-  document owning the parent whose chain is at stake and on the document owning the detached child, each
-  resolved through `owningDocument` so a `*Document` names ITSELF (a document node's own `doc` pointer is nil
-  because it IS the owner). Once set it stays set, and appends for that document walk — which is what every
-  other tree operation does unconditionally. The record FOLLOWS THE TREE, not only the document it was first
-  made on, because a subtree can change owning document afterwards, and a claim made on a still-DETACHED subtree
-  has no document to be recorded on at all. `adoptOffChainClaims` (`node.go`) carries it across every change of
-  owner — `docnode.SetOwnerDocument`, `setTreeDoc`'s attribute write, `setListDoc`'s direct write, and
-  `noteCrossDocumentEscape` — and the unattributable case lands on the package-level `unownedOffChainClaim` (an
-  `atomic.Bool`), which a document inherits when it adopts a subtree that arrives owning no document. That
-  global is the ONE package-wide part; the flag itself stays per-DOCUMENT, because one claim must not slow every
-  other document in the process. `TestAdoptOffChainClaimWithoutOwner` (`node_sibling_internal_test.go`) pins the
-  unowned case. A `*Document` parent is NOT declined by type. Its owning document is read through
-  `owningDocument`, so it names itself, and a document's child list is an ordinary sibling chain that an append
-  walks exactly like any other. A document is claimed off-chain by `CopyExtSubset`, which gives the copied
-  EXTERNAL subset the destination document as its parent and then leaves it reachable only through `ExtSubset`,
-  never from the child list, so an append through that subset records a tail off the child list. That is a
-  CONDITION, not a type, and `Document.offChainChildClaim` (`document.go`, set by `CopyExtSubset`) records it
-  separately from `offChainClaims` so it declines only for the `*Document` parent handed the claimant, not for
-  every parent in that document. (`CreateInternalSubset` also gives a `DTD` the document as its parent, but it
-  splices that `DTD` into the child list, so it creates no claim.) `TestTailJumpTargetDocumentParent`
-  (`node_sibling_internal_test.go`) pins all three outcomes. `tailJumpTarget` then makes three cheap
-  confirmations that the record is usable (`tail != anchor`, `tail.next == nil`, `tail.parent` is this parent);
-  they cannot fail on a document holding no recorded claim, and are kept because a tree may span documents
+  returns its true tail, so the append joins the list instead of overwriting `firstChild`; neither does a
+  parent whose `firstChild` claims someone else, which keeps its list too. The guarded paths therefore detach
+  no child from a chain it goes on claiming, and create no claim of their own. A `*Document` parent is NOT
+  declined by type: a document's child list is an ordinary sibling chain that an append walks exactly like any
+  other. A document IS the one parent safe API hands such a claimant, through `CopyExtSubset`, which gives the
+  copied EXTERNAL subset the destination document as its parent and then leaves it reachable only through
+  `ExtSubset`, never from the child list, so an append through that subset records a tail off the child list.
+  That is a CONDITION, not a type, and `Document.offChainChildClaim` (`document.go`, set by `CopyExtSubset`)
+  records it on that document as the claimed PARENT, so it declines only for appends onto the document node
+  itself and never for the elements that document owns. (`CreateInternalSubset` also gives a `DTD` the document
+  as its parent, but it splices that `DTD` into the child list, so it creates no claim.) Every other parent
+  answers `false` in a type assertion, so an ordinary append pays nothing for the check.
+  `TestTailJumpTargetDocumentParent` (`node_sibling_internal_test.go`) pins all three outcomes, including that
+  a claim on the document leaves every element in it resolving in O(1), and
+  `TestAppendCostIsLinearBesideAnOffChainClaim` (`node_owned_tail_test.go`) pins the SHAPE of the cost:
+  doubling the appends onto a clean element beside a claim roughly doubles the time rather than quadrupling
+  it. `tailJumpTarget` then makes three cheap confirmations that the record is usable (`tail != anchor`,
+  `tail.next == nil`, `tail.parent` is this parent); they cannot fail on a parent holding no recorded claim,
+  and are kept because a tree may span documents
   (`noteCrossDocumentEscape`) while the record does not, so an uncovered corner degrades to the walk instead of
   splicing onto the wrong node. They also keep the stale-`lastChild` repair path `addChild`/`appendFastChild`
   depend on: they call `AddSibling` on `parent.lastChild` precisely when that node's `next` is non-nil, so the
@@ -307,24 +303,32 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   which track the element arms to within noise. The attribute-chain branch (an anchor genuinely reachable from
   its owning `*Element`'s `properties` chain) resolves its tail by walking, bounded by the attribute count,
   because the `properties` membership test already costs that walk. A node can claim a parent without being a
-  member of that parent's child list — the detached-child shape above, `CopyExtSubset`'s copied external subset,
-  or a package-private `unsafeSetParent` write. An append through such a node records its own result as the
-  parent's `lastChild`, moving that record off the child list. All three append entry points then land at the
-  end of the REACHABLE children: `AddSibling` walks from its anchor, and `AddChild`, `appendFastChild` and
-  `appendCopiedChild` reach the same node through `resolveOwnedTail` (`node.go`), which returns nil when
-  `parent.firstChild` is nil whatever `lastChild` records, trusts the record only when that node claims this
-  parent, has no `next`, AND the owning document holds no off-chain claim (the same signal `tailJumpTarget`
-  declines on, read through `holdsOffChainChildClaim`), and otherwise walks the child list under a
-  `siblingCycleGuard` to the last node still claiming the parent. That is what keeps an append in the same place
-  whichever entry point the caller used, and it is why a stale record is repaired rather than followed: trusting
-  `lastChild` alone loses the reachable list when `firstChild` is nil (the `CopyExtSubset` shape) and discards
-  it when `lastChild` is nil (the `stringToNodeList` shape). `TestAddChildResolvesAnOwnedTail`
-  (`node_owned_tail_test.go`) pins all three reachable shapes, and `TestAddSiblingOffChainParentClaim`,
-  `TestAddSiblingCopiedExternalSubsetClaim` and `TestAddSiblingCorruptShapesMatchWalk` (`node_sibling_test.go`)
-  pin the sibling side; every expectation in the last of those holds for the walk-only implementation too, which
-  is what makes it a differential check. The raw setters record NOTHING, so a tree corrupted through them is
-  outside this agreement — they already document the tree as inconsistent afterwards, and no importer and no
-  production path can reach them.
+  member of that parent's child list — `CopyExtSubset`'s copied external subset, or a package-private
+  `unsafeSetParent` write. An append through such a node records its own result as the parent's `lastChild`,
+  moving that record off the child list. All three append entry points then land at the end of the REACHABLE
+  children: `AddSibling` walks from its anchor, and `AddChild`, `appendFastChild` and `appendCopiedChild` reach
+  the same node through `resolveOwnedTail` (`node.go`). It returns nil ONLY when `parent.firstChild` is nil,
+  whatever `lastChild` records, so the empty-parent branch of its callers — the one that OVERWRITES
+  `firstChild` — is reachable only for a parent that is genuinely empty and can never discard a child list. It
+  trusts the record when that node claims this parent, has no `next`, AND this parent holds no off-chain claim
+  (the same signal `tailJumpTarget` declines on, read through `holdsOffChainChildClaim`); otherwise it walks
+  the child list under a `siblingCycleGuard` to the last node still claiming the parent, and when NOTHING on
+  that list claims the parent it returns the list's head instead, so the append joins the existing children
+  rather than replacing them. The node about to be appended is excluded from that head fallback: the callers
+  unlink it first, so a `firstChild` that IS the operand leaves a list of one node with nothing to preserve,
+  and returning it would build a self-link. That is what keeps an append in the same place whichever entry
+  point the caller used, and it is why a stale record is repaired rather than followed: trusting `lastChild`
+  alone loses the reachable list when `firstChild` is nil (the `CopyExtSubset` shape), discards it when
+  `lastChild` is nil (the `stringToNodeList` shape), and discards it again when `firstChild` claims another
+  parent (the `CreateReference` shape, where the shared `Entity` keeps the `DTD`).
+  `TestAddChildResolvesAnOwnedTail` (`node_owned_tail_test.go`) pins all four reachable shapes, and
+  `TestAddSiblingOffChainParentClaim`, `TestAddSiblingCopiedExternalSubsetClaim` and
+  `TestAddSiblingCorruptShapesMatchWalk` (`node_sibling_test.go`) pin the sibling side; every expectation in
+  the last of those holds for the walk-only implementation too, which is what makes it a differential check.
+  `TestAppendKeepsAForeignChildList` (`node_sibling_internal_test.go`) pins the same survival rule on nodes no
+  document owns. The raw setters record NOTHING, so a tree corrupted through them is outside this agreement —
+  they already document the tree as inconsistent afterwards, and no importer and no production path can reach
+  them.
 - `replaceNode(old, new)` — swap in same position. Attribute-aware: replacing an `Attribute` updates the
   owning `Element.properties` head/chain (NOT `firstChild`/`lastChild`), and an attribute may only be replaced
   by attribute node(s) (non-attribute replacement is rejected)

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -348,7 +348,9 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   never carry the one production foreign-link source `wouldCreateCycle` exists to catch. `appendCopiedChild`
   is distinct from `appendFastChild` — it is not used outside the copier — because `appendFastChild` also
   backs `xslt3`'s strip-space copier, and widening its linking rule to add a merge check would change behavior
-  for that unrelated caller too.
+  for that unrelated caller too. `CopyDoc` builds the fresh document child list before `CopyExtSubset` records
+  its off-chain claim on the destination document, so each document-level append can use the recorded owned
+  tail instead of walking the growing child list.
 - `DeclareNamespace(prefix, uri)` / `AddNamespaceDecl(ns)` — do NOT themselves add a second declaration for a
   prefix in `nsDefs`, and NEVER touch the node's active namespace (`n.ns`) or expanded name.
   `DeclareNamespace` allocates a fresh `*Namespace`; `AddNamespaceDecl` attaches the caller's existing object

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -250,75 +250,81 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   unconditional exactly as it is in that walk. What changes is how the append point is REACHED: the generic
   child-list branch resolves it from `parent.lastChild` without walking whenever `tailJumpTarget` (`node.go`)
   can prove that record is the very node the walk would have found, and otherwise walks. The proof needs two
-  facts. (1) The ANCHOR is a member of the chain `parent` owns — `chainMember` (`node.go`) answers in a
-  pointer comparison when the anchor is `parent.firstChild`, and otherwise walks `prev` to the head of the
-  anchor's own chain and compares it against `parent.firstChild`. (An anchor that is `parent.lastChild` never
-  reaches `chainMember`: `tailJumpTarget` has already declined, because the anchor and the recorded tail are
-  the same node.) That walk is bounded by the anchor's distance BEHIND it, never by the chain ahead of it, so
-  it can never cost more than the `NextSibling()` walk it replaces; it carries a `siblingCycleGuard` so a
-  corrupt `prev` chain terminates instead of spinning, and it crosses only RECIPROCAL `prev` edges
-  (`reciprocalPrev` — the `prev` node points forward at the node again), so a one-way edge cannot carry it out
-  of the anchor's own chain. There is no raw `prev` setter, but a one-way `prev` edge survives whenever a node
-  is spliced out of a chain from the FRONT, so the check is not hypothetical. (2) `parent.lastChild` is the
-  final node of that same chain. NO local read can establish (2): two trees can have pointer-identical
-  neighborhoods around `parent` and `lastChild` and differ only in a `next` pointer an unbounded distance
-  forward from `firstChild`. It holds instead as an INVARIANT of the guarded paths, each of which moves
-  `lastChild` only to a node it has just linked onto the chain, so what is checked is that this document holds
-  no node claiming a parent it is not a child of: `Document.offChainClaims` (`document.go`).
-  `noteOrphanedChildClaim` records the one such claim the GUARDED paths create, which is how an ordinary
-  caller reaches one: a parent holding a `firstChild` with NO `lastChild` — the shape
-  `Document.stringToNodeList` leaves behind on an entity referenced from an attribute value — makes
-  `addChild`/`appendFastChild` take their empty-parent branch, which OVERWRITES `firstChild` and detaches the
-  child that was there while it goes on claiming the parent. An append through that detached child then moves
-  the parent's recorded tail off the child list. Recording the claim at the moment it is created is what keeps
-  the later append byte-identical to the walk. Each claim is recorded on the document owning the parent whose
-  chain is at stake and on the document owning the detached child, each resolved through `owningDocument` so a
-  `*Document` names ITSELF (a document node's own `doc` pointer is nil because it IS the owner). Once set it
-  stays set, and appends for that document walk — which is what every other tree operation does
-  unconditionally. The record FOLLOWS THE TREE, not only the document it was first made on, because a subtree
-  can change owning document afterwards, and a claim made on a still-DETACHED subtree has no document to be
-  recorded on at all. `adoptOffChainClaims` (`node.go`) carries it across every change of owner —
-  `docnode.SetOwnerDocument`, `setTreeDoc`'s attribute write, `setListDoc`'s direct write, and
-  `noteCrossDocumentEscape` — and the unattributable case lands on the package-level `unownedOffChainClaim`
-  (an `atomic.Bool`), which a document inherits when it adopts a subtree that arrives owning no document. That
-  global is the ONE package-wide part; the flag itself stays per-DOCUMENT, because one claim must not slow
-  every other document in the process. `TestAdoptOffChainClaimWithoutOwner` (`node_sibling_internal_test.go`)
-  pins the unowned case. A `*Document` parent is NOT declined by type. Its owning document is read through
-  `owningDocument`, so it names itself, and a document's child list is an ordinary sibling chain that an
-  append walks exactly like any other. A document is claimed off-chain by `CopyExtSubset`, which gives the
-  copied EXTERNAL subset the destination document as its parent and then leaves it reachable only through
-  `ExtSubset`, never from the child list, so an append through that subset records a tail off the child list.
-  That is a CONDITION, not a type, and `Document.offChainChildClaim` (`document.go`, set by `CopyExtSubset`)
-  records it separately from `offChainClaims` so it declines only for the `*Document` parent handed the
-  claimant, not for every parent in that document. (`CreateInternalSubset` also gives a `DTD` the document as
-  its parent, but it splices that `DTD` into the child list, so it creates no claim.)
-  `TestTailJumpTargetDocumentParent` (`node_sibling_internal_test.go`) pins all three outcomes.
-  `tailJumpTarget` then makes three cheap confirmations that the record is usable (`tail != anchor`,
-  `tail.next == nil`, `tail.parent` is this parent); they cannot fail on a document holding no recorded claim,
-  and are kept because a tree may span documents (`noteCrossDocumentEscape`) while the record does not, so an
-  uncovered corner degrades to the walk instead of splicing onto the wrong node. They also keep the
-  stale-`lastChild` repair path `addChild`/`appendFastChild` depend on: they call `AddSibling` on
-  `parent.lastChild` precisely when that node's `next` is non-nil, so the resolution declines and the walk
-  finds and repairs the true tail. WHAT THE O(1) RESOLUTION IS WORTH DEPENDS ON THE ANCHOR: appending through
-  `parent.firstChild`, or at the true tail (where the anchor's `next` is nil and `addSibling` links directly
-  without consulting `tailJumpTarget` at all), is O(1) per call and LINEAR over N appends (105µs vs 49.5ms at
-  N=4000, a ~470x win), while appending through a MIDDLE anchor stays QUADRATIC — `chainMember`'s `prev` walk
-  grows with the chain — and gains a ~3.8x constant factor instead (26.5ms vs 99.6ms at N=4000).
-  `BenchmarkAddSibling` (`node_sibling_bench_test.go`) measures five arms: `tail`, `nontail` (= first child)
-  and `middle` on an `*Element` parent, plus `docnontail` and `docmiddle` on a `*Document` parent, which track
-  the element arms to within noise. The attribute-chain branch (an anchor genuinely reachable from its owning
-  `*Element`'s `properties` chain) resolves its tail by walking, bounded by the attribute count, because the
-  `properties` membership test already costs that walk. A node can claim a parent without being a member of
-  that parent's child list — the detached-child shape above, `CopyExtSubset`'s copied external subset, or a
-  package-private `unsafeSetParent` write. An append through such a node records its own result as the
-  parent's `lastChild`, moving that record off the child list, after which `AddSibling` (which walks from its
-  anchor) lands at the end of the REACHABLE children while `AddChild` and `UnsafeAppendChild` (which start
-  from the record) land after the off-chain node. `TestAddSiblingOffChainParentClaim`,
-  `TestAddSiblingCopiedExternalSubsetClaim` and `TestAddSiblingCorruptShapesMatchWalk`
-  (`node_sibling_test.go`) pin those shapes; every expectation in them holds for the walk-only implementation
-  too, which is what makes them a differential check. The raw setters record NOTHING, so a tree corrupted
-  through them is outside this agreement — they already document the tree as inconsistent afterwards, and no
-  importer and no production path can reach them.
+  facts. (1) The ANCHOR is a member of the chain `parent` owns — `chainMember` (`node.go`) answers in a pointer
+  comparison when the anchor is `parent.firstChild`, and otherwise walks `prev` to the head of the anchor's own
+  chain and compares it against `parent.firstChild`. (An anchor that is `parent.lastChild` never reaches
+  `chainMember`: `tailJumpTarget` has already declined, because the anchor and the recorded tail are the same
+  node.) That walk is bounded by the anchor's distance BEHIND it, never by the chain ahead of it, so it can
+  never cost more than the `NextSibling()` walk it replaces; it carries a `siblingCycleGuard` so a corrupt
+  `prev` chain terminates instead of spinning, and it crosses only RECIPROCAL `prev` edges (`reciprocalPrev` —
+  the `prev` node points forward at the node again), so a one-way edge cannot carry it out of the anchor's own
+  chain. There is no raw `prev` setter, but a one-way `prev` edge survives whenever a node is spliced out of a
+  chain from the FRONT, so the check is not hypothetical. (2) `parent.lastChild` is the final node of that same
+  chain. NO local read can establish (2): two trees can have pointer-identical neighborhoods around `parent` and
+  `lastChild` and differ only in a `next` pointer an unbounded distance forward from `firstChild`. It holds
+  instead as an INVARIANT of the guarded paths, each of which moves `lastChild` only to a node it has just
+  linked onto the chain, so what is checked is that this document holds no node claiming a parent it is not a
+  child of: `Document.offChainClaims` (`document.go`). `noteOrphanedChildClaim` records the one such claim the
+  GUARDED paths create. A parent holding a `firstChild` with NO `lastChild` — the shape
+  `Document.stringToNodeList` leaves behind on an entity referenced from an attribute value — no longer reaches
+  the empty-parent branch of `addChild`/`appendFastChild`, because `resolveOwnedTail` walks that child list and
+  returns its true tail, so the append joins the list instead of overwriting `firstChild`. An append through
+  that detached child then moves the parent's recorded tail off the child list. Recording the claim at the
+  moment it is created is what keeps the later append byte-identical to the walk. Each claim is recorded on the
+  document owning the parent whose chain is at stake and on the document owning the detached child, each
+  resolved through `owningDocument` so a `*Document` names ITSELF (a document node's own `doc` pointer is nil
+  because it IS the owner). Once set it stays set, and appends for that document walk — which is what every
+  other tree operation does unconditionally. The record FOLLOWS THE TREE, not only the document it was first
+  made on, because a subtree can change owning document afterwards, and a claim made on a still-DETACHED subtree
+  has no document to be recorded on at all. `adoptOffChainClaims` (`node.go`) carries it across every change of
+  owner — `docnode.SetOwnerDocument`, `setTreeDoc`'s attribute write, `setListDoc`'s direct write, and
+  `noteCrossDocumentEscape` — and the unattributable case lands on the package-level `unownedOffChainClaim` (an
+  `atomic.Bool`), which a document inherits when it adopts a subtree that arrives owning no document. That
+  global is the ONE package-wide part; the flag itself stays per-DOCUMENT, because one claim must not slow every
+  other document in the process. `TestAdoptOffChainClaimWithoutOwner` (`node_sibling_internal_test.go`) pins the
+  unowned case. A `*Document` parent is NOT declined by type. Its owning document is read through
+  `owningDocument`, so it names itself, and a document's child list is an ordinary sibling chain that an append
+  walks exactly like any other. A document is claimed off-chain by `CopyExtSubset`, which gives the copied
+  EXTERNAL subset the destination document as its parent and then leaves it reachable only through `ExtSubset`,
+  never from the child list, so an append through that subset records a tail off the child list. That is a
+  CONDITION, not a type, and `Document.offChainChildClaim` (`document.go`, set by `CopyExtSubset`) records it
+  separately from `offChainClaims` so it declines only for the `*Document` parent handed the claimant, not for
+  every parent in that document. (`CreateInternalSubset` also gives a `DTD` the document as its parent, but it
+  splices that `DTD` into the child list, so it creates no claim.) `TestTailJumpTargetDocumentParent`
+  (`node_sibling_internal_test.go`) pins all three outcomes. `tailJumpTarget` then makes three cheap
+  confirmations that the record is usable (`tail != anchor`, `tail.next == nil`, `tail.parent` is this parent);
+  they cannot fail on a document holding no recorded claim, and are kept because a tree may span documents
+  (`noteCrossDocumentEscape`) while the record does not, so an uncovered corner degrades to the walk instead of
+  splicing onto the wrong node. They also keep the stale-`lastChild` repair path `addChild`/`appendFastChild`
+  depend on: they call `AddSibling` on `parent.lastChild` precisely when that node's `next` is non-nil, so the
+  resolution declines and the walk finds and repairs the true tail. WHAT THE O(1) RESOLUTION IS WORTH DEPENDS ON
+  THE ANCHOR: appending through `parent.firstChild`, or at the true tail (where the anchor's `next` is nil and
+  `addSibling` links directly without consulting `tailJumpTarget` at all), is O(1) per call and LINEAR over N
+  appends (105µs vs 49.5ms at N=4000, a ~470x win), while appending through a MIDDLE anchor stays QUADRATIC —
+  `chainMember`'s `prev` walk grows with the chain — and gains a ~3.8x constant factor instead (26.5ms vs 99.6ms
+  at N=4000). `BenchmarkAddSibling` (`node_sibling_bench_test.go`) measures five arms: `tail`, `nontail` (=
+  first child) and `middle` on an `*Element` parent, plus `docnontail` and `docmiddle` on a `*Document` parent,
+  which track the element arms to within noise. The attribute-chain branch (an anchor genuinely reachable from
+  its owning `*Element`'s `properties` chain) resolves its tail by walking, bounded by the attribute count,
+  because the `properties` membership test already costs that walk. A node can claim a parent without being a
+  member of that parent's child list — the detached-child shape above, `CopyExtSubset`'s copied external subset,
+  or a package-private `unsafeSetParent` write. An append through such a node records its own result as the
+  parent's `lastChild`, moving that record off the child list. All three append entry points then land at the
+  end of the REACHABLE children: `AddSibling` walks from its anchor, and `AddChild`, `appendFastChild` and
+  `appendCopiedChild` reach the same node through `resolveOwnedTail` (`node.go`), which returns nil when
+  `parent.firstChild` is nil whatever `lastChild` records, trusts the record only when that node claims this
+  parent, has no `next`, AND the owning document holds no off-chain claim (the same signal `tailJumpTarget`
+  declines on, read through `holdsOffChainChildClaim`), and otherwise walks the child list under a
+  `siblingCycleGuard` to the last node still claiming the parent. That is what keeps an append in the same place
+  whichever entry point the caller used, and it is why a stale record is repaired rather than followed: trusting
+  `lastChild` alone loses the reachable list when `firstChild` is nil (the `CopyExtSubset` shape) and discards
+  it when `lastChild` is nil (the `stringToNodeList` shape). `TestAddChildResolvesAnOwnedTail`
+  (`node_owned_tail_test.go`) pins all three reachable shapes, and `TestAddSiblingOffChainParentClaim`,
+  `TestAddSiblingCopiedExternalSubsetClaim` and `TestAddSiblingCorruptShapesMatchWalk` (`node_sibling_test.go`)
+  pin the sibling side; every expectation in the last of those holds for the walk-only implementation too, which
+  is what makes it a differential check. The raw setters record NOTHING, so a tree corrupted through them is
+  outside this agreement — they already document the tree as inconsistent afterwards, and no importer and no
+  production path can reach them.
 - `replaceNode(old, new)` — swap in same position. Attribute-aware: replacing an `Attribute` updates the
   owning `Element.properties` head/chain (NOT `firstChild`/`lastChild`), and an attribute may only be replaced
   by attribute node(s) (non-attribute replacement is rejected)

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -285,9 +285,10 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   answers `false` in a type assertion, so an ordinary append pays nothing for the check.
   `TestTailJumpTargetDocumentParent` (`node_sibling_internal_test.go`) pins all three outcomes, including that
   a claim on the document leaves every element in it resolving in O(1), and
-  `TestAppendCostIsLinearBesideAnOffChainClaim` (`node_owned_tail_test.go`) pins the SHAPE of the cost:
-  doubling the appends onto a clean element beside a claim roughly doubles the time rather than quadrupling
-  it. `tailJumpTarget` then makes three cheap confirmations that the record is usable (`tail != anchor`,
+  `TestAppendCostIsLinearBesideAnOffChainClaim` (`node_sibling_internal_test.go`) appends through counted
+  element wrappers beside a document claim and requires zero `NextSibling` calls, so a document-wide fallback
+  fails deterministically. `tailJumpTarget` then makes three cheap confirmations that the record is usable
+  (`tail != anchor`,
   `tail.next == nil`, `tail.parent` is this parent); they cannot fail on a parent holding no recorded claim,
   and are kept because a tree may span documents
   (`noteCrossDocumentEscape`) while the record does not, so an uncovered corner degrades to the walk instead of

--- a/copy.go
+++ b/copy.go
@@ -78,15 +78,12 @@ func CopyDoc(src *Document) (*Document, error) {
 		}
 	}
 
-	// Deep-copy the external subset too (independent *DTD, not aliased). The lazy
-	// GetElementByID fallback consults it for ID-typed ATTLIST declarations, so a
-	// copy that dropped it would resolve fewer ids than the source.
-	CopyExtSubset(src, dst)
-
 	// Copy all document children (the DTD was already handled) through the shared
 	// core in over-declare / AddChild mode, reproducing the historical behavior.
 	// onCopy records the source->copy element correspondence so the ID table can be
 	// rebuilt against the copy's own elements, aliasing nothing in the source map.
+	// Build this fresh child list before CopyExtSubset records its off-chain claim
+	// on dst; otherwise every append must walk the growing list to recover its tail.
 	var onCopy func(src, cp Node)
 	var corr elemCorrespondence
 	if len(src.ids) > 0 {
@@ -97,6 +94,11 @@ func CopyDoc(src *Document) (*Document, error) {
 	if err := dc.copyChildren(src, dst, nil, nil); err != nil {
 		return nil, err
 	}
+
+	// Deep-copy the external subset too (independent *DTD, not aliased). The lazy
+	// GetElementByID fallback consults it for ID-typed ATTLIST declarations, so a
+	// copy that dropped it would resolve fewer ids than the source.
+	CopyExtSubset(src, dst)
 
 	// Rebuild the interned ID table by translating each source entry's element
 	// through the source->copy correspondence, so id()/GetElementByID on the copy

--- a/copy_bench_test.go
+++ b/copy_bench_test.go
@@ -2,6 +2,8 @@ package helium_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/lestrrat-go/helium"
@@ -29,6 +31,32 @@ func buildChainTree(b *testing.B, n int) *helium.Element {
 		prev = cur
 	}
 	return root
+}
+
+// buildDocumentWithExternalSubset builds the public-API shape that makes the
+// document's last-child record untrustworthy: CopyExtSubset installs a DTD that
+// claims the document as its parent while remaining outside its child list.
+func buildDocumentWithExternalSubset(b *testing.B, n int) *helium.Document {
+	b.Helper()
+
+	dtdPath := filepath.Join(b.TempDir(), "ext.dtd")
+	if err := os.WriteFile(dtdPath, []byte(`<!ELEMENT root ANY>`), 0600); err != nil {
+		b.Fatal(err)
+	}
+	dtdSource, err := helium.NewParser().BlockXXE(false).LoadExternalDTD(true).
+		FS(helium.PermissiveFS()).Parse(b.Context(), []byte(`<!DOCTYPE root SYSTEM "`+dtdPath+`"><root/>`))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	doc := helium.NewDefaultDocument()
+	for range n {
+		if err := doc.AddChild(doc.CreateComment([]byte("x"))); err != nil {
+			b.Fatal(err)
+		}
+	}
+	helium.CopyExtSubset(dtdSource, doc)
+	return doc
 }
 
 // buildFlatTree builds a document whose root has n childless element
@@ -92,4 +120,21 @@ func BenchmarkCopyNode(b *testing.B) {
 			})
 		}
 	})
+}
+
+// BenchmarkCopyDocExternalSubset measures CopyDoc's document-child build when
+// the source carries an external subset. CopyDoc must build the fresh child list
+// before copying the subset, so doubling the reachable children stays linear.
+func BenchmarkCopyDocExternalSubset(b *testing.B) {
+	for _, n := range []int{2000, 4000, 8000} {
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			src := buildDocumentWithExternalSubset(b, n)
+			b.ResetTimer()
+			for range b.N {
+				if _, err := helium.CopyDoc(src); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }

--- a/copy_deep.go
+++ b/copy_deep.go
@@ -119,7 +119,7 @@ func appendCopiedChild(parent MutableNode, child Node) error {
 	pdn := parent.baseDocNode()
 	cdn := child.baseDocNode()
 
-	last := pdn.lastChild
+	last := resolveOwnedTail(parent, pdn)
 	if last == nil {
 		pdn.firstChild = child
 		pdn.lastChild = child

--- a/copy_deep.go
+++ b/copy_deep.go
@@ -119,7 +119,7 @@ func appendCopiedChild(parent MutableNode, child Node) error {
 	pdn := parent.baseDocNode()
 	cdn := child.baseDocNode()
 
-	last := resolveOwnedTail(parent, pdn, cdn)
+	last := resolveOwnedTail(parent, pdn)
 	if last == nil {
 		pdn.firstChild = child
 		pdn.lastChild = child

--- a/copy_deep.go
+++ b/copy_deep.go
@@ -119,7 +119,7 @@ func appendCopiedChild(parent MutableNode, child Node) error {
 	pdn := parent.baseDocNode()
 	cdn := child.baseDocNode()
 
-	last := resolveOwnedTail(parent, pdn)
+	last := resolveOwnedTail(parent, pdn, cdn)
 	if last == nil {
 		pdn.firstChild = child
 		pdn.lastChild = child

--- a/copy_dtd.go
+++ b/copy_dtd.go
@@ -67,8 +67,10 @@ func CopyExtSubset(src, dst *Document) {
 	dst.extSubset = dstDTD
 	// dstDTD claims dst as its parent but is deliberately NOT in dst's child
 	// list, so dst now holds a node that can move its recorded lastChild off that
-	// list. Record it: addSibling stops resolving an append point from
-	// dst.lastChild (tailJumpTarget) and walks instead.
+	// list. Record it on dst, the parent that was handed the claimant: appends
+	// onto dst itself stop resolving their point from dst.lastChild
+	// (tailJumpTarget, resolveOwnedTail) and walk instead, while every element
+	// dst owns keeps its own O(1) resolution.
 	dst.offChainChildClaim = true
 }
 

--- a/copy_test.go
+++ b/copy_test.go
@@ -773,10 +773,10 @@ func TestCopyDTD(t *testing.T) {
 		helium.CopyExtSubset(src, dst)
 		require.NotNil(t, dst.ExtSubset(), "external subset copied")
 
-		copy, err := helium.CopyDoc(src)
+		copiedDoc, err := helium.CopyDoc(src)
 		require.NoError(t, err)
-		require.NotNil(t, copy.DocumentElement(), "document children copied")
-		require.NotNil(t, copy.ExtSubset(), "external subset copied with the document")
+		require.NotNil(t, copiedDoc.DocumentElement(), "document children copied")
+		require.NotNil(t, copiedDoc.ExtSubset(), "external subset copied with the document")
 
 		// nil arguments are a no-op.
 		helium.CopyExtSubset(nil, dst)

--- a/copy_test.go
+++ b/copy_test.go
@@ -773,6 +773,11 @@ func TestCopyDTD(t *testing.T) {
 		helium.CopyExtSubset(src, dst)
 		require.NotNil(t, dst.ExtSubset(), "external subset copied")
 
+		copy, err := helium.CopyDoc(src)
+		require.NoError(t, err)
+		require.NotNil(t, copy.DocumentElement(), "document children copied")
+		require.NotNil(t, copy.ExtSubset(), "external subset copied with the document")
+
 		// nil arguments are a no-op.
 		helium.CopyExtSubset(nil, dst)
 		helium.CopyExtSubset(src, nil)

--- a/document.go
+++ b/document.go
@@ -108,42 +108,21 @@ type Document struct {
 	// paths (node.go noteCrossDocumentEscape).
 	slabEscaped bool
 
-	// offChainClaims records that a tree this document owns holds at least one
-	// node claiming a parent it is not a child of. The guarded paths produce one
-	// on a parent that already holds a firstChild with NO lastChild — a shape
-	// Document.stringToNodeList leaves behind on an entity referenced from an
-	// attribute value — because AddChild then takes its empty-parent branch and
-	// overwrites firstChild, detaching that child while it goes on claiming the
-	// parent (node.go noteOrphanedChildClaim). (A DOCUMENT can also be claimed
-	// without being on its child list, by the external subset CopyExtSubset
-	// attaches to it; offChainChildClaim below records that, because it needs to
-	// decline only for a *Document parent.)
-	//
-	// While it is false, every parent in this document has its lastChild at the
-	// end of the chain that starts at its firstChild, so addSibling may resolve
-	// its append point from that record in O(1). Once true it stays true, and
-	// addSibling falls back to its sibling walk for this document, which is what
-	// every other tree operation does unconditionally.
-	//
-	// The record follows the TREE, not only the node it was made on: a claim on a
-	// still-detached subtree has no document to be recorded on at the time, and a
-	// subtree can change owner afterwards, so adoptOffChainClaims (node.go)
-	// carries the record onto whichever document adopts it. Set by node.go
-	// noteOrphanedChildClaim / adoptOffChainClaims; read by tailJumpTarget.
-	offChainClaims bool
-
 	// offChainChildClaim records that a node has been given this document as its
 	// parent WITHOUT being linked into the document's child list. CopyExtSubset
 	// is the one path in this package that does it: the copied external subset
 	// claims the destination document and is then reachable only through
 	// ExtSubset. An append through such a subset records its own result as the
-	// document's lastChild, which moves that record off the child list, so
-	// tailJumpTarget must stop resolving an append point from it. This is
-	// separate from offChainClaims above because it must decline only for the
-	// *Document parent that was handed the claimant, not for every parent in the
-	// document. (CreateInternalSubset also gives a DTD this document as its
-	// parent, but it splices that DTD into the child list, so it creates no
-	// claim.) Set by copy_dtd.go CopyExtSubset; read by tailJumpTarget.
+	// document's lastChild, which moves that record off the child list, so the
+	// O(1) append-point resolution must stop trusting that record.
+	//
+	// The record is per-PARENT, and this document IS the parent that was handed
+	// the claimant: it declines only for appends onto the document node itself,
+	// never for the elements the document owns, whose own lastChild records the
+	// claimant says nothing about. (CreateInternalSubset also gives a DTD this
+	// document as its parent, but it splices that DTD into the child list, so it
+	// creates no claim.) Set by copy_dtd.go CopyExtSubset; read through
+	// node.go holdsOffChainChildClaim by tailJumpTarget and resolveOwnedTail.
 	offChainChildClaim bool
 }
 

--- a/node.go
+++ b/node.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"sync/atomic"
 
 	"github.com/lestrrat-go/helium/internal/nodelink"
 )
@@ -201,12 +200,8 @@ func setLastChild(n MutableNode, cur Node) {
 	n.baseDocNode().lastChild = cur
 }
 
-// SetOwnerDocument makes doc this node's owning document. An off-chain-claim
-// record travels with the node (adoptOffChainClaims), so a document that adopts a
-// subtree holding such a claim inherits the record instead of starting out
-// trusting its own lastChild.
+// SetOwnerDocument makes doc this node's owning document.
 func (n *docnode) SetOwnerDocument(doc *Document) {
-	adoptOffChainClaims(n.doc, doc)
 	n.doc = doc
 }
 
@@ -638,10 +633,6 @@ func noteCrossDocumentEscape(dest *Document, cur Node) {
 	if curDoc == dest {
 		return
 	}
-	// A node crossing into dest's tree brings its links with it, so an
-	// off-chain-claim record on the document it came from has to travel too:
-	// dest's own lastChild is what the O(1) append-point resolution trusts.
-	adoptOffChainClaims(curDoc, dest)
 	if curDoc == nil {
 		return
 	}
@@ -740,9 +731,11 @@ func addChild(n MutableNode, cur Node) error {
 		return err
 	}
 
-	l := resolveOwnedTail(n, pdn)
+	// A nil tail means pdn has no child list at all, so this branch installs the
+	// first one. resolveOwnedTail never returns nil for a parent that already
+	// holds children, which is what keeps an existing list from being dropped.
+	l := resolveOwnedTail(n, pdn, cdn)
 	if l == nil {
-		noteOrphanedChildClaim(n, pdn.firstChild)
 		pdn.firstChild = cur
 		pdn.lastChild = cur
 		cdn.parent = n
@@ -818,6 +811,115 @@ func addSiblingPreflight(n MutableNode, cur Node) error {
 	return nil
 }
 
+// resolveOwnedTail returns the node an append onto pdn must link after, or nil
+// when pdn has NO child list at all. A nil return means exactly one thing —
+// pdn.firstChild is nil — so the callers' empty-parent branch, which overwrites
+// firstChild, can never run on a parent that already holds children. It never
+// returns a node pdn does not own from a chain pdn does not reach, which is
+// what separates it from a bare pdn.lastChild read.
+//
+// The recorded tail and the reachable child list can disagree, and safe API
+// builds every direction of that disagreement. A copied external subset claims
+// the document as its parent while living only in extSubset, so appending
+// through it records a tail that is on no child list and leaves firstChild nil;
+// stringToNodeList materializes an entity's replacement children with
+// firstChild set and lastChild nil; CreateReference installs the DTD's shared
+// Entity as the reference's firstChild while that Entity goes on claiming the
+// DTD. Trusting lastChild alone loses the reachable list in the first shape and
+// discards it in the second, so the record is used only when it proves itself
+// and the list is walked otherwise.
+//
+// The walk stops at the first node that does not claim pdn, because the chain
+// beyond such a node belongs to whichever parent it does claim and an append
+// must not run off into it. When the walk stops on the very FIRST node it
+// yields no owned tail at all, and the head of the list pdn reaches is returned
+// instead: that node is still the anchor the existing children hang off, so an
+// append lands behind it exactly as a bare lastChild read used to, and the
+// children can never be dropped. Deciding the parent is empty in that case is
+// what silently discarded them.
+//
+// cdn is the node about to be appended, and it is excluded from that head
+// fallback. The callers run their preflight first, which unlinks cdn from
+// wherever it was, so a pdn whose firstChild is cdn reaches a list of exactly
+// one node — cdn itself — and there is nothing left to preserve. Returning it
+// would link cdn after itself, which is the self-link the callers must never
+// build.
+//
+// Healthy trees take the O(1) route: two pointer comparisons on top of the read
+// the callers already did. Only a tree already carrying a stale record pays the
+// walk, and that walk is the same one addSibling performs, so an append lands
+// in the same place whichever of the two the caller went through.
+func resolveOwnedTail(parent Node, pdn, cdn *docnode) Node {
+	// No child list means no tail to link after, whatever lastChild records.
+	// This is the copied-external-subset shape: the subset claims the document
+	// as its parent while living only in extSubset, so appending through it
+	// records a tail while firstChild stays nil.
+	first := pdn.firstChild
+	if first == nil {
+		return nil
+	}
+
+	// Trust the recorded tail only when it proves itself AND this parent has not
+	// been handed a child that claims it from off its child list. Without that
+	// second condition a node can claim this parent from another chain entirely,
+	// and linking behind it would abandon the reachable list. tailJumpTarget
+	// declines on the same signal, so both append routes degrade together.
+	if l := pdn.lastChild; l != nil {
+		ldn := l.baseDocNode()
+		if ldn.next == nil && ldn.parent != nil && ldn.parent.baseDocNode() == pdn && !holdsOffChainChildClaim(parent) {
+			return l
+		}
+	}
+
+	// The record is unusable, so walk to the last node that still claims pdn,
+	// bounded by the same allocation-free guard the iterators use. This is the
+	// walk addSibling performs, so an append lands in the same place whichever
+	// route the caller took.
+	var g siblingCycleGuard
+	var tail Node
+	for cur := first; cur != nil; {
+		cdn := cur.baseDocNode()
+		if g.step(cdn) {
+			break
+		}
+		if cdn.parent == nil || cdn.parent.baseDocNode() != pdn {
+			break
+		}
+		tail = cur
+		cur = cdn.next
+	}
+	if tail == nil {
+		// Nothing on the list claims pdn, so pdn owns no tail — but it does hold
+		// children, and the append must join them rather than replace them. The
+		// one exception is a list that is the operand itself: it holds nothing to
+		// preserve, and linking after it would be a self-link.
+		if first.baseDocNode() == cdn {
+			return nil
+		}
+		return first
+	}
+	return tail
+}
+
+// holdsOffChainChildClaim reports whether THIS parent has been handed a child
+// that claims it while sitting on no child list of its own, which is the one
+// signal that a self-proving lastChild may still belong to another chain. The
+// record is per-PARENT: a claim on one parent says nothing about any other
+// parent, including every other parent in the same document, so it must never
+// be read from the owning document.
+//
+// The only claimant safe API creates is the external subset CopyExtSubset
+// copies, which is given the destination document as its parent and left
+// reachable only through ExtSubset. The claimed parent is that *Document
+// itself, and Document.offChainChildClaim records it. (CreateInternalSubset
+// also gives a DTD the document as its parent, but it splices that DTD into the
+// child list, so it creates no claim.) Every other parent answers false in a
+// type assertion, so an ordinary append pays nothing for the check.
+func holdsOffChainChildClaim(parent Node) bool {
+	doc, ok := parent.(*Document)
+	return ok && doc.offChainChildClaim
+}
+
 // chainMember reports whether x is a member of the single child chain pdn owns:
 // the chain that starts at pdn.firstChild and runs forward through next
 // pointers. It answers ONE question, about the anchor of an append: may
@@ -848,78 +950,6 @@ func addSiblingPreflight(n MutableNode, cur Node) error {
 // caller would splice into the parent's real child list and abandon the rest of
 // x's chain. Rejecting the non-reciprocal edge costs one pointer comparison per
 // step, so the walk keeps the bound above.
-// resolveOwnedTail returns the node an append onto pdn must link after, or nil
-// when pdn has no child that claims it. It never returns a node pdn does not
-// own, which is what separates it from a bare pdn.lastChild read.
-//
-// The recorded tail and the reachable child list can disagree, and safe API
-// builds both directions of that disagreement. A copied external subset claims
-// the document as its parent while living only in extSubset, so appending
-// through it records a tail that is on no child list and leaves firstChild nil;
-// stringToNodeList materializes an entity's replacement children with
-// firstChild set and lastChild nil. Trusting lastChild alone loses the
-// reachable list in the first shape and discards it in the second, so the
-// record is used only when it proves itself and the list is walked otherwise.
-//
-// Healthy trees take the O(1) route: two pointer comparisons on top of the read
-// the callers already did. Only a tree already carrying a stale record pays the
-// walk, and that walk is the same one addSibling performs, so an append lands
-// in the same place whichever of the two the caller went through.
-func resolveOwnedTail(parent Node, pdn *docnode) Node {
-	// No reachable child list means no owned tail, whatever lastChild records.
-	// This is the copied-external-subset shape: the subset claims the document
-	// as its parent while living only in extSubset, so appending through it
-	// records a tail while firstChild stays nil.
-	if pdn.firstChild == nil {
-		return nil
-	}
-
-	// Trust the recorded tail only when it proves itself AND the owning document
-	// carries no off-chain parent claim. Without that second condition a node
-	// can claim this parent from another chain entirely, and linking behind it
-	// would abandon the reachable list. tailJumpTarget declines on the same
-	// signal, so both append routes degrade together.
-	if l := pdn.lastChild; l != nil {
-		ldn := l.baseDocNode()
-		if ldn.next == nil && ldn.parent != nil && ldn.parent.baseDocNode() == pdn && !holdsOffChainChildClaim(parent) {
-			return l
-		}
-	}
-
-	// The record is unusable, so walk to the last node that still claims pdn,
-	// bounded by the same allocation-free guard the iterators use. This is the
-	// walk addSibling performs, so an append lands in the same place whichever
-	// route the caller took.
-	var g siblingCycleGuard
-	var tail Node
-	for cur := pdn.firstChild; cur != nil; {
-		cdn := cur.baseDocNode()
-		if g.step(cdn) {
-			break
-		}
-		if cdn.parent == nil || cdn.parent.baseDocNode() != pdn {
-			break
-		}
-		tail = cur
-		cur = cdn.next
-	}
-	return tail
-}
-
-// holdsOffChainChildClaim reports whether parent's owning document has recorded
-// a parent claim that sits in no child list, which is the one signal that a
-// self-proving lastChild may still belong to another chain.
-func holdsOffChainChildClaim(parent Node) bool {
-	doc := owningDocument(parent)
-	if doc == nil {
-		return true
-	}
-	if doc.offChainClaims {
-		return true
-	}
-	return doc == parent && doc.offChainChildClaim
-}
-
 func chainMember(pdn, x *docnode) bool {
 	if pdn == nil || x == nil {
 		return false
@@ -984,44 +1014,39 @@ func reciprocalPrev(x *docnode) *docnode {
 //     pointer an unbounded distance forward from firstChild. It holds as an
 //     invariant of the guarded paths — every one of them moves lastChild only to
 //     a node it has just linked onto the chain — so what is checked instead is
-//     that no node in this document claims a parent it is not a child of.
-//     Document.offChainClaims records exactly that, so the shortcut is declined
-//     for a document that holds such a claim.
+//     that THIS parent has not been handed a child that claims it from off its
+//     child list. holdsOffChainChildClaim answers that, and the shortcut is
+//     declined for a parent that has.
 //
-// The owning document is read through owningDocument, so a *Document parent
-// names ITSELF: a document node holds the trees it owns and its own doc pointer
-// stays nil, which is a fact about how a document is initialized and not a
-// statement about whether its child list can be trusted. A document is claimed
-// off-chain by CopyExtSubset, which gives the copied external subset the
-// destination document as its parent and then leaves it reachable only through
-// ExtSubset, never from the child list, so an append through that subset records
-// its own result as the document's tail and moves the record off the child list.
-// That is a condition, not a type, and Document.offChainChildClaim records it:
-// the shortcut is declined for a document that has actually been handed such a
-// claimant, and taken for every other one. (CreateInternalSubset also gives a
-// DTD the document as its parent, but it splices that DTD into the child list,
-// so it creates no claim.)
+// The claim is read per-PARENT, never per-document: the parent whose chain is at
+// stake is the only one whose lastChild record the claim can invalidate, so a
+// claim on one parent must not cost every other parent in the same document its
+// O(1) resolution. The one parent safe API hands such a claimant is a *Document,
+// through CopyExtSubset, which gives the copied external subset the destination
+// document as its parent and then leaves it reachable only through ExtSubset,
+// never from the child list, so an append through that subset records its own
+// result as the document's tail and moves the record off the child list. That is
+// a condition, not a type: the shortcut is declined for a document that has
+// actually been handed such a claimant, and taken for every other parent,
+// documents included. resolveOwnedTail declines on the same signal, so both
+// append routes degrade together.
 //
 // The remaining reads are cheap confirmations that the record is a usable tail:
 // it must not be the anchor itself, it must genuinely end its chain, and it must
-// claim this very parent. On a document holding no off-chain claim they cannot
-// fail, and they are kept anyway because the record is per-DOCUMENT while a tree
-// is not: a cross-document node move (noteCrossDocumentEscape) leaves one
-// document's chain holding nodes another document owns, and these three
-// comparisons are what makes a claim that slipped past the record degrade to the
-// walk instead of splicing onto the wrong node. They also keep the
-// stale-lastChild repair path addChild and appendFastChild depend on: they call
-// AddSibling on parent.lastChild precisely when that node's next is non-nil, so
-// the shortcut declines and the walk finds and repairs the true tail.
+// claim this very parent. On a parent holding no off-chain claim they cannot
+// fail, and they are kept anyway because a tree may span documents: a
+// cross-document node move (noteCrossDocumentEscape) leaves one document's chain
+// holding nodes another document owns, and these three comparisons are what
+// makes a claim that slipped past the record degrade to the walk instead of
+// splicing onto the wrong node. They also keep the stale-lastChild repair path
+// addChild and appendFastChild depend on: they call AddSibling on
+// parent.lastChild precisely when that node's next is non-nil, so the shortcut
+// declines and the walk finds and repairs the true tail.
 func tailJumpTarget(parent Node, ndn *docnode) Node {
 	if parent == nil {
 		return nil
 	}
-	doc := owningDocument(parent)
-	if doc == nil || doc.offChainClaims {
-		return nil
-	}
-	if doc == parent && doc.offChainChildClaim {
+	if holdsOffChainChildClaim(parent) {
 		return nil
 	}
 	pdn := parent.baseDocNode()
@@ -1176,84 +1201,6 @@ func unsafeSetParent(n Node, parent Node) {
 // AddChild/AddSibling/UnlinkNode instead.
 func unsafeSetNextSibling(n Node, next Node) {
 	n.baseDocNode().next = next
-}
-
-// noteOrphanedChildClaim records the off-chain parent claim the GUARDED paths
-// themselves create, which is how an ordinary caller reaches one. A parent
-// holding a firstChild with NO lastChild is a shape Document.stringToNodeList
-// leaves behind on an entity referenced from an attribute value. An append onto
-// such a parent takes the empty-parent branch, which overwrites firstChild: the
-// child that was there is detached from the chain while it goes on claiming this
-// parent, and a later append THROUGH that detached child records its own result
-// as the parent's lastChild, moving that record off the child list.
-//
-// Record it at the moment the claim is created, on the documents that own the
-// parent whose chain is at stake and the child being detached from it. orphan is
-// the parent's firstChild BEFORE the overwrite; a nil one means the parent was
-// genuinely empty and nothing is recorded.
-func noteOrphanedChildClaim(parent Node, orphan Node) {
-	if isNilNode(orphan) {
-		return
-	}
-	attributed := markOffChainClaim(owningDocument(parent))
-	attributed = markOffChainClaim(owningDocument(orphan)) && attributed
-	if !attributed {
-		unownedOffChainClaim.Store(true)
-	}
-}
-
-// markOffChainClaim records an off-chain parent claim on doc and reports whether
-// there was a document to record it on.
-func markOffChainClaim(doc *Document) bool {
-	if doc == nil {
-		return false
-	}
-	doc.offChainClaims = true
-	return true
-}
-
-// unownedOffChainClaim records an off-chain parent claim that no document owned
-// at the time it was made. It is package-level because there is nowhere else to
-// put it: a detached node carries no document, and the claim is still there when
-// a document later adopts the subtree. It is atomic because the documents that
-// read it are otherwise independent and may live in different goroutines.
-var unownedOffChainClaim atomic.Bool
-
-// adoptOffChainClaims carries an off-chain-claim record forward when a node
-// changes owning document. The record lives on the DOCUMENT, so a subtree that
-// moves between documents would otherwise leave it behind: the destination would
-// trust a lastChild that is not the end of its own child chain. A node arriving
-// from NO document is the case unownedOffChainClaim exists for — the claim had
-// no document to be recorded on when it was made.
-//
-// It errs toward marking. Marking a document that holds no claim only costs it
-// the O(1) append-point resolution, which is a fallback to the sibling walk
-// every other tree operation performs unconditionally; failing to mark one that
-// does hold a claim is a wrong tree.
-func adoptOffChainClaims(from, to *Document) {
-	if to == nil || to.offChainClaims || from == to {
-		return
-	}
-	if from == nil {
-		if unownedOffChainClaim.Load() {
-			to.offChainClaims = true
-		}
-		return
-	}
-	if from.offChainClaims {
-		to.offChainClaims = true
-	}
-}
-
-// owningDocument returns the document whose trees n belongs to. A *Document is
-// its OWN owner — a document node holds the trees it owns and its embedded
-// docnode's doc pointer stays nil — so it must be resolved by type rather than
-// by reading that pointer.
-func owningDocument(n Node) *Document {
-	if doc, ok := n.(*Document); ok {
-		return doc
-	}
-	return n.baseDocNode().doc
 }
 
 func init() {
@@ -1811,7 +1758,6 @@ func setListDoc(n Node, doc *Document) {
 			mn.SetTreeDoc(doc)
 			continue
 		}
-		adoptOffChainClaims(cdn.doc, doc)
 		cdn.doc = doc
 	}
 }
@@ -1836,7 +1782,6 @@ func setTreeDoc(n MutableNode, doc *Document) {
 			}
 			seenAttrs[pdn] = struct{}{}
 			// if prop.atype == XML_ATTRIBUTE_ID; xmlRemoveID(tree->doc, prop)
-			adoptOffChainClaims(prop.doc, doc)
 			prop.doc = doc
 			if child := prop.firstChild; child != nil {
 				setListDoc(child, doc)

--- a/node.go
+++ b/node.go
@@ -740,7 +740,7 @@ func addChild(n MutableNode, cur Node) error {
 		return err
 	}
 
-	l := pdn.lastChild
+	l := resolveOwnedTail(n, pdn)
 	if l == nil {
 		noteOrphanedChildClaim(n, pdn.firstChild)
 		pdn.firstChild = cur
@@ -848,6 +848,78 @@ func addSiblingPreflight(n MutableNode, cur Node) error {
 // caller would splice into the parent's real child list and abandon the rest of
 // x's chain. Rejecting the non-reciprocal edge costs one pointer comparison per
 // step, so the walk keeps the bound above.
+// resolveOwnedTail returns the node an append onto pdn must link after, or nil
+// when pdn has no child that claims it. It never returns a node pdn does not
+// own, which is what separates it from a bare pdn.lastChild read.
+//
+// The recorded tail and the reachable child list can disagree, and safe API
+// builds both directions of that disagreement. A copied external subset claims
+// the document as its parent while living only in extSubset, so appending
+// through it records a tail that is on no child list and leaves firstChild nil;
+// stringToNodeList materializes an entity's replacement children with
+// firstChild set and lastChild nil. Trusting lastChild alone loses the
+// reachable list in the first shape and discards it in the second, so the
+// record is used only when it proves itself and the list is walked otherwise.
+//
+// Healthy trees take the O(1) route: two pointer comparisons on top of the read
+// the callers already did. Only a tree already carrying a stale record pays the
+// walk, and that walk is the same one addSibling performs, so an append lands
+// in the same place whichever of the two the caller went through.
+func resolveOwnedTail(parent Node, pdn *docnode) Node {
+	// No reachable child list means no owned tail, whatever lastChild records.
+	// This is the copied-external-subset shape: the subset claims the document
+	// as its parent while living only in extSubset, so appending through it
+	// records a tail while firstChild stays nil.
+	if pdn.firstChild == nil {
+		return nil
+	}
+
+	// Trust the recorded tail only when it proves itself AND the owning document
+	// carries no off-chain parent claim. Without that second condition a node
+	// can claim this parent from another chain entirely, and linking behind it
+	// would abandon the reachable list. tailJumpTarget declines on the same
+	// signal, so both append routes degrade together.
+	if l := pdn.lastChild; l != nil {
+		ldn := l.baseDocNode()
+		if ldn.next == nil && ldn.parent != nil && ldn.parent.baseDocNode() == pdn && !holdsOffChainChildClaim(parent) {
+			return l
+		}
+	}
+
+	// The record is unusable, so walk to the last node that still claims pdn,
+	// bounded by the same allocation-free guard the iterators use. This is the
+	// walk addSibling performs, so an append lands in the same place whichever
+	// route the caller took.
+	var g siblingCycleGuard
+	var tail Node
+	for cur := pdn.firstChild; cur != nil; {
+		cdn := cur.baseDocNode()
+		if g.step(cdn) {
+			break
+		}
+		if cdn.parent == nil || cdn.parent.baseDocNode() != pdn {
+			break
+		}
+		tail = cur
+		cur = cdn.next
+	}
+	return tail
+}
+
+// holdsOffChainChildClaim reports whether parent's owning document has recorded
+// a parent claim that sits in no child list, which is the one signal that a
+// self-proving lastChild may still belong to another chain.
+func holdsOffChainChildClaim(parent Node) bool {
+	doc := owningDocument(parent)
+	if doc == nil {
+		return true
+	}
+	if doc.offChainClaims {
+		return true
+	}
+	return doc == parent && doc.offChainChildClaim
+}
+
 func chainMember(pdn, x *docnode) bool {
 	if pdn == nil || x == nil {
 		return false

--- a/node.go
+++ b/node.go
@@ -731,10 +731,10 @@ func addChild(n MutableNode, cur Node) error {
 		return err
 	}
 
-	// A nil tail means pdn has no child list at all, so this branch installs the
-	// first one. resolveOwnedTail never returns nil for a parent that already
-	// holds children, which is what keeps an existing list from being dropped.
-	l := resolveOwnedTail(n, pdn, cdn)
+	// A nil tail means pdn has no child it owns. Install cur as the owned child
+	// list instead of linking through a foreign head whose sibling links belong
+	// to another parent.
+	l := resolveOwnedTail(n, pdn)
 	if l == nil {
 		pdn.firstChild = cur
 		pdn.lastChild = cur
@@ -812,11 +812,8 @@ func addSiblingPreflight(n MutableNode, cur Node) error {
 }
 
 // resolveOwnedTail returns the node an append onto pdn must link after, or nil
-// when pdn has NO child list at all. A nil return means exactly one thing —
-// pdn.firstChild is nil — so the callers' empty-parent branch, which overwrites
-// firstChild, can never run on a parent that already holds children. It never
-// returns a node pdn does not own from a chain pdn does not reach, which is
-// what separates it from a bare pdn.lastChild read.
+// when pdn has no child it owns. It never returns a node pdn does not own from
+// a chain pdn does not reach, which separates it from a bare pdn.lastChild read.
 //
 // The recorded tail and the reachable child list can disagree, and safe API
 // builds every direction of that disagreement. A copied external subset claims
@@ -825,31 +822,23 @@ func addSiblingPreflight(n MutableNode, cur Node) error {
 // stringToNodeList materializes an entity's replacement children with
 // firstChild set and lastChild nil; CreateReference installs the DTD's shared
 // Entity as the reference's firstChild while that Entity goes on claiming the
-// DTD. Trusting lastChild alone loses the reachable list in the first shape and
-// discards it in the second, so the record is used only when it proves itself
-// and the list is walked otherwise.
+// DTD. Trusting lastChild alone loses the reachable list in the first shape,
+// discards it in the second, and crosses into the DTD chain in the third. The
+// record is used only when it proves itself, and the owned list is walked
+// otherwise.
 //
 // The walk stops at the first node that does not claim pdn, because the chain
 // beyond such a node belongs to whichever parent it does claim and an append
-// must not run off into it. When the walk stops on the very FIRST node it
-// yields no owned tail at all, and the head of the list pdn reaches is returned
-// instead: that node is still the anchor the existing children hang off, so an
-// append lands behind it exactly as a bare lastChild read used to, and the
-// children can never be dropped. Deciding the parent is empty in that case is
-// what silently discarded them.
-//
-// cdn is the node about to be appended, and it is excluded from that head
-// fallback. The callers run their preflight first, which unlinks cdn from
-// wherever it was, so a pdn whose firstChild is cdn reaches a list of exactly
-// one node — cdn itself — and there is nothing left to preserve. Returning it
-// would link cdn after itself, which is the self-link the callers must never
-// build.
+// must not run off into it. When the first node is foreign, there is no owned
+// append anchor. Returning that foreign head would let AddSibling follow and
+// mutate its owner's sibling chain, so the caller replaces the non-owned child
+// pointer with a new owned list.
 //
 // Healthy trees take the O(1) route: two pointer comparisons on top of the read
 // the callers already did. Only a tree already carrying a stale record pays the
-// walk, and that walk is the same one addSibling performs, so an append lands
-// in the same place whichever of the two the caller went through.
-func resolveOwnedTail(parent Node, pdn, cdn *docnode) Node {
+// walk. An owned tail matches the node addSibling would reach; a foreign head
+// returns nil so the caller never delegates into another parent's chain.
+func resolveOwnedTail(parent Node, pdn *docnode) Node {
 	// No child list means no tail to link after, whatever lastChild records.
 	// This is the copied-external-subset shape: the subset claims the document
 	// as its parent while living only in extSubset, so appending through it
@@ -872,9 +861,9 @@ func resolveOwnedTail(parent Node, pdn, cdn *docnode) Node {
 	}
 
 	// The record is unusable, so walk to the last node that still claims pdn,
-	// bounded by the same allocation-free guard the iterators use. This is the
-	// walk addSibling performs, so an append lands in the same place whichever
-	// route the caller took.
+	// bounded by the same allocation-free guard the iterators use. If the first
+	// node is foreign, the walk returns nil instead of delegating AddSibling into
+	// that node's owning chain.
 	var g siblingCycleGuard
 	var tail Node
 	for cur := first; cur != nil; {
@@ -887,16 +876,6 @@ func resolveOwnedTail(parent Node, pdn, cdn *docnode) Node {
 		}
 		tail = cur
 		cur = cdn.next
-	}
-	if tail == nil {
-		// Nothing on the list claims pdn, so pdn owns no tail — but it does hold
-		// children, and the append must join them rather than replace them. The
-		// one exception is a list that is the operand itself: it holds nothing to
-		// preserve, and linking after it would be a self-link.
-		if first.baseDocNode() == cdn {
-			return nil
-		}
-		return first
 	}
 	return tail
 }

--- a/node.go
+++ b/node.go
@@ -727,6 +727,18 @@ func addChild(n MutableNode, cur Node) error {
 	pdn := n.baseDocNode()
 	cdn := cur.baseDocNode()
 
+	// CreateReference stores the DTD-owned Entity as both child endpoints while
+	// leaving the Entity's parent and sibling links on the DTD declaration list.
+	// Re-adding that same stored foreign endpoint is already represented on n, so
+	// treat it as a no-op. Auto-unlinking it would remove the declaration from its
+	// real owner before resolveOwnedTail could recognize the foreign child list.
+	foreignParent := cdn.parent != nil && cdn.parent.baseDocNode() != pdn
+	isFirstChild := pdn.firstChild != nil && pdn.firstChild.baseDocNode() == cdn
+	isLastChild := pdn.lastChild != nil && pdn.lastChild.baseDocNode() == cdn
+	if foreignParent && (isFirstChild || isLastChild) {
+		return nil
+	}
+
 	if err := addChildPreflight(n, cur); err != nil {
 		return err
 	}
@@ -832,7 +844,9 @@ func addSiblingPreflight(n MutableNode, cur Node) error {
 // must not run off into it. When the first node is foreign, there is no owned
 // append anchor. Returning that foreign head would let AddSibling follow and
 // mutate its owner's sibling chain, so the caller replaces the non-owned child
-// pointer with a new owned list.
+// pointer with a new owned list. addChild handles the one different case before
+// calling this resolver: re-adding that stored foreign endpoint is a no-op, so
+// its real owner's chain and the foreign child pointer both stay unchanged.
 //
 // Healthy trees take the O(1) route: two pointer comparisons on top of the read
 // the callers already did. Only a tree already carrying a stale record pays the

--- a/node_owned_tail_test.go
+++ b/node_owned_tail_test.go
@@ -1,0 +1,116 @@
+package helium_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/enum"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddChildResolvesAnOwnedTail drives the shapes that safe API can build in
+// which a parent's recorded lastChild is not the last node that actually claims
+// that parent. AddChild must land the new child after the tail its own child
+// list reaches, exactly as AddSibling already does, rather than trusting the
+// recorded pointer.
+func TestAddChildResolvesAnOwnedTail(t *testing.T) {
+	t.Parallel()
+
+	// A copied external subset claims the document as its parent while living
+	// only in extSubset, so appending through it records a tail that is on no
+	// child list. A later AddChild must not link behind that record and lose the
+	// reachable list.
+	t.Run("recorded tail is off the child list", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		dtdPath := dir + "/ext.dtd"
+		require.NoError(t, os.WriteFile(dtdPath, []byte(`<!ELEMENT root (#PCDATA)>`), 0600))
+
+		xml := `<?xml version="1.0"?>
+<!DOCTYPE root SYSTEM "` + dtdPath + `">
+<root/>`
+		src, err := helium.NewParser().BlockXXE(false).LoadExternalDTD(true).FS(helium.PermissiveFS()).Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+		require.NotNil(t, src.ExtSubset())
+
+		dst := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+		helium.CopyExtSubset(src, dst)
+		ext := dst.ExtSubset()
+		require.NotNil(t, ext)
+		require.Equal(t, helium.Node(dst), ext.Parent())
+
+		// Records dst.lastChild = comment while dst.firstChild stays nil.
+		comment := dst.CreateComment([]byte("stray"))
+		require.NoError(t, ext.AddSibling(comment))
+
+		root, err := dst.CreateElement("root")
+		require.NoError(t, err)
+		require.NoError(t, dst.AddChild(root))
+
+		require.Equal(t, helium.Node(root), dst.DocumentElement(),
+			"the document element must be reachable after the append")
+		require.Equal(t, helium.Node(root), dst.FirstChild(),
+			"an empty reachable child list must start at the appended node")
+	})
+
+	// stringToNodeList materializes an entity's replacement children with
+	// firstChild set and lastChild nil. AddChild must append after the existing
+	// children instead of discarding them.
+	t.Run("recorded tail is nil while a child list exists", func(t *testing.T) {
+		t.Parallel()
+
+		doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+		dtd, err := doc.CreateInternalSubset("root", "", "")
+		require.NoError(t, err)
+		_, err = dtd.AddEntity("e", enum.InternalGeneralEntity, "", "", "val")
+		require.NoError(t, err)
+
+		root, err := doc.CreateElement("root")
+		require.NoError(t, err)
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.SetParsedAttribute("a", "&e;"))
+
+		ent, ok := doc.GetEntity("e")
+		require.True(t, ok)
+		first := ent.FirstChild()
+		require.NotNil(t, first, "the entity carries its replacement children")
+
+		extra, err := doc.CreateElement("extra")
+		require.NoError(t, err)
+		require.NoError(t, ent.AddChild(extra))
+
+		require.Equal(t, first, ent.FirstChild(),
+			"the existing child list must survive the append")
+		var names []string
+		for child := range helium.Children(ent) {
+			names = append(names, child.Type().String())
+		}
+		require.Contains(t, names, "ElementNode", "the appended child must be reachable")
+	})
+
+	// CreateReference hands the EntityRef the DTD's shared Entity as its child
+	// while that Entity's parent stays the DTD. Appending the Entity into its own
+	// reference must not link it after itself.
+	t.Run("operand is the parent's own foreign child", func(t *testing.T) {
+		t.Parallel()
+
+		doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+		dtd, err := doc.CreateInternalSubset("root", "", "")
+		require.NoError(t, err)
+		ent, err := dtd.AddEntity("e", enum.InternalGeneralEntity, "", "", "val")
+		require.NoError(t, err)
+
+		ref, err := doc.CreateReference("e")
+		require.NoError(t, err)
+		require.Equal(t, helium.Node(ent), ref.FirstChild())
+
+		_ = ref.AddChild(ent)
+
+		require.NotEqual(t, helium.Node(ent), ent.NextSibling(),
+			"a node must never become its own next sibling")
+		require.NotEqual(t, helium.Node(ent), ent.PrevSibling(),
+			"a node must never become its own previous sibling")
+	})
+}

--- a/node_owned_tail_test.go
+++ b/node_owned_tail_test.go
@@ -3,11 +3,14 @@ package helium_test
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/enum"
 	"github.com/stretchr/testify/require"
 )
+
+const appendCostRuns = 7
 
 // TestAddChildResolvesAnOwnedTail drives the shapes that safe API can build in
 // which a parent's recorded lastChild is not the last node that actually claims
@@ -146,6 +149,82 @@ func TestAddChildResolvesAnOwnedTail(t *testing.T) {
 		require.Equal(t, helium.Node(next), ent.NextSibling())
 		require.Equal(t, helium.Node(ent), next.PrevSibling())
 	})
+}
+
+// TestAppendCostIsLinearBesideAnOffChainClaim guards the per-parent scope of
+// off-chain child claims. CopyExtSubset gives the document such a claim, but an
+// element the document owns must still resolve appends through its first child
+// from the element's own last-child record. If the claim were read per document,
+// every append after the first would walk the growing sibling list and doubling
+// the workload would quadruple the cost.
+func TestAppendCostIsLinearBesideAnOffChainClaim(t *testing.T) {
+	const (
+		small    = 4000
+		large    = 8000
+		maxRatio = 3.2
+	)
+
+	src := documentWithExternalSubset(t)
+	smallCost := bestAppendCostBesideOffChainClaim(t, src, small)
+	largeCost := bestAppendCostBesideOffChainClaim(t, src, large)
+	ratio := float64(largeCost) / float64(smallCost)
+
+	t.Logf("append cost beside off-chain claim: n=%d -> %s, n=%d -> %s, ratio=%.2f",
+		small, smallCost, large, largeCost, ratio)
+	require.LessOrEqual(t, ratio, maxRatio,
+		"append cost looks quadratic: doubling a linear workload should stay below a %.1fx cost increase", maxRatio)
+}
+
+func documentWithExternalSubset(t *testing.T) *helium.Document {
+	t.Helper()
+
+	dtdPath := t.TempDir() + "/ext.dtd"
+	require.NoError(t, os.WriteFile(dtdPath, []byte(`<!ELEMENT root (#PCDATA)>`), 0600))
+	xml := `<?xml version="1.0"?>
+<!DOCTYPE root SYSTEM "` + dtdPath + `">
+<root/>`
+	doc, err := helium.NewParser().BlockXXE(false).LoadExternalDTD(true).FS(helium.PermissiveFS()).Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+	require.NotNil(t, doc.ExtSubset())
+	return doc
+}
+
+func bestAppendCostBesideOffChainClaim(t *testing.T, src *helium.Document, n int) time.Duration {
+	t.Helper()
+
+	best := time.Duration(-1)
+	for range appendCostRuns {
+		doc := helium.NewDefaultDocument()
+		helium.CopyExtSubset(src, doc)
+		require.Equal(t, helium.Node(doc), doc.ExtSubset().Parent())
+
+		parent, err := doc.CreateElement("parent")
+		require.NoError(t, err)
+		require.NoError(t, doc.AddChild(parent))
+		anchor, err := doc.CreateElement("anchor")
+		require.NoError(t, err)
+		require.NoError(t, parent.AddChild(anchor))
+
+		children := make([]*helium.Element, n)
+		for i := range n {
+			children[i], err = doc.CreateElement("child")
+			require.NoError(t, err)
+		}
+
+		start := time.Now()
+		for _, child := range children {
+			if err = anchor.AddSibling(child); err != nil {
+				break
+			}
+		}
+		elapsed := time.Since(start)
+		require.NoError(t, err)
+		require.Equal(t, helium.Node(children[n-1]), parent.LastChild())
+		if best < 0 || elapsed < best {
+			best = elapsed
+		}
+	}
+	return best
 }
 
 func collectChildren(parent helium.Node) []helium.Node {

--- a/node_owned_tail_test.go
+++ b/node_owned_tail_test.go
@@ -1,8 +1,10 @@
 package helium_test
 
 import (
+	"math"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/enum"
@@ -113,4 +115,107 @@ func TestAddChildResolvesAnOwnedTail(t *testing.T) {
 		require.NotEqual(t, helium.Node(ent), ent.PrevSibling(),
 			"a node must never become its own previous sibling")
 	})
+
+	// The same EntityRef shape, with a DIFFERENT node appended. No child on the
+	// reference's list claims the reference, so no owned tail exists — but the
+	// list is not empty, and the append must join it. Treating "no owned tail"
+	// as "empty parent" overwrites firstChild and drops the Entity with no
+	// error returned.
+	t.Run("a foreign first child survives an append", func(t *testing.T) {
+		t.Parallel()
+
+		doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+		dtd, err := doc.CreateInternalSubset("root", "", "")
+		require.NoError(t, err)
+		ent, err := dtd.AddEntity("e", enum.InternalGeneralEntity, "", "", "x")
+		require.NoError(t, err)
+
+		ref, err := doc.CreateReference("e")
+		require.NoError(t, err)
+		require.Equal(t, helium.Node(ent), ref.FirstChild())
+
+		comment := doc.CreateComment([]byte("added"))
+		require.NoError(t, ref.AddChild(comment))
+
+		require.Equal(t, helium.Node(ent), ref.FirstChild(),
+			"the entity the reference already held must not be discarded")
+		require.Equal(t, helium.Node(comment), ref.LastChild())
+
+		// Walk the raw sibling links rather than Children: the Entity claims the
+		// DTD, so the owned-boundary rule ends the Children iteration at it.
+		var children []helium.Node
+		for child := ref.FirstChild(); child != nil; child = child.NextSibling() {
+			children = append(children, child)
+		}
+		require.Len(t, children, 2, "the reference must hold both children")
+		require.Equal(t, helium.Node(ent), children[0])
+		require.Equal(t, helium.Node(comment), children[1])
+	})
+}
+
+// appendChildren times n AddChild calls onto a freshly created element in doc.
+// The element is well formed and holds no stale record of its own, so the cost
+// is entirely the cost of resolving the append point.
+func appendChildren(t *testing.T, doc *helium.Document, n int) time.Duration {
+	t.Helper()
+
+	host, err := doc.CreateElement("host")
+	require.NoError(t, err)
+	children := make([]*helium.Comment, n)
+	for i := range children {
+		children[i] = doc.CreateComment([]byte("c"))
+	}
+
+	start := time.Now()
+	for _, child := range children {
+		if err := host.AddChild(child); err != nil {
+			require.NoError(t, err)
+		}
+	}
+	return time.Since(start)
+}
+
+// TestAppendCostIsLinearBesideAnOffChainClaim pins the SCOPE of the off-chain
+// claim record. A parent that has been handed a child claiming it from off its
+// child list cannot trust its own lastChild, but every OTHER parent still can,
+// including every other parent in the same document. Reading the record from the
+// owning document instead of from the parent makes one claim anywhere turn every
+// later append in that document into a walk of the whole child list, which is
+// quadratic over N appends.
+//
+// The assertion is a SHAPE, not a time: doubling the number of appends must
+// roughly double the cost (ratio near 2), not quadruple it (ratio near 4). A
+// loaded machine moves both measurements together, and the best of several
+// attempts is taken so a single scheduling stall cannot fail the test.
+func TestAppendCostIsLinearBesideAnOffChainClaim(t *testing.T) {
+	// Not parallel: it measures elapsed time.
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<!DOCTYPE r [<!ENTITY e "x">]><r/>`))
+	require.NoError(t, err)
+
+	// The sequence that used to record a document-wide claim: the reference's
+	// firstChild is the DTD's shared Entity, which claims the DTD and not the
+	// reference, so the append finds no tail the reference owns.
+	ref, err := doc.CreateReference("e")
+	require.NoError(t, err)
+	require.NoError(t, ref.AddChild(doc.CreateComment([]byte("stray"))))
+
+	const n = 8000
+	appendChildren(t, doc, n) // warm up allocator and caches
+
+	best := math.Inf(1)
+	for range 3 {
+		single := appendChildren(t, doc, n)
+		double := appendChildren(t, doc, 2*n)
+		if single <= 0 {
+			continue
+		}
+		if ratio := float64(double) / float64(single); ratio < best {
+			best = ratio
+		}
+	}
+
+	require.Less(t, best, 3.0,
+		"doubling the appends must roughly double the cost, not quadruple it; "+
+			"a ratio near 4 means every append is walking the whole child list")
 }

--- a/node_owned_tail_test.go
+++ b/node_owned_tail_test.go
@@ -1,10 +1,8 @@
 package helium_test
 
 import (
-	"math"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/enum"
@@ -156,71 +154,4 @@ func collectChildren(parent helium.Node) []helium.Node {
 		children = append(children, child)
 	}
 	return children
-}
-
-// appendChildren times n AddChild calls onto a freshly created element in doc.
-// The element is well formed and holds no stale record of its own, so the cost
-// is entirely the cost of resolving the append point.
-func appendChildren(t *testing.T, doc *helium.Document, n int) time.Duration {
-	t.Helper()
-
-	host, err := doc.CreateElement("host")
-	require.NoError(t, err)
-	children := make([]*helium.Comment, n)
-	for i := range children {
-		children[i] = doc.CreateComment([]byte("c"))
-	}
-
-	start := time.Now()
-	for _, child := range children {
-		if err := host.AddChild(child); err != nil {
-			require.NoError(t, err)
-		}
-	}
-	return time.Since(start)
-}
-
-// TestAppendCostIsLinearBesideAnOffChainClaim pins the SCOPE of the off-chain
-// claim record. A parent that has been handed a child claiming it from off its
-// child list cannot trust its own lastChild, but every OTHER parent still can,
-// including every other parent in the same document. Reading the record from the
-// owning document instead of from the parent makes one claim anywhere turn every
-// later append in that document into a walk of the whole child list, which is
-// quadratic over N appends.
-//
-// The assertion is a SHAPE, not a time: doubling the number of appends must
-// roughly double the cost (ratio near 2), not quadruple it (ratio near 4). A
-// loaded machine moves both measurements together, and the best of several
-// attempts is taken so a single scheduling stall cannot fail the test.
-func TestAppendCostIsLinearBesideAnOffChainClaim(t *testing.T) {
-	// Not parallel: it measures elapsed time.
-	doc, err := helium.NewParser().Parse(t.Context(),
-		[]byte(`<!DOCTYPE r [<!ENTITY e "x">]><r/>`))
-	require.NoError(t, err)
-
-	// The sequence that used to record a document-wide claim: the reference's
-	// firstChild is the DTD's shared Entity, which claims the DTD and not the
-	// reference, so the append finds no tail the reference owns.
-	ref, err := doc.CreateReference("e")
-	require.NoError(t, err)
-	require.NoError(t, ref.AddChild(doc.CreateComment([]byte("stray"))))
-
-	const n = 8000
-	appendChildren(t, doc, n) // warm up allocator and caches
-
-	best := math.Inf(1)
-	for range 3 {
-		single := appendChildren(t, doc, n)
-		double := appendChildren(t, doc, 2*n)
-		if single <= 0 {
-			continue
-		}
-		if ratio := float64(double) / float64(single); ratio < best {
-			best = ratio
-		}
-	}
-
-	require.Less(t, best, 3.0,
-		"doubling the appends must roughly double the cost, not quadruple it; "+
-			"a ratio near 4 means every append is walking the whole child list")
 }

--- a/node_owned_tail_test.go
+++ b/node_owned_tail_test.go
@@ -3,14 +3,11 @@ package helium_test
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/enum"
 	"github.com/stretchr/testify/require"
 )
-
-const appendCostRuns = 7
 
 // TestAddChildResolvesAnOwnedTail drives the shapes that safe API can build in
 // which a parent's recorded lastChild is not the last node that actually claims
@@ -149,82 +146,6 @@ func TestAddChildResolvesAnOwnedTail(t *testing.T) {
 		require.Equal(t, helium.Node(next), ent.NextSibling())
 		require.Equal(t, helium.Node(ent), next.PrevSibling())
 	})
-}
-
-// TestAppendCostIsLinearBesideAnOffChainClaim guards the per-parent scope of
-// off-chain child claims. CopyExtSubset gives the document such a claim, but an
-// element the document owns must still resolve appends through its first child
-// from the element's own last-child record. If the claim were read per document,
-// every append after the first would walk the growing sibling list and doubling
-// the workload would quadruple the cost.
-func TestAppendCostIsLinearBesideAnOffChainClaim(t *testing.T) {
-	const (
-		small    = 4000
-		large    = 8000
-		maxRatio = 3.2
-	)
-
-	src := documentWithExternalSubset(t)
-	smallCost := bestAppendCostBesideOffChainClaim(t, src, small)
-	largeCost := bestAppendCostBesideOffChainClaim(t, src, large)
-	ratio := float64(largeCost) / float64(smallCost)
-
-	t.Logf("append cost beside off-chain claim: n=%d -> %s, n=%d -> %s, ratio=%.2f",
-		small, smallCost, large, largeCost, ratio)
-	require.LessOrEqual(t, ratio, maxRatio,
-		"append cost looks quadratic: doubling a linear workload should stay below a %.1fx cost increase", maxRatio)
-}
-
-func documentWithExternalSubset(t *testing.T) *helium.Document {
-	t.Helper()
-
-	dtdPath := t.TempDir() + "/ext.dtd"
-	require.NoError(t, os.WriteFile(dtdPath, []byte(`<!ELEMENT root (#PCDATA)>`), 0600))
-	xml := `<?xml version="1.0"?>
-<!DOCTYPE root SYSTEM "` + dtdPath + `">
-<root/>`
-	doc, err := helium.NewParser().BlockXXE(false).LoadExternalDTD(true).FS(helium.PermissiveFS()).Parse(t.Context(), []byte(xml))
-	require.NoError(t, err)
-	require.NotNil(t, doc.ExtSubset())
-	return doc
-}
-
-func bestAppendCostBesideOffChainClaim(t *testing.T, src *helium.Document, n int) time.Duration {
-	t.Helper()
-
-	best := time.Duration(-1)
-	for range appendCostRuns {
-		doc := helium.NewDefaultDocument()
-		helium.CopyExtSubset(src, doc)
-		require.Equal(t, helium.Node(doc), doc.ExtSubset().Parent())
-
-		parent, err := doc.CreateElement("parent")
-		require.NoError(t, err)
-		require.NoError(t, doc.AddChild(parent))
-		anchor, err := doc.CreateElement("anchor")
-		require.NoError(t, err)
-		require.NoError(t, parent.AddChild(anchor))
-
-		children := make([]*helium.Element, n)
-		for i := range n {
-			children[i], err = doc.CreateElement("child")
-			require.NoError(t, err)
-		}
-
-		start := time.Now()
-		for _, child := range children {
-			if err = anchor.AddSibling(child); err != nil {
-				break
-			}
-		}
-		elapsed := time.Since(start)
-		require.NoError(t, err)
-		require.Equal(t, helium.Node(children[n-1]), parent.LastChild())
-		if best < 0 || elapsed < best {
-			best = elapsed
-		}
-	}
-	return best
 }
 
 func collectChildren(parent helium.Node) []helium.Node {

--- a/node_owned_tail_test.go
+++ b/node_owned_tail_test.go
@@ -91,27 +91,44 @@ func TestAddChildResolvesAnOwnedTail(t *testing.T) {
 	})
 
 	// CreateReference hands the EntityRef the DTD's shared Entity as its child
-	// while that Entity's parent stays the DTD. Appending the Entity into its own
-	// reference must not link it after itself.
+	// while that Entity's parent stays the DTD. Re-adding that same Entity is a
+	// successful no-op that must preserve both views of the shared node.
 	t.Run("operand is the parent's own foreign child", func(t *testing.T) {
 		t.Parallel()
 
 		doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
 		dtd, err := doc.CreateInternalSubset("root", "", "")
 		require.NoError(t, err)
-		ent, err := dtd.AddEntity("e", enum.InternalGeneralEntity, "", "", "val")
+		ent, err := dtd.AddEntity("e1", enum.InternalGeneralEntity, "", "", "x")
+		require.NoError(t, err)
+		next, err := dtd.AddEntity("e2", enum.InternalGeneralEntity, "", "", "y")
+		require.NoError(t, err)
+		dtdChildren := []helium.Node{ent, next}
+		require.Equal(t, dtdChildren, collectChildren(dtd))
+		before, err := helium.WriteString(dtd)
 		require.NoError(t, err)
 
-		ref, err := doc.CreateReference("e")
+		ref, err := doc.CreateReference("e1")
 		require.NoError(t, err)
 		require.Equal(t, helium.Node(ent), ref.FirstChild())
+		require.Equal(t, helium.Node(ent), ref.LastChild())
 
-		_ = ref.AddChild(ent)
+		require.NoError(t, ref.AddChild(ent), "re-adding the stored foreign child is a no-op")
 
-		require.NotEqual(t, helium.Node(ent), ent.NextSibling(),
-			"a node must never become its own next sibling")
-		require.NotEqual(t, helium.Node(ent), ent.PrevSibling(),
-			"a node must never become its own previous sibling")
+		require.Equal(t, dtdChildren, collectChildren(dtd),
+			"the DTD declaration chain must remain intact")
+		require.Equal(t, helium.Node(dtd), ent.Parent(),
+			"the shared Entity must remain owned by the DTD")
+		require.Equal(t, []helium.Node{ent}, collectChildren(ref),
+			"the reference must retain its shared Entity child")
+		require.Equal(t, helium.Node(ent), ref.FirstChild())
+		require.Equal(t, helium.Node(ent), ref.LastChild())
+		require.Equal(t, helium.Node(next), ent.NextSibling())
+		require.Equal(t, helium.Node(ent), next.PrevSibling())
+
+		after, err := helium.WriteString(dtd)
+		require.NoError(t, err)
+		require.Equal(t, before, after, "DTD serialization must retain both declarations")
 	})
 
 	// The same EntityRef shape, with a DIFFERENT node appended. The reference's

--- a/node_owned_tail_test.go
+++ b/node_owned_tail_test.go
@@ -116,41 +116,46 @@ func TestAddChildResolvesAnOwnedTail(t *testing.T) {
 			"a node must never become its own previous sibling")
 	})
 
-	// The same EntityRef shape, with a DIFFERENT node appended. No child on the
-	// reference's list claims the reference, so no owned tail exists — but the
-	// list is not empty, and the append must join it. Treating "no owned tail"
-	// as "empty parent" overwrites firstChild and drops the Entity with no
-	// error returned.
-	t.Run("a foreign first child survives an append", func(t *testing.T) {
+	// The same EntityRef shape, with a DIFFERENT node appended. The reference's
+	// shared Entity child still belongs to the DTD, so its sibling links must not
+	// be used as an append point for the reference.
+	t.Run("a foreign first child is not an append anchor", func(t *testing.T) {
 		t.Parallel()
 
 		doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
 		dtd, err := doc.CreateInternalSubset("root", "", "")
 		require.NoError(t, err)
-		ent, err := dtd.AddEntity("e", enum.InternalGeneralEntity, "", "", "x")
+		ent, err := dtd.AddEntity("e1", enum.InternalGeneralEntity, "", "", "x")
 		require.NoError(t, err)
+		next, err := dtd.AddEntity("e2", enum.InternalGeneralEntity, "", "", "y")
+		require.NoError(t, err)
+		dtdChildren := []helium.Node{ent, next}
+		require.Equal(t, dtdChildren, collectChildren(dtd))
 
-		ref, err := doc.CreateReference("e")
+		ref, err := doc.CreateReference("e1")
 		require.NoError(t, err)
 		require.Equal(t, helium.Node(ent), ref.FirstChild())
 
 		comment := doc.CreateComment([]byte("added"))
 		require.NoError(t, ref.AddChild(comment))
 
-		require.Equal(t, helium.Node(ent), ref.FirstChild(),
-			"the entity the reference already held must not be discarded")
+		require.Equal(t, helium.Node(ref), comment.Parent(),
+			"the appended node must belong to the requested parent")
+		require.Equal(t, helium.Node(comment), ref.FirstChild())
 		require.Equal(t, helium.Node(comment), ref.LastChild())
-
-		// Walk the raw sibling links rather than Children: the Entity claims the
-		// DTD, so the owned-boundary rule ends the Children iteration at it.
-		var children []helium.Node
-		for child := ref.FirstChild(); child != nil; child = child.NextSibling() {
-			children = append(children, child)
-		}
-		require.Len(t, children, 2, "the reference must hold both children")
-		require.Equal(t, helium.Node(ent), children[0])
-		require.Equal(t, helium.Node(comment), children[1])
+		require.Equal(t, dtdChildren, collectChildren(dtd),
+			"appending to the reference must not change the DTD declaration chain")
+		require.Equal(t, helium.Node(next), ent.NextSibling())
+		require.Equal(t, helium.Node(ent), next.PrevSibling())
 	})
+}
+
+func collectChildren(parent helium.Node) []helium.Node {
+	var children []helium.Node
+	for child := range helium.Children(parent) {
+		children = append(children, child)
+	}
+	return children
 }
 
 // appendChildren times n AddChild calls onto a freshly created element in doc.

--- a/node_sibling_internal_test.go
+++ b/node_sibling_internal_test.go
@@ -57,33 +57,41 @@ func TestTailJumpTargetDocumentParent(t *testing.T) {
 		require.Nil(t, tailJumpTarget(doc, comment.baseDocNode()))
 	})
 
-	t.Run("a document holding an off-chain claim declines", func(t *testing.T) {
+	t.Run("a claim on one parent leaves every other parent resolving", func(t *testing.T) {
 		t.Parallel()
 
 		doc, comment := documentTailFixture(t)
 
-		// stringToNodeList leaves an entity referenced from an attribute value
-		// with a firstChild and no lastChild; setFirstChild is the call that does
-		// it. An append onto such a parent detaches that child while the child
-		// goes on claiming the parent. Recording the claim is what stops the
-		// document trusting a lastChild that a later append through the detached
-		// child can move off a child list.
-		claimed, err := doc.CreateElement("claimed")
-		require.NoError(t, err)
-		setFirstChild(claimed, doc.CreateText([]byte("first")))
-		require.NoError(t, claimed.AddChild(doc.CreateComment([]byte("q"))))
+		src := NewDefaultDocument()
+		srcDTD := newDTD()
+		srcDTD.name = "root"
+		src.extSubset = srcDTD
+		CopyExtSubset(src, doc)
+		require.Nil(t, tailJumpTarget(doc, comment.baseDocNode()),
+			"the parent handed the claimant declines")
 
-		require.True(t, doc.offChainClaims)
-		require.Nil(t, tailJumpTarget(doc, comment.baseDocNode()))
+		// The claimant was handed to the DOCUMENT. Every element the document
+		// owns still has its lastChild at the end of its own chain, so each keeps
+		// its O(1) resolution: a claim on one parent must never cost the others.
+		elem, err := doc.CreateElement("elem")
+		require.NoError(t, err)
+		require.NoError(t, doc.AddChild(elem))
+		lead := doc.CreateComment([]byte("lead"))
+		trail := doc.CreateComment([]byte("trail"))
+		require.NoError(t, elem.AddChild(lead))
+		require.NoError(t, elem.AddChild(trail))
+
+		require.Equal(t, Node(trail), tailJumpTarget(elem, lead.baseDocNode()))
 	})
 }
 
-// TestAdoptOffChainClaimWithoutOwner pins the record that no document owned when
-// it was made. An off-chain claim created on a still-detached subtree has
-// nowhere to be recorded, so it lands on the package-level flag, and the
-// document that later adopts the subtree must inherit it.
-func TestAdoptOffChainClaimWithoutOwner(t *testing.T) {
-	// Not parallel: it asserts on the package-level unowned-claim flag.
+// TestAppendKeepsAForeignChildList pins the shape that has a firstChild claiming
+// nobody, on nodes no document owns. resolveOwnedTail finds no tail this parent
+// owns, and the append must still join the list the parent reaches instead of
+// deciding the parent is empty and overwriting it.
+func TestAppendKeepsAForeignChildList(t *testing.T) {
+	t.Parallel()
+
 	var standalone *Document
 	parent, err := standalone.CreateElement("parent")
 	require.NoError(t, err)
@@ -92,13 +100,12 @@ func TestAdoptOffChainClaimWithoutOwner(t *testing.T) {
 	later, err := standalone.CreateElement("later")
 	require.NoError(t, err)
 
-	// The firstChild-without-lastChild shape, on nodes no document owns.
+	// The firstChild-without-lastChild shape: first claims no parent at all, so
+	// nothing on parent's list claims parent.
 	setFirstChild(parent, first)
 	require.NoError(t, parent.AddChild(later))
-	require.True(t, unownedOffChainClaim.Load(), "a claim no document owned is recorded package-wide")
 
-	doc := NewDefaultDocument()
-	require.False(t, doc.offChainClaims)
-	parent.SetTreeDoc(doc)
-	require.True(t, doc.offChainClaims, "the adopting document inherits the record")
+	require.Equal(t, Node(first), parent.FirstChild(), "the existing child must survive")
+	require.Equal(t, Node(later), parent.LastChild())
+	require.Equal(t, Node(later), first.NextSibling(), "the append joins the list it found")
 }

--- a/node_sibling_internal_test.go
+++ b/node_sibling_internal_test.go
@@ -85,11 +85,11 @@ func TestTailJumpTargetDocumentParent(t *testing.T) {
 	})
 }
 
-// TestAppendKeepsAForeignChildList pins the shape that has a firstChild claiming
-// nobody, on nodes no document owns. resolveOwnedTail finds no tail this parent
-// owns, and the append must still join the list the parent reaches instead of
-// deciding the parent is empty and overwriting it.
-func TestAppendKeepsAForeignChildList(t *testing.T) {
+// TestAppendReplacesAForeignChildList pins the shape that has a firstChild
+// claiming nobody, on nodes no document owns. resolveOwnedTail finds no tail
+// this parent owns, so the append must start an owned list without changing the
+// foreign node's sibling links.
+func TestAppendReplacesAForeignChildList(t *testing.T) {
 	t.Parallel()
 
 	var standalone *Document
@@ -105,7 +105,8 @@ func TestAppendKeepsAForeignChildList(t *testing.T) {
 	setFirstChild(parent, first)
 	require.NoError(t, parent.AddChild(later))
 
-	require.Equal(t, Node(first), parent.FirstChild(), "the existing child must survive")
+	require.Equal(t, Node(later), parent.FirstChild(), "the appended child starts the owned list")
 	require.Equal(t, Node(later), parent.LastChild())
-	require.Equal(t, Node(later), first.NextSibling(), "the append joins the list it found")
+	require.Equal(t, Node(parent), later.Parent())
+	require.Nil(t, first.NextSibling(), "the foreign node's sibling links stay unchanged")
 }

--- a/node_sibling_internal_test.go
+++ b/node_sibling_internal_test.go
@@ -25,6 +25,45 @@ func documentTailFixture(t *testing.T) (*Document, *Comment) {
 	return doc, comment
 }
 
+// nextSiblingCountingElement records every fallback sibling-walk step made
+// through it. Its AddSibling override keeps the wrapper as addSibling's anchor
+// so virtual NextSibling calls remain observable to the test.
+type nextSiblingCountingElement struct {
+	*Element
+	nextSiblingCalls *int
+}
+
+func (n *nextSiblingCountingElement) AddSibling(cur Node) error {
+	return addSibling(n, cur)
+}
+
+func (n *nextSiblingCountingElement) NextSibling() Node {
+	(*n.nextSiblingCalls)++
+	return n.Element.NextSibling()
+}
+
+func newNextSiblingCountingElement(t *testing.T, doc *Document, nextSiblingCalls *int) *nextSiblingCountingElement {
+	t.Helper()
+
+	elem, err := doc.CreateElement("child")
+	require.NoError(t, err)
+	return &nextSiblingCountingElement{
+		Element:          elem,
+		nextSiblingCalls: nextSiblingCalls,
+	}
+}
+
+func documentWithOffChainClaim() *Document {
+	src := NewDefaultDocument()
+	srcDTD := newDTD()
+	srcDTD.name = "root"
+	src.extSubset = srcDTD
+
+	doc := NewDefaultDocument()
+	CopyExtSubset(src, doc)
+	return doc
+}
+
 // TestTailJumpTargetDocumentParent pins which *Document parents may resolve an
 // append point from their own lastChild. A document is not excluded by TYPE: it
 // is excluded by the one CONDITION that makes its record untrustworthy, which is
@@ -82,6 +121,59 @@ func TestTailJumpTargetDocumentParent(t *testing.T) {
 		require.NoError(t, elem.AddChild(trail))
 
 		require.Equal(t, Node(trail), tailJumpTarget(elem, lead.baseDocNode()))
+	})
+}
+
+// TestAppendCostIsLinearBesideAnOffChainClaim guards the per-parent scope of
+// off-chain child claims without measuring elapsed time. CopyExtSubset gives the
+// document such a claim, but an element it owns must still append through its
+// first child without calling NextSibling. A document-wide claim would force the
+// fallback walk on every append and make the counter nonzero.
+func TestAppendCostIsLinearBesideAnOffChainClaim(t *testing.T) {
+	t.Parallel()
+
+	t.Run("counter observes a required fallback walk", func(t *testing.T) {
+		doc := documentWithOffChainClaim()
+		require.True(t, holdsOffChainChildClaim(doc))
+
+		nextSiblingCalls := 0
+		anchor := newNextSiblingCountingElement(t, doc, &nextSiblingCalls)
+		tail := newNextSiblingCountingElement(t, doc, &nextSiblingCalls)
+		require.NoError(t, doc.AddChild(anchor))
+		require.NoError(t, doc.AddChild(tail))
+
+		nextSiblingCalls = 0
+		appended := newNextSiblingCountingElement(t, doc, &nextSiblingCalls)
+		require.NoError(t, anchor.AddSibling(appended))
+		require.Positive(t, nextSiblingCalls,
+			"a parent with an off-chain claim must walk instead of trusting its recorded tail")
+		require.Equal(t, Node(appended), doc.LastChild())
+	})
+
+	t.Run("another parent keeps constant-time tail resolution", func(t *testing.T) {
+		doc := documentWithOffChainClaim()
+		require.True(t, holdsOffChainChildClaim(doc))
+
+		parent, err := doc.CreateElement("parent")
+		require.NoError(t, err)
+		require.NoError(t, doc.AddChild(parent))
+		require.False(t, holdsOffChainChildClaim(parent))
+
+		nextSiblingCalls := 0
+		anchor := newNextSiblingCountingElement(t, doc, &nextSiblingCalls)
+		require.NoError(t, parent.AddChild(anchor))
+
+		const appendCount = 256
+		var last Node = anchor
+		for range appendCount {
+			child := newNextSiblingCountingElement(t, doc, &nextSiblingCalls)
+			require.NoError(t, anchor.AddSibling(child))
+			last = child
+		}
+
+		require.Equal(t, last, parent.LastChild())
+		require.Zero(t, nextSiblingCalls,
+			"appending through the first child must resolve the recorded tail without walking siblings")
 	})
 }
 

--- a/node_sibling_test.go
+++ b/node_sibling_test.go
@@ -166,49 +166,49 @@ func TestAddSiblingAttributeInChildList(t *testing.T) {
 }
 
 // offChainParentClaimTree builds, through public non-Unsafe calls only, a parent
-// holding a node that claims it without being a member of its child list, and an
-// append through that node that has already moved the parent's recorded tail off
-// the child list.
+// whose RECORDED tail is not a member of its child list.
 //
-// Document.stringToNodeList leaves an entity referenced from an attribute value
-// with a firstChild and no lastChild. AddChild onto such a parent takes its
-// empty-parent branch and overwrites firstChild, which detaches the child that
-// was there while it goes on claiming the entity as its parent.
+// CopyExtSubset installs the copied external subset as a *Document's extSubset
+// and gives it that document as its parent, but the subset is not in the
+// document's child list. An AddSibling through the subset therefore records its
+// own result as the document's lastChild while the reachable list still ends
+// where it did.
 //
 // It returns the parent, the last node of its REACHABLE child list, and the
 // off-chain node now recorded as its lastChild.
 func offChainParentClaimTree(t *testing.T) (helium.MutableNode, helium.Node, helium.Node) {
 	t.Helper()
 
-	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<!DOCTYPE d [<!ENTITY e "xy">]><d a="&e;"/>`))
+	dir := t.TempDir()
+	dtdPath := dir + "/ext.dtd"
+	require.NoError(t, os.WriteFile(dtdPath, []byte(`<!ELEMENT root (#PCDATA)>`), 0600))
+
+	xml := `<?xml version="1.0"?>
+<!DOCTYPE root SYSTEM "` + dtdPath + `">
+<root/>`
+	src, err := helium.NewParser().BlockXXE(false).LoadExternalDTD(true).FS(helium.PermissiveFS()).Parse(t.Context(), []byte(xml))
 	require.NoError(t, err)
+	require.NotNil(t, src.ExtSubset())
 
-	parent, ok := doc.GetEntity("e")
-	require.True(t, ok)
-	require.NotNil(t, parent.FirstChild(), "the attribute-value expansion is the entity's child")
-	require.Nil(t, parent.LastChild(), "and it was recorded without a lastChild")
-
-	claimant, ok := parent.FirstChild().(helium.MutableNode)
-	require.True(t, ok)
-
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
 	a := doc.CreateComment([]byte("a"))
-	require.NoError(t, parent.AddChild(a))
-	require.Equal(t, helium.Node(parent), claimant.Parent(), "the detached child still claims the entity")
-
+	require.NoError(t, doc.AddChild(a))
 	b := doc.CreateComment([]byte("b"))
-	require.NoError(t, a.AddSibling(b))
+	require.NoError(t, doc.AddChild(b))
+
+	helium.CopyExtSubset(src, doc)
+	ext := doc.ExtSubset()
+	require.NotNil(t, ext)
+	require.Equal(t, helium.Node(doc), ext.Parent(), "the copied external subset claims the document as its parent")
 
 	trailer := doc.CreateComment([]byte("trailer"))
-	require.NoError(t, claimant.AddSibling(trailer))
+	require.NoError(t, ext.AddSibling(trailer))
 
-	require.Equal(t, helium.Node(trailer), claimant.NextSibling(), "the append lands after the off-chain anchor")
-	require.Equal(t, helium.Node(parent), trailer.Parent())
-	require.Equal(t, helium.Node(a), parent.FirstChild())
-	require.Equal(t, helium.Node(trailer), parent.LastChild(), "the append records its own node as the tail, off the child list")
-	require.Equal(t, []string{"a", "b"}, childContents(t, parent), "the reachable child list is unchanged")
+	require.Equal(t, helium.Node(trailer), doc.LastChild(), "the append records its own node as the tail, off the child list")
+	require.Equal(t, []string{"a", "b"}, childContents(t, doc), "the reachable child list is unchanged")
 	require.Nil(t, b.NextSibling(), "the reachable chain still ends at b")
 
-	return parent, b, trailer
+	return doc, b, trailer
 }
 
 // childContents collects the contents of a parent's reachable children.
@@ -238,12 +238,12 @@ func elementNames(t *testing.T, parent *helium.Element) []string {
 // TestAddSiblingOffChainParentClaim covers a node that claims a parent without
 // being a member of that parent's child list. An append through such a node
 // records its own result as the parent's lastChild, so the record leaves the
-// child list. The three append entry points then part company, and each one
-// keeps the position it has always had: AddSibling walks from its anchor and so
-// lands at the end of the REACHABLE child list, while AddChild and
-// UnsafeAppendChildForTesting both start from the recorded lastChild and so land
-// after the off-chain node. The O(1) tail resolution changes none of that — it
-// declines for a document holding an off-chain claim and lets AddSibling walk.
+// child list. All three append entry points then agree: each resolves the tail
+// its own child list reaches and appends there, leaving the off-chain record to
+// be repaired rather than followed. AddSibling walks from its anchor, and
+// AddChild and UnsafeAppendChildForTesting reach the same node through
+// resolveOwnedTail, which declines a recorded tail that the parent's list does
+// not reach.
 func TestAddSiblingOffChainParentClaim(t *testing.T) {
 	t.Parallel()
 
@@ -265,32 +265,34 @@ func TestAddSiblingOffChainParentClaim(t *testing.T) {
 		require.Nil(t, trailer.NextSibling(), "the off-chain chain is untouched")
 	})
 
-	t.Run("AddChild appends after the recorded tail", func(t *testing.T) {
+	t.Run("AddChild appends after the reachable tail", func(t *testing.T) {
 		t.Parallel()
 
-		parent, _, trailer := offChainParentClaimTree(t)
+		parent, b, trailer := offChainParentClaimTree(t)
 		doc := parent.OwnerDocument()
 
 		added := doc.CreateComment([]byte(nameAdded))
 		require.NoError(t, parent.AddChild(added))
 
-		require.Equal(t, []string{"a", "b"}, childContents(t, parent), "the reachable child list is unchanged")
-		require.Equal(t, trailer, added.PrevSibling(), "AddChild starts from the recorded tail")
+		require.Equal(t, []string{"a", "b", nameAdded}, childContents(t, parent), "the append joins the reachable child list")
+		require.Equal(t, b, added.PrevSibling(), "AddChild resolves the tail its own child list reaches")
 		require.Equal(t, helium.Node(added), parent.LastChild())
+		require.Nil(t, trailer.NextSibling(), "the off-chain chain is untouched")
 	})
 
-	t.Run("UnsafeAppendChildForTesting appends after the recorded tail", func(t *testing.T) {
+	t.Run("UnsafeAppendChildForTesting appends after the reachable tail", func(t *testing.T) {
 		t.Parallel()
 
-		parent, _, trailer := offChainParentClaimTree(t)
+		parent, b, trailer := offChainParentClaimTree(t)
 		doc := parent.OwnerDocument()
 
 		added := doc.CreateComment([]byte(nameAdded))
 		require.NoError(t, helium.UnsafeAppendChildForTesting(parent, added))
 
-		require.Equal(t, []string{"a", "b"}, childContents(t, parent), "the reachable child list is unchanged")
-		require.Equal(t, trailer, added.PrevSibling(), "UnsafeAppendChildForTesting starts from the recorded tail")
+		require.Equal(t, []string{"a", "b", nameAdded}, childContents(t, parent), "the append joins the reachable child list")
+		require.Equal(t, b, added.PrevSibling(), "the no-preflight append resolves the same tail")
 		require.Equal(t, helium.Node(added), parent.LastChild())
+		require.Nil(t, trailer.NextSibling(), "the off-chain chain is untouched")
 	})
 }
 

--- a/tree_fastpath.go
+++ b/tree_fastpath.go
@@ -42,10 +42,9 @@ func appendFastChild(parent MutableNode, child Node) error {
 	pdn := parent.baseDocNode()
 	cdn := child.baseDocNode()
 
-	// A nil tail means parent has no child list at all. resolveOwnedTail never
-	// returns nil for a parent that already holds children, so this branch
-	// cannot overwrite an existing list.
-	last := resolveOwnedTail(parent, pdn, cdn)
+	// A nil tail means parent has no child it owns. Install child as the owned
+	// list rather than linking through a foreign head's sibling chain.
+	last := resolveOwnedTail(parent, pdn)
 	if last == nil {
 		pdn.firstChild = child
 		pdn.lastChild = child

--- a/tree_fastpath.go
+++ b/tree_fastpath.go
@@ -42,9 +42,11 @@ func appendFastChild(parent MutableNode, child Node) error {
 	pdn := parent.baseDocNode()
 	cdn := child.baseDocNode()
 
-	last := resolveOwnedTail(parent, pdn)
+	// A nil tail means parent has no child list at all. resolveOwnedTail never
+	// returns nil for a parent that already holds children, so this branch
+	// cannot overwrite an existing list.
+	last := resolveOwnedTail(parent, pdn, cdn)
 	if last == nil {
-		noteOrphanedChildClaim(parent, pdn.firstChild)
 		pdn.firstChild = child
 		pdn.lastChild = child
 		cdn.parent = parent

--- a/tree_fastpath.go
+++ b/tree_fastpath.go
@@ -42,7 +42,7 @@ func appendFastChild(parent MutableNode, child Node) error {
 	pdn := parent.baseDocNode()
 	cdn := child.baseDocNode()
 
-	last := pdn.lastChild
+	last := resolveOwnedTail(parent, pdn)
 	if last == nil {
 		noteOrphanedChildClaim(parent, pdn.firstChild)
 		pdn.firstChild = child


### PR DESCRIPTION
- AddChild trusted parent.lastChild raw, so safe API could lose a document's root element.
- All three append paths now resolve the tail their own child list reaches, as AddSibling did.
- Contract change: AddChild no longer follows a recorded tail that is off the child list.
