### PR TITLE
wrap long lines in claude docs

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -8,24 +8,95 @@ All error formatting matches libxml2 output for golden test compatibility.
 
 - **`ErrorLevel`** — `ErrorLevelNone`, `ErrorLevelWarning`, `ErrorLevelError`, `ErrorLevelFatal`
 - **`ErrorDomain`** — `ErrorDomainParser`, `ErrorDomainNamespace`
-- **`ErrorLeveler`** interface — optional interface for errors to report their `ErrorLevel()`; default is `ErrorLevelWarning`. `ErrorCollector`'s level filter (`errorAccumulator.Handle`) reads it via `errors.As`, so a wrapped leveler in the error chain is honored, not only a top-level one
+- **`ErrorLeveler`** interface — optional interface for errors to report their `ErrorLevel()`; default is
+  `ErrorLevelWarning`. `ErrorCollector`'s level filter (`errorAccumulator.Handle`) reads it via `errors.As`,
+  so a wrapped leveler in the error chain is honored, not only a top-level one
 - **`NewLeveledError(msg, level)`** — factory creating error implementing `ErrorLeveler`
-- **`ErrExternalDTDTooLarge`** (`errors.go`) — sentinel returned from the `ExternalSubset` bounded read when a loaded external DTD subset exceeds the byte cap (`MaxExternalDTDBytes` or default `MaxExternalDTDSize`, 10 MiB). Enforced against actual bytes read, never the advisory `fs.FileInfo.Size()`, and checked before any read error; match with `errors.Is`
-- **`ErrInvalidOperation`** (`errors.go`) — sentinel for a DOM mutation the tree state forbids; wrapped via `%w` into a descriptive message, matched with `errors.Is`. Returned by: `Document.SetDocumentElement` when `root` is not an element; and `node.DeclareNamespace(prefix, uri)` / `node.AddNamespaceDecl(ns)` on an ELEMENT node when `prefix` is in use by the element's own name (`n.ns`) or a NON-empty-prefix attribute at a URI DIFFERENT from `uri` — a genuine prefix conflict, left unchanged (the conflict check is element-scoped: a non-element node never serializes `n.ns`, so it never returns this error; this holds whether or not an nsDefs entry already exists; an empty-prefix attribute is not counted, since it never uses the default namespace and the serializer skips it; a same-URI use is not a conflict, a same-URI redeclare is a no-op, and an unused-prefix redeclare collapses the slot, all returning nil; on that collapse `DeclareNamespace` installs a fresh `Namespace` while `AddNamespaceDecl` installs the caller's object, both leaving the replaced object unmodified; `AddNamespaceDecl` applies the same rule and returns the same `%w`-wrapped `ErrInvalidOperation` on a conflict — a nil ns returns `ErrNilNode` instead). These methods do not reconcile a conflict introduced afterward by `SetActiveNamespace`/`SetNamespace`; keeping one `xmlns:prefix` per element across all mutators is a serializer-level concern.
-- **`ErrNodeContentTooLarge`** (`errors.go`) — sentinel returned when a single indivisible content run — a CDATA section (`parseCDataContent`), comment body (`parseComment`), processing-instruction body (`parsePI`), character-data run (`parseCharDataContent`), or attribute value (`parseAttributeValueInternal`) — exceeds the byte cap (`MaxNodeContentSize` or default `DefaultMaxNodeContentSize`, 10 MiB). The cap fires DURING accumulation (the loop scanners check `buf.Len()` each iteration; the char-data fast/fallback scanners pass a `maxBytes` budget into `ScanCharDataSlice`/`ScanCharDataInto`; the attribute-value fast path bounds `ScanSimpleAttrValue` with the same budget and re-checks the exact count, while the slow path routes every write through cap-enforcing `writeAttr*` helpers and decodes entity replacements through a cap-checking `attrEntitySink`) so the parse fails before the whole run is buffered. The SAME cap also bounds a single contiguous run of XML whitespace: `skipBlankRun` (`parser_whitespace.go`) scans blanks in 4 KiB chunks and trips this error once the run exceeds `blankRunLimit()` (= the resolved `maxNodeContent`), so an unbounded whitespace run cannot grow the cursor buffer. This covers the prolog/epilogue/inter-root blank skips (`skipBlanks`/`skipBlankBytes`) AND the blank skips inside the external DTD subset declaration loop and INCLUDE conditional sections (`parser_dtd_subset.go`, which call `skipBlankRun` directly to preserve `%pe;` expansion). `NewParser` applies the default (secure by default); `MaxNodeContentSize(-1)` resolves `maxNodeContent` to `0` and disables BOTH the node-content and the blank-run cap. The streaming SAX char-data path (`CharBufferSize>0`) is exempt — it is already chunked. Match with `errors.Is`
-- **`ErrInvalidOutputVersion`** (`errors.go`) — writer sentinel raised (via `isValidXMLVersion`) when the effective output XML version is not a valid `VersionNum` `'1.' [0-9]+`. A non-empty `OutputVersion` override is validated at the `WriteTo` entry, ahead of the node-type branch, so BOTH a Document and a bare element/fragment fail on a malformed override; a Document's own version (`Document.SetVersion`, used when there is no override) is validated at the `writeDoc` entry. Both checks run BEFORE any output byte (ahead of the transcoding-encoder setup, whose deferred flush would emit a BOM), so a value carrying a quote (markup injection into the version pseudo-attribute) or a malformed/non-`1.x` value emits nothing. Match with `errors.Is`. See `packages.md` for the full serialization-parameter description
-- **`ErrElementDeclNotFound`** (`errors.go`) — sentinel returned by `Document.IsMixedElement` when neither the internal nor the external subset has an element declaration for the given name (or the document has no internal subset). Match with `errors.Is`
-- **`ErrUnsupportedOutputEncoding`** (`errors.go`) — writer sentinel; the `writeDoc`-entry label-well-formedness case rejects a non-empty effective encoding that is not a valid `EncName` (`xmlchar.IsValidEncName`) before any output byte (ahead of the transcoding encoder, so no BOM leaks; guarding the encoding pseudo-attribute against markup injection), layered before the separate US-ASCII/encoder-table transcoding rejects. Full description (all cases) in `packages.md`. Match with `errors.Is`
-- **Writer structural-serialization sentinels** (`errors.go`) — `ErrWriterReservedElementName`, `ErrWriterReservedAttributeName`, `ErrWriterReservedNamespacePrefix`, `ErrWriterInvalidElementName`, `ErrWriterInvalidAttributeName`, `ErrWriterInvalidNamespacePrefix`, `ErrWriterUnboundNamespacePrefix`, `ErrWriterInvalidName`, `ErrWriterInvalidComment`, `ErrWriterInvalidPITarget`, `ErrWriterInvalidPIContent`, `ErrWriterInvalidDTDNode`. `ErrWriterInvalidName` covers malformed numeric-reference markup, EntityValue named/parameter references, DTD enumeration tokens, full DTD Names, and the NCName-only entity and notation declaration names. Each flags a DOM node that cannot be serialized into well-formed XML (`writer.go` raw-name and reference checks, `writer_dtd.go` DTD emission, and the comment/PI guards). `ErrWriterUnboundNamespacePrefix` covers an element or attribute QName whose non-empty prefix resolves to an empty namespace URI (`prefix:local` with no `xmlns:prefix` is not reparseable); the reserved `xml` prefix is exempt — it is implicitly bound to the XML namespace, so it reparses without a declaration. The original human-readable message is preserved and the sentinel appended via `fmt.Errorf("... : %w", …)`, so a caller can distinguish the failure class with `errors.Is`. `WriteTo` runs these checks in an `io.Discard` pass before it calls the supplied writer, so a validation error leaves that writer untouched; a valid second pass keeps I/O errors from that writer unchanged. Full list in `packages.md`
-- **`ErrUnsupportedNormalizationForm`** (`errors.go`) — writer sentinel returned by `Writer.WriteTo` when `Writer.Normalization` was given a value outside `{"", "none", "NFC", "NFD", "NFKC", "NFKD"}`. `Normalization` stores the raw form and defers the check to `WriteTo` (both the Document and bare-element paths), which fails closed before any output byte; an out-of-range form never silently disables normalization. Match with `errors.Is`
+- **`ErrExternalDTDTooLarge`** (`errors.go`) — sentinel returned from the `ExternalSubset` bounded read when a
+  loaded external DTD subset exceeds the byte cap (`MaxExternalDTDBytes` or default `MaxExternalDTDSize`, 10
+  MiB). Enforced against actual bytes read, never the advisory `fs.FileInfo.Size()`, and checked before any
+  read error; match with `errors.Is`
+- **`ErrInvalidOperation`** (`errors.go`) — sentinel for a DOM mutation the tree state forbids; wrapped via
+  `%w` into a descriptive message, matched with `errors.Is`. Returned by: `Document.SetDocumentElement` when
+  `root` is not an element; and `node.DeclareNamespace(prefix, uri)` / `node.AddNamespaceDecl(ns)` on an
+  ELEMENT node when `prefix` is in use by the element's own name (`n.ns`) or a NON-empty-prefix attribute at a
+  URI DIFFERENT from `uri` — a genuine prefix conflict, left unchanged (the conflict check is element-scoped:
+  a non-element node never serializes `n.ns`, so it never returns this error; this holds whether or not an
+  nsDefs entry already exists; an empty-prefix attribute is not counted, since it never uses the default
+  namespace and the serializer skips it; a same-URI use is not a conflict, a same-URI redeclare is a no-op,
+  and an unused-prefix redeclare collapses the slot, all returning nil; on that collapse `DeclareNamespace`
+  installs a fresh `Namespace` while `AddNamespaceDecl` installs the caller's object, both leaving the
+  replaced object unmodified; `AddNamespaceDecl` applies the same rule and returns the same `%w`-wrapped
+  `ErrInvalidOperation` on a conflict — a nil ns returns `ErrNilNode` instead). These methods do not reconcile
+  a conflict introduced afterward by `SetActiveNamespace`/`SetNamespace`; keeping one `xmlns:prefix` per
+  element across all mutators is a serializer-level concern.
+- **`ErrNodeContentTooLarge`** (`errors.go`) — sentinel returned when a single indivisible content run — a
+  CDATA section (`parseCDataContent`), comment body (`parseComment`), processing-instruction body (`parsePI`),
+  character-data run (`parseCharDataContent`), or attribute value (`parseAttributeValueInternal`) — exceeds
+  the byte cap (`MaxNodeContentSize` or default `DefaultMaxNodeContentSize`, 10 MiB). The cap fires DURING
+  accumulation (the loop scanners check `buf.Len()` each iteration; the char-data fast/fallback scanners pass
+  a `maxBytes` budget into `ScanCharDataSlice`/`ScanCharDataInto`; the attribute-value fast path bounds
+  `ScanSimpleAttrValue` with the same budget and re-checks the exact count, while the slow path routes every
+  write through cap-enforcing `writeAttr*` helpers and decodes entity replacements through a cap-checking
+  `attrEntitySink`) so the parse fails before the whole run is buffered. The SAME cap also bounds a single
+  contiguous run of XML whitespace: `skipBlankRun` (`parser_whitespace.go`) scans blanks in 4 KiB chunks and
+  trips this error once the run exceeds `blankRunLimit()` (= the resolved `maxNodeContent`), so an unbounded
+  whitespace run cannot grow the cursor buffer. This covers the prolog/epilogue/inter-root blank skips
+  (`skipBlanks`/`skipBlankBytes`) AND the blank skips inside the external DTD subset declaration loop and
+  INCLUDE conditional sections (`parser_dtd_subset.go`, which call `skipBlankRun` directly to preserve `%pe;`
+  expansion). `NewParser` applies the default (secure by default); `MaxNodeContentSize(-1)` resolves
+  `maxNodeContent` to `0` and disables BOTH the node-content and the blank-run cap. The streaming SAX
+  char-data path (`CharBufferSize>0`) is exempt — it is already chunked. Match with `errors.Is`
+- **`ErrInvalidOutputVersion`** (`errors.go`) — writer sentinel raised (via `isValidXMLVersion`) when the
+  effective output XML version is not a valid `VersionNum` `'1.' [0-9]+`. A non-empty `OutputVersion` override
+  is validated at the `WriteTo` entry, ahead of the node-type branch, so BOTH a Document and a bare
+  element/fragment fail on a malformed override; a Document's own version (`Document.SetVersion`, used when
+  there is no override) is validated at the `writeDoc` entry. Both checks run BEFORE any output byte (ahead of
+  the transcoding-encoder setup, whose deferred flush would emit a BOM), so a value carrying a quote (markup
+  injection into the version pseudo-attribute) or a malformed/non-`1.x` value emits nothing. Match with
+  `errors.Is`. See `packages.md` for the full serialization-parameter description
+- **`ErrElementDeclNotFound`** (`errors.go`) — sentinel returned by `Document.IsMixedElement` when neither the
+  internal nor the external subset has an element declaration for the given name (or the document has no
+  internal subset). Match with `errors.Is`
+- **`ErrUnsupportedOutputEncoding`** (`errors.go`) — writer sentinel; the `writeDoc`-entry
+  label-well-formedness case rejects a non-empty effective encoding that is not a valid `EncName`
+  (`xmlchar.IsValidEncName`) before any output byte (ahead of the transcoding encoder, so no BOM leaks;
+  guarding the encoding pseudo-attribute against markup injection), layered before the separate
+  US-ASCII/encoder-table transcoding rejects. Full description (all cases) in `packages.md`. Match with
+  `errors.Is`
+- **Writer structural-serialization sentinels** (`errors.go`) — `ErrWriterReservedElementName`,
+  `ErrWriterReservedAttributeName`, `ErrWriterReservedNamespacePrefix`, `ErrWriterInvalidElementName`,
+  `ErrWriterInvalidAttributeName`, `ErrWriterInvalidNamespacePrefix`, `ErrWriterUnboundNamespacePrefix`,
+  `ErrWriterInvalidName`, `ErrWriterInvalidComment`, `ErrWriterInvalidPITarget`, `ErrWriterInvalidPIContent`,
+  `ErrWriterInvalidDTDNode`. `ErrWriterInvalidName` covers malformed numeric-reference markup, EntityValue
+  named/parameter references, DTD enumeration tokens, full DTD Names, and the NCName-only entity and notation
+  declaration names. Each flags a DOM node that cannot be serialized into well-formed XML (`writer.go`
+  raw-name and reference checks, `writer_dtd.go` DTD emission, and the comment/PI guards).
+  `ErrWriterUnboundNamespacePrefix` covers an element or attribute QName whose non-empty prefix resolves to an
+  empty namespace URI (`prefix:local` with no `xmlns:prefix` is not reparseable); the reserved `xml` prefix is
+  exempt — it is implicitly bound to the XML namespace, so it reparses without a declaration. The original
+  human-readable message is preserved and the sentinel appended via `fmt.Errorf("... : %w", …)`, so a caller
+  can distinguish the failure class with `errors.Is`. `WriteTo` runs these checks in an `io.Discard` pass
+  before it calls the supplied writer, so a validation error leaves that writer untouched; a valid second pass
+  keeps I/O errors from that writer unchanged. Full list in `packages.md`
+- **`ErrUnsupportedNormalizationForm`** (`errors.go`) — writer sentinel returned by `Writer.WriteTo` when
+  `Writer.Normalization` was given a value outside `{"", "none", "NFC", "NFD", "NFKC", "NFKD"}`.
+  `Normalization` stores the raw form and defers the check to `WriteTo` (both the Document and bare-element
+  paths), which fails closed before any output byte; an out-of-range form never silently disables
+  normalization. Match with `errors.Is`
 
 ### DOM operation sentinels (root package, `errors.go`)
 
 `ErrNilNode`, `ErrInvalidOperation`, and `ErrCyclicNode` back the guarded tree API and are all matchable via `errors.Is`:
 
-- **`ErrNilNode`** — a nil or typed-nil node (including Go's interface nil trap, e.g. the typed-nil `*Element` `Document.DocumentElement()` returns for a rootless doc) reached `AddChild`/`AddSibling`/`Replace`/`Walk`/`CopyNode`/`ParseInNodeContext`/`SetDocumentElement`.
+- **`ErrNilNode`** — a nil or typed-nil node (including Go's interface nil trap, e.g. the typed-nil `*Element`
+  `Document.DocumentElement()` returns for a rootless doc) reached
+  `AddChild`/`AddSibling`/`Replace`/`Walk`/`CopyNode`/`ParseInNodeContext`/`SetDocumentElement`.
 - **`ErrInvalidOperation`** — an unsupported structural op: an empty `Replace()` (matching `Document.Replace`), a non-attribute sibling/replacement of a property attribute, or duplicate replacement operands.
-- **`ErrCyclicNode`** — a `wouldCreateCycle` rejection in `AddChild`/`AddSibling`/`Replace` (inserting a node into itself or a descendant, or replacing a node with an ancestor), plus the identity-checked self-add in `ProcessingInstruction.AddChild` (`pi.AddChild(pi)`); a PI given any other rejected operand — including an ancestor — wraps `ErrInvalidOperation` like the other strict leaves.
+- **`ErrCyclicNode`** — a `wouldCreateCycle` rejection in `AddChild`/`AddSibling`/`Replace` (inserting a node
+  into itself or a descendant, or replacing a node with an ancestor), plus the identity-checked self-add in
+  `ProcessingInstruction.AddChild` (`pi.AddChild(pi)`); a PI given any other rejected operand — including an
+  ancestor — wraps `ErrInvalidOperation` like the other strict leaves.
 
 The `ErrInvalidOperation`/`ErrCyclicNode` mutation sites wrap a descriptive message via `%w`, so the human text is preserved while `errors.Is` still matches.
 
@@ -64,7 +135,21 @@ Implementations:
 - **`NilErrorHandler`** — discards all errors
 - **`ErrorCollector`** — accumulates into slice via `Sink[error]`, filterable by level
 
-**Ownership & lifecycle**: a handler is retained by reference on the component it is set on (root `Parser`; `xinclude` `Processor`; `xsd`/`relaxng`/`schematron` compilers and validators; the `catalog` `Loader`) and shared across every operation run on that configured value. `xslt3` has no `ErrorHandler` of its own — it drives the `xsd` compiler's handler internally. These are immutable-value builders, so setting a handler returns a new value and leaves the original unchanged; there is no in-place replacement. A nil handler is normalized to `NilErrorHandler` (discard) at use time — never a panic. Which errors reach the handler is component-specific: the root `Parser` consults it ONLY during DTD validation (`ValidateDTD`) — well-formedness/namespace errors surface solely as `Parse`'s returned error, not through the handler; the `xinclude` `Processor` delivers non-fatal XInclude warnings (`ErrorLevelWarning`) during `Process`/`ProcessTree`. **Close ownership differs by component.** When a handler also implements `io.Closer`, the root `Parser` (after each DTD-validating `Parse`) and the `xsd`/`relaxng`/`schematron` compilers and validators (after each `Compile`/`Validate`) close it once by calling `closeHandler` at the end of that operation, so a `Closer` handler should not be shared across those operations. The `catalog` `Loader` and the `xinclude` `Processor` do NOT close the handler — they retain it (the `Loader` for lazy delegate/`nextCatalog` loads) and the caller owns its lifecycle, closing it once the resulting value is no longer in use.
+**Ownership & lifecycle**: a handler is retained by reference on the component it is set on (root `Parser`;
+`xinclude` `Processor`; `xsd`/`relaxng`/`schematron` compilers and validators; the `catalog` `Loader`) and
+shared across every operation run on that configured value. `xslt3` has no `ErrorHandler` of its own — it
+drives the `xsd` compiler's handler internally. These are immutable-value builders, so setting a handler
+returns a new value and leaves the original unchanged; there is no in-place replacement. A nil handler is
+normalized to `NilErrorHandler` (discard) at use time — never a panic. Which errors reach the handler is
+component-specific: the root `Parser` consults it ONLY during DTD validation (`ValidateDTD`) —
+well-formedness/namespace errors surface solely as `Parse`'s returned error, not through the handler; the
+`xinclude` `Processor` delivers non-fatal XInclude warnings (`ErrorLevelWarning`) during
+`Process`/`ProcessTree`. **Close ownership differs by component.** When a handler also implements `io.Closer`,
+the root `Parser` (after each DTD-validating `Parse`) and the `xsd`/`relaxng`/`schematron` compilers and
+validators (after each `Compile`/`Validate`) close it once by calling `closeHandler` at the end of that
+operation, so a `Closer` handler should not be shared across those operations. The `catalog` `Loader` and the
+`xinclude` `Processor` do NOT close the handler — they retain it (the `Loader` for lazy delegate/`nextCatalog`
+loads) and the caller owns its lifecycle, closing it once the resulting value is no longer in use.
 
 ## Package-Specific Error Formatting
 
@@ -112,12 +197,42 @@ Context extraction matches libxml2's `xmlParserInputGetWindow`: skip-eol, walk b
 
 #### HTML sentinel errors (`html/sax.go`)
 
-- **`ErrContentSizeExceeded`** (exported) — returned from `parse()` when an over-cap construct blows a hard cap. Wrapped with a descriptive prefix via `fmt.Errorf("... : %w", ErrContentSizeExceeded)`; callers match with `errors.Is`. The error reaches `parse()`'s caller via one of two surfacing paths, both checked at the top of (and after) the main loop: a sub-parser sets `parser.fatalErr` for an in-band content/structural overrun, OR — on the streaming `ParseReader`/push path — the over-cap deferred-encoding reader sets a sticky `capErr` whose bytes propagate up the cursor as `p.cur.Err()`. Returned in these cases:
-  - A comment, bogus comment, or PI (`parseComment`/`parseBogusComment`/`parsePI`) that exceeds `MaxContentSize` before reaching its terminator. These map to a single indivisible SAX event / DOM node, so they cannot be chunked — a hard cap, not a soft chunk size. (Sets `parser.fatalErr`.)
-  - An over-cap UNRESOLVED named-reference literal in normal data-state text OR the RCDATA path (`parseCharRefBounded`/`parseSaturatedCharRefLiteral`): ANY `"&"`-prefixed run that does not resolve to a known entity or legacy prefix, once the literal bytes it would emit (`"&"` + name + optional `";"`) exceed the cap — whether short, semicolon-terminated, or unbounded. Also an over-cap SATURATED ambiguous legacy-prefix run (`&amp` + a tail overflowing the 32-byte lookahead): it is consumed into a cap-bounded spool and hard-fails (emitting nothing) if the run exceeds the cap before its end is reached, because the resolve-vs-literal decision can only be made at the run's end. A SHORT resolvable reference whose run fits the cap is exempt: it is resolved to its value and never charged. (Sets `parser.fatalErr`.)
-  - An over-cap leading-whitespace deferral (`deferPendingWS`) or an over-cap attribute value (`parseQuotedAttrValue`/`parseUnquotedAttrValue`, enforced per byte and covering `&`-led entity and `&#`-led numeric runs) before its significance/terminator is known. (Sets `parser.fatalErr`.)
-  - An over-cap indivisible STRUCTURAL token scan — a tag name (`parseName`), end-tag name, attribute name, PUBLIC/SYSTEM DOCTYPE literal (`parseQuotedString`), or intra-tag whitespace run (`skipWhitespace`). Bounded by the `scanTokenLimit` STRUCTURAL cap, NOT `MaxContentSize`: it is FLOORED at the 16 MiB default (so a tiny `MaxContentSize` never rejects ordinary names like `script`) and grows only when `MaxContentSize` is raised above the floor. `parseStartTag`/`parseEndTag`/`parseDoctype` check `fatalErr` after EACH scanner (skipWhitespace/parseName/parseQuotedString) so an over-cap run on a streaming reader stalled at the boundary surfaces the fatal promptly — returning before any text-fallback drain — instead of issuing another blocking read. (Sets `parser.fatalErr`.)
-  - An UNDECLARED-charset stream (`ParseReader`/push only) whose bytes stay valid UTF-8 past `MaxContentSize` (16 MiB default) without ever revealing their encoding (`html/encoding_reader.go` `deferredLatin1Reader.decide`): the encoding decision cannot be made within the memory bound — a later non-UTF-8 byte would flip the whole document to Windows-1252, EOF would keep it UTF-8 — so the reader fails closed instead of committing to one interpretation. This is NOT routed through `parser.fatalErr`; the reader stores a sticky `capErr` (`fmt.Errorf("... %w", ErrContentSizeExceeded)`) returned from its `Read`, which surfaces as `p.cur.Err()`. A declared-charset stream (incl. declared Latin-1, which `Parse([]byte)` and `ParseReader` decode identically) or one that settles below the cap is unaffected.
+- **`ErrContentSizeExceeded`** (exported) — returned from `parse()` when an over-cap construct blows a hard
+  cap. Wrapped with a descriptive prefix via `fmt.Errorf("... : %w", ErrContentSizeExceeded)`; callers match
+  with `errors.Is`. The error reaches `parse()`'s caller via one of two surfacing paths, both checked at the
+  top of (and after) the main loop: a sub-parser sets `parser.fatalErr` for an in-band content/structural
+  overrun, OR — on the streaming `ParseReader`/push path — the over-cap deferred-encoding reader sets a sticky
+  `capErr` whose bytes propagate up the cursor as `p.cur.Err()`. Returned in these cases:
+  - A comment, bogus comment, or PI (`parseComment`/`parseBogusComment`/`parsePI`) that exceeds
+    `MaxContentSize` before reaching its terminator. These map to a single indivisible SAX event / DOM node,
+    so they cannot be chunked — a hard cap, not a soft chunk size. (Sets `parser.fatalErr`.)
+  - An over-cap UNRESOLVED named-reference literal in normal data-state text OR the RCDATA path
+    (`parseCharRefBounded`/`parseSaturatedCharRefLiteral`): ANY `"&"`-prefixed run that does not resolve to a
+    known entity or legacy prefix, once the literal bytes it would emit (`"&"` + name + optional `";"`) exceed
+    the cap — whether short, semicolon-terminated, or unbounded. Also an over-cap SATURATED ambiguous
+    legacy-prefix run (`&amp` + a tail overflowing the 32-byte lookahead): it is consumed into a cap-bounded
+    spool and hard-fails (emitting nothing) if the run exceeds the cap before its end is reached, because the
+    resolve-vs-literal decision can only be made at the run's end. A SHORT resolvable reference whose run fits
+    the cap is exempt: it is resolved to its value and never charged. (Sets `parser.fatalErr`.)
+  - An over-cap leading-whitespace deferral (`deferPendingWS`) or an over-cap attribute value
+    (`parseQuotedAttrValue`/`parseUnquotedAttrValue`, enforced per byte and covering `&`-led entity and
+    `&#`-led numeric runs) before its significance/terminator is known. (Sets `parser.fatalErr`.)
+  - An over-cap indivisible STRUCTURAL token scan — a tag name (`parseName`), end-tag name, attribute name,
+    PUBLIC/SYSTEM DOCTYPE literal (`parseQuotedString`), or intra-tag whitespace run (`skipWhitespace`).
+    Bounded by the `scanTokenLimit` STRUCTURAL cap, NOT `MaxContentSize`: it is FLOORED at the 16 MiB default
+    (so a tiny `MaxContentSize` never rejects ordinary names like `script`) and grows only when
+    `MaxContentSize` is raised above the floor. `parseStartTag`/`parseEndTag`/`parseDoctype` check `fatalErr`
+    after EACH scanner (skipWhitespace/parseName/parseQuotedString) so an over-cap run on a streaming reader
+    stalled at the boundary surfaces the fatal promptly — returning before any text-fallback drain — instead
+    of issuing another blocking read. (Sets `parser.fatalErr`.)
+  - An UNDECLARED-charset stream (`ParseReader`/push only) whose bytes stay valid UTF-8 past `MaxContentSize`
+    (16 MiB default) without ever revealing their encoding (`html/encoding_reader.go`
+    `deferredLatin1Reader.decide`): the encoding decision cannot be made within the memory bound — a later
+    non-UTF-8 byte would flip the whole document to Windows-1252, EOF would keep it UTF-8 — so the reader
+    fails closed instead of committing to one interpretation. This is NOT routed through `parser.fatalErr`;
+    the reader stores a sticky `capErr` (`fmt.Errorf("... %w", ErrContentSizeExceeded)`) returned from its
+    `Read`, which surfaces as `p.cur.Err()`. A declared-charset stream (incl. declared Latin-1, which
+    `Parse([]byte)` and `ParseReader` decode identically) or one that settles below the cap is unaffected.
 - **`ErrHandlerUnspecified`** (exported) — returned by a `SAXCallbacks` method whose handler is unset (see SAX-callback error routing below; filtered by `handleSAXErr`, never fatal).
 
 #### HTML SAX-callback error routing (`html/parser.go`)
@@ -169,34 +284,114 @@ matches any joined sentinel (see `dynamicErrorCause`).
 
 ### XML Digital Signatures (`xmldsig1/errors.go`)
 
-Per-reference failures use parallel wrapper types so sign and verify report the offending Reference symmetrically. Both hold `Reference int` (0-based index), `URI string`, `Err error`, and `Unwrap()` to the cause so sentinels (`ErrReferenceNotFound`, `ErrUnsupportedTransform`, `ErrDigestMismatch`, …) stay `errors.Is`/`errors.As`-reachable through the wrapper.
+Per-reference failures use parallel wrapper types so sign and verify report the offending Reference
+symmetrically. Both hold `Reference int` (0-based index), `URI string`, `Err error`, and `Unwrap()` to the
+cause so sentinels (`ErrReferenceNotFound`, `ErrUnsupportedTransform`, `ErrDigestMismatch`, …) stay
+`errors.Is`/`errors.As`-reachable through the wrapper.
 
-- `ReferenceError` (signing): adds `Op string` (`"sign"`). Format: `xmldsig1: sign reference N ("URI") failed: <cause>`. Wrapped both in the `processReference` loops of `signEnveloped`/`signEnveloping`/`signDetached` and in the pre-mutation `preflightSignerTransforms` transform-pipeline validation (`transforms.go`), so a rejected pipeline still names its Reference.
+- `ReferenceError` (signing): adds `Op string` (`"sign"`). Format: `xmldsig1: sign reference N ("URI") failed:
+  <cause>`. Wrapped both in the `processReference` loops of `signEnveloped`/`signEnveloping`/`signDetached`
+  and in the pre-mutation `preflightSignerTransforms` transform-pipeline validation (`transforms.go`), so a
+  rejected pipeline still names its Reference.
 - `VerificationError` (verification): `Reference == -1` marks a SignatureValue failure (`xmldsig1: signature value verification failed: <cause>`); otherwise `xmldsig1: reference N ("URI") verification failed: <cause>`.
 
-External-reference resolution sentinels (`errors.go`, `reference_resolver.go`): `ErrReferenceNotFound` is the fail-closed default for an external Reference with no configured `ReferenceResolver`, AND every `FSReferenceResolver` rejection short of the size cap — a scheme URI, a path escaping the root, a leftover fragment, a missing file, and an unparseable external XML resource. `ErrReferenceTooLarge` is returned when an external resource exceeds the resolver's 64 MiB cap. Both wrap via `%w` and are matchable with `errors.Is`. A per-reference external failure still surfaces through `VerificationError` (verify) / `ReferenceError` (sign) with the sentinel reachable via `Unwrap`.
+External-reference resolution sentinels (`errors.go`, `reference_resolver.go`): `ErrReferenceNotFound` is the
+fail-closed default for an external Reference with no configured `ReferenceResolver`, AND every
+`FSReferenceResolver` rejection short of the size cap — a scheme URI, a path escaping the root, a leftover
+fragment, a missing file, and an unparseable external XML resource. `ErrReferenceTooLarge` is returned when an
+external resource exceeds the resolver's 64 MiB cap. Both wrap via `%w` and are matchable with `errors.Is`. A
+per-reference external failure still surfaces through `VerificationError` (verify) / `ReferenceError` (sign)
+with the sentinel reachable via `Unwrap`.
 
-Ordered-transform diagnostics (`transform_pipeline.go` `executeTransformPipeline`) identify the zero-based transform index + algorithm. Static algorithm/parameter/capability failures wrap `ErrUnsupportedTransform` before execution. A first required parse of resolver-supplied octets wraps `ErrReferenceNotFound`; a parse of intermediate transform output wraps `ErrUnsupportedTransform` and names both producer + consumer steps. Invalid Base64 wraps `ErrInvalidSignature`. Context and injected-XSLT errors return unchanged.
+Ordered-transform diagnostics (`transform_pipeline.go` `executeTransformPipeline`) identify the zero-based
+transform index + algorithm. Static algorithm/parameter/capability failures wrap `ErrUnsupportedTransform`
+before execution. A first required parse of resolver-supplied octets wraps `ErrReferenceNotFound`; a parse of
+intermediate transform output wraps `ErrUnsupportedTransform` and names both producer + consumer steps.
+Invalid Base64 wraps `ErrInvalidSignature`. Context and injected-XSLT errors return unchanged.
 
 A RetrievalMethod transform list exceeding `maxRetrievalTransformSteps` wraps `ErrResourceLimitExceeded` before URI dereference, transform execution, or key resolution.
 
 ### XML Encryption (`xmlenc1/errors.go`)
 
-`ErrCipherValueBytesExceeded` is returned when an EncryptedData payload exceeds `Decryptor.MaxCipherValueBytes` (default `DefaultMaxCipherValueBytes`, 10 MiB). The parser charges decoded payload bytes before base64 assembly or block decryption, so text or CDATA splitting cannot bypass the limit. Match it with `errors.Is`.
+`ErrCipherValueBytesExceeded` is returned when an EncryptedData payload exceeds
+`Decryptor.MaxCipherValueBytes` (default `DefaultMaxCipherValueBytes`, 10 MiB). The parser charges decoded
+payload bytes before base64 assembly or block decryption, so text or CDATA splitting cannot bypass the limit.
+Match it with `errors.Is`.
 
-`ErrReferenceNotFound` and `ErrAmbiguousReference` are the two reference-resolution sentinels (`reference.go` `resolveSameDocument`), shared by `ds:RetrievalMethod` and `xenc:CipherReference`. `ErrAmbiguousReference` covers a same-document URI matching MORE than one element: resolution collects every match and refuses on a duplicate. Taking the first would let an injected duplicate `Id` choose which key the recipient unwraps or which octets it decrypts (XML Signature Wrapping applied to encryption). `ErrReferenceNotFound` covers a same-document URI matching no element, plus a URI that is not one of the four same-document forms at all — and the two constructs differ there: a non-same-document `ds:RetrievalMethod` URI is refused with NO setting that lifts it (xmlenc-core1 §3.5 mandates only the same-document form, and an external key location steers which key material the recipient trial-decrypts), while a non-same-document `xenc:CipherReference` URI is refused only until the caller sets `Decryptor.CipherReferenceResolver` (§3.3.1 imports xmldsig-core1's model, where §4.4.3.1 makes HTTP dereferencing RECOMMENDED and §4.4.3.2/§4.4.3.3 make the same-document forms MUSTs). `FSReferenceResolver` (`reference_resolver.go`) also wraps `ErrReferenceNotFound` for every URI shape it refuses — a scheme, a fragment, a root escape — and for a resource it cannot open or read. Both sentinels wrap via `%w` and are matched with `errors.Is`. They are raised while the document is READ, so they precede block-algorithm resolution, the AES-CBC opt-in gate, and the `Decryptor.SessionKey` early return: a pre-shared session key does not decrypt past a refused reference. A `ds:RetrievalMethod` whose `Type` this package does not implement is stepped over before any URI is looked at and so reaches neither sentinel; a `Type` of `TypeEncryptedKey` that resolves to a non-`EncryptedKey` element is `ErrMalformedEncrypted`, not a reference error.
+`ErrReferenceNotFound` and `ErrAmbiguousReference` are the two reference-resolution sentinels (`reference.go`
+`resolveSameDocument`), shared by `ds:RetrievalMethod` and `xenc:CipherReference`. `ErrAmbiguousReference`
+covers a same-document URI matching MORE than one element: resolution collects every match and refuses on a
+duplicate. Taking the first would let an injected duplicate `Id` choose which key the recipient unwraps or
+which octets it decrypts (XML Signature Wrapping applied to encryption). `ErrReferenceNotFound` covers a
+same-document URI matching no element, plus a URI that is not one of the four same-document forms at all — and
+the two constructs differ there: a non-same-document `ds:RetrievalMethod` URI is refused with NO setting that
+lifts it (xmlenc-core1 §3.5 mandates only the same-document form, and an external key location steers which
+key material the recipient trial-decrypts), while a non-same-document `xenc:CipherReference` URI is refused
+only until the caller sets `Decryptor.CipherReferenceResolver` (§3.3.1 imports xmldsig-core1's model, where
+§4.4.3.1 makes HTTP dereferencing RECOMMENDED and §4.4.3.2/§4.4.3.3 make the same-document forms MUSTs).
+`FSReferenceResolver` (`reference_resolver.go`) also wraps `ErrReferenceNotFound` for every URI shape it
+refuses — a scheme, a fragment, a root escape — and for a resource it cannot open or read. Both sentinels wrap
+via `%w` and are matched with `errors.Is`. They are raised while the document is READ, so they precede
+block-algorithm resolution, the AES-CBC opt-in gate, and the `Decryptor.SessionKey` early return: a pre-shared
+session key does not decrypt past a refused reference. A `ds:RetrievalMethod` whose `Type` this package does
+not implement is stepped over before any URI is looked at and so reaches neither sentinel; a `Type` of
+`TypeEncryptedKey` that resolves to a non-`EncryptedKey` element is `ErrMalformedEncrypted`, not a reference
+error.
 
-A `xenc:CipherReference` refused for its SHAPE, not for its target, is `ErrMalformedEncrypted`: an absent `@URI` (a present-and-empty one is the valid null URI, not this error), a second `xenc:Transforms`, a transform list over `maxCipherReferenceTransforms`, and a declared `ds:Transform` algorithm other than `NamespaceDSig + "base64"` — that last one wrapping an `*UnsupportedAlgorithmError` whose `Parameter` is `paramCipherReferenceTransform`, so `errors.As` recovers the refused URI. Every algorithm in the list is validated before any is executed. An over-budget resolution is the budget's own sentinel, not a reference error: `ErrCipherValueBytesExceeded` for a payload reference and `ErrEncryptedKeyBytesExceeded` for an `EncryptedKey` one, raised by the `budgetWriter` mid-canonicalization or by charging what a resolver returned.
+A `xenc:CipherReference` refused for its SHAPE, not for its target, is `ErrMalformedEncrypted`: an absent
+`@URI` (a present-and-empty one is the valid null URI, not this error), a second `xenc:Transforms`, a
+transform list over `maxCipherReferenceTransforms`, and a declared `ds:Transform` algorithm other than
+`NamespaceDSig + "base64"` — that last one wrapping an `*UnsupportedAlgorithmError` whose `Parameter` is
+`paramCipherReferenceTransform`, so `errors.As` recovers the refused URI. Every algorithm in the list is
+validated before any is executed. An over-budget resolution is the budget's own sentinel, not a reference
+error: `ErrCipherValueBytesExceeded` for a payload reference and `ErrEncryptedKeyBytesExceeded` for an
+`EncryptedKey` one, raised by the `budgetWriter` mid-canonicalization or by charging what a resolver returned.
 
-`ErrUnsupportedKeyDerivation` is the refusal of an `EncryptedData` that offers its session key ONLY through an `xenc11:DerivedKey` (xmlenc-core1 §3.5.2), which asks the recipient to derive the content key from master key material it already holds. `noCandidateError` (`xmlenc1.go`) is the single wording site: it is reached from the empty-candidate branch of both decrypt terminals, and picks this sentinel over `ErrMissingKey` when `encryptedData.offersDerivedKey` is set. `parseKeyInfoForEncryption` sets that flag for an inline `xenc11:DerivedKey` child and `parseRetrievalMethod` for a `ds:RetrievalMethod` whose `@Type` is `typeDerivedKey`; neither reads the construct any further. The split matters because the two errors ask different things of the caller: `ErrMissingKey` says supply a key, which no caller can act on here, while this names the facility the package lacks. A document ALSO carrying a usable `xenc:EncryptedKey` decrypts under it, and a pre-shared `Decryptor.SessionKey` returns before key resolution runs, so neither reaches the sentinel.
+`ErrUnsupportedKeyDerivation` is the refusal of an `EncryptedData` that offers its session key ONLY through an
+`xenc11:DerivedKey` (xmlenc-core1 §3.5.2), which asks the recipient to derive the content key from master key
+material it already holds. `noCandidateError` (`xmlenc1.go`) is the single wording site: it is reached from
+the empty-candidate branch of both decrypt terminals, and picks this sentinel over `ErrMissingKey` when
+`encryptedData.offersDerivedKey` is set. `parseKeyInfoForEncryption` sets that flag for an inline
+`xenc11:DerivedKey` child and `parseRetrievalMethod` for a `ds:RetrievalMethod` whose `@Type` is
+`typeDerivedKey`; neither reads the construct any further. The split matters because the two errors ask
+different things of the caller: `ErrMissingKey` says supply a key, which no caller can act on here, while this
+names the facility the package lacks. A document ALSO carrying a usable `xenc:EncryptedKey` decrypts under it,
+and a pre-shared `Decryptor.SessionKey` returns before key resolution runs, so neither reaches the sentinel.
 
-`ErrOpaquePayload` is `Decryptor.Decrypt`'s refusal of an `EncryptedData` whose `@Type` declares no XML content — absent, empty, or any URI other than `TypeElement`/`TypeContent`. `decryptElement`'s `@Type` switch raises it through `opaqueTypeError` (`xmlenc1.go`), which has one form for the absent case and one naming the refused URI, both pointing the caller at `Decryptor.DecryptBytes`; that terminal never returns the sentinel, since it does not read `@Type`. The switch sits ahead of block-algorithm resolution, the CBC opt-in gate, and the `Decryptor.SessionKey` early return. It is deliberately NOT `ErrMalformedEncrypted`: such a document is well-formed, and a caller must be able to tell "retry with `DecryptBytes`" from a document to reject outright. `@Type` sits outside the ciphertext and no block algorithm authenticates it, so parsing an absent or unrecognized value as `TypeElement` would let a stripped attribute turn an authenticated opaque octet stream into nodes a caller may graft into its tree (xmlenc-core1 §4.2, §3.1). Match with `errors.Is`.
+`ErrOpaquePayload` is `Decryptor.Decrypt`'s refusal of an `EncryptedData` whose `@Type` declares no XML
+content — absent, empty, or any URI other than `TypeElement`/`TypeContent`. `decryptElement`'s `@Type` switch
+raises it through `opaqueTypeError` (`xmlenc1.go`), which has one form for the absent case and one naming the
+refused URI, both pointing the caller at `Decryptor.DecryptBytes`; that terminal never returns the sentinel,
+since it does not read `@Type`. The switch sits ahead of block-algorithm resolution, the CBC opt-in gate, and
+the `Decryptor.SessionKey` early return. It is deliberately NOT `ErrMalformedEncrypted`: such a document is
+well-formed, and a caller must be able to tell "retry with `DecryptBytes`" from a document to reject outright.
+`@Type` sits outside the ciphertext and no block algorithm authenticates it, so parsing an absent or
+unrecognized value as `TypeElement` would let a stripped attribute turn an authenticated opaque octet stream
+into nodes a caller may graft into its tree (xmlenc-core1 §4.2, §3.1). Match with `errors.Is`.
 
-Block encryption and decryption failures wrap `ErrEncryptionFailed` or `ErrDecryptionFailed` as appropriate. Unsupported block-algorithm URI failures preserve `*UnsupportedAlgorithmError` in the chain, so callers can match the operation sentinel with `errors.Is` and inspect the algorithm with `errors.As`. Both `*UnsupportedAlgorithmError` and `*KeySizeError` carry a leading blank `_ struct{}` field so an unkeyed composite literal cannot compile from another package, which is what lets either field set grow without breaking a caller; keyed construction and `errors.As` recovery are unaffected.
+Block encryption and decryption failures wrap `ErrEncryptionFailed` or `ErrDecryptionFailed` as appropriate.
+Unsupported block-algorithm URI failures preserve `*UnsupportedAlgorithmError` in the chain, so callers can
+match the operation sentinel with `errors.Is` and inspect the algorithm with `errors.As`. Both
+`*UnsupportedAlgorithmError` and `*KeySizeError` carry a leading blank `_ struct{}` field so an unkeyed
+composite literal cannot compile from another package, which is what lets either field set grow without
+breaking a caller; keyed construction and `errors.As` recovery are unaffected.
 
-A nil operand handed to an encrypt terminal wraps BOTH sentinels with `%w`, `ErrEncryptionFailed` first and `helium.ErrNilNode` under it, identically across `EncryptBytes`, `EncryptElement`, and `EncryptContent`. A caller matching the operation sentinel therefore gets the same answer whichever entry point it called, and one matching `ErrNilNode` still learns the operand was nil.
+A nil operand handed to an encrypt terminal wraps BOTH sentinels with `%w`, `ErrEncryptionFailed` first and
+`helium.ErrNilNode` under it, identically across `EncryptBytes`, `EncryptElement`, and `EncryptContent`. A
+caller matching the operation sentinel therefore gets the same answer whichever entry point it called, and one
+matching `ErrNilNode` still learns the operand was nil.
 
-A key-size mismatch (`*KeySizeError`) is bare (no operation sentinel in its chain) only when the key came directly from caller configuration and its length is therefore neither attacker- nor document-influenced: encryption's pre-block `SessionKey` check, and decryption's `Decryptor.SessionKey` check (`decryptElement`/`decryptBytes`), both run before any ciphertext is touched and return `*KeySizeError` unwrapped. Every other decrypt-side key-size mismatch is wrapped in `ErrDecryptionFailed` — reachable via `errors.Is` on the wrapped error, with `*KeySizeError` still reachable via `errors.As` and its message text unchanged — because the length involved is not caller configuration: an RSA-key-transported or AES-key-unwrapped session key can be any length an attacker chooses (the recipient's public key is public), and the KEK-length check ahead of AES key unwrap (`resolveSessionKeyFromEncryptedKey`) is evaluated against a document-declared key-wrap algorithm URI, so an unwrapped error there would disclose the length of the recipient's own configured `KeyEncryptionKey`.
+A key-size mismatch (`*KeySizeError`) is bare (no operation sentinel in its chain) only when the key came
+directly from caller configuration and its length is therefore neither attacker- nor document-influenced:
+encryption's pre-block `SessionKey` check, and decryption's `Decryptor.SessionKey` check
+(`decryptElement`/`decryptBytes`), both run before any ciphertext is touched and return `*KeySizeError`
+unwrapped. Every other decrypt-side key-size mismatch is wrapped in `ErrDecryptionFailed` — reachable via
+`errors.Is` on the wrapped error, with `*KeySizeError` still reachable via `errors.As` and its message text
+unchanged — because the length involved is not caller configuration: an RSA-key-transported or
+AES-key-unwrapped session key can be any length an attacker chooses (the recipient's public key is public),
+and the KEK-length check ahead of AES key unwrap (`resolveSessionKeyFromEncryptedKey`) is evaluated against a
+document-declared key-wrap algorithm URI, so an unwrapped error there would disclose the length of the
+recipient's own configured `KeyEncryptionKey`.
 
 ## Error Accumulation Pattern
 
@@ -204,9 +399,16 @@ A key-size mismatch (`*KeySizeError`) is bare (no operation sentinel in its chai
 
 All validation errors flow through `ErrorHandler.Handle()`. No `strings.Builder` accumulation.
 
-- `Compile()` / `CompileFile()` return `(nil, ErrCompilationFailed)` when the schema has one or more fatal diagnostics (`compileSchema` converts `c.errorCount > 0` into the sentinel after linking); the individual diagnostics are still delivered to the `ErrorHandler`. A well-formed schema returns `(schema, nil)`. This prevents callers from validating against an invalid schema. `xslt3` schema-awareness maps the sentinel to `XTSE0220`.
+- `Compile()` / `CompileFile()` return `(nil, ErrCompilationFailed)` when the schema has one or more fatal
+  diagnostics (`compileSchema` converts `c.errorCount > 0` into the sentinel after linking); the individual
+  diagnostics are still delivered to the `ErrorHandler`. A well-formed schema returns `(schema, nil)`. This
+  prevents callers from validating against an invalid schema. `xslt3` schema-awareness maps the sentinel to
+  `XTSE0220`.
 - `Validate()` returns `ErrValidationFailed` when the document is invalid; individual errors go to `ErrorHandler`
-- `Validate()` returns `ErrNilSchema` (Validator has no compiled schema) or `ErrNilDocument` (doc is nil) before touching the document, instead of panicking. Handler setup runs first and `closeHandler()` is deferred, so a closable `ErrorHandler` is closed on every exit path (including the nil guards); a nil `ctx` is normalized to `context.Background()` at entry
+- `Validate()` returns `ErrNilSchema` (Validator has no compiled schema) or `ErrNilDocument` (doc is nil)
+  before touching the document, instead of panicking. Handler setup runs first and `closeHandler()` is
+  deferred, so a closable `ErrorHandler` is closed on every exit path (including the nil guards); a nil `ctx`
+  is normalized to `context.Background()` at entry
 - Errors sent to the handler are `*xsd.ValidationError` (extractable via `errors.As`) wrapped with an `ErrorLeveler` for transport. `ValidationError` fields: `Filename`, `Line`, `Element`, `AttributeName` (empty for element-level errors), `Message`.
 - `reportValidityError` / `reportValidityErrorAttr` on `validationContext` check `suppressDepth > 0` to suppress errors during union member trials
 
@@ -220,9 +422,27 @@ All validation errors flow through `ErrorHandler.Handle()`. No `strings.Builder`
 
 ### DTD
 
-`Parse()` with `ValidateDTD(true)` returns `ErrDTDValidationFailed` sentinel on failure, or `ErrNoDTDFound` when the document has neither an internal nor an external subset (VC: Element Declared, XML §3.2; libxml2 `XML_DTD_NO_DTD` "no DTD found!"). `ErrNoDTDFound` is declared as `fmt.Errorf("%w: no DTD found", ErrDTDValidationFailed)`, so `errors.Is` matches BOTH sentinels: a caller checking only `ErrDTDValidationFailed` is unaffected, while one that needs to tell "no DTD to validate against" apart from "document violates its DTD" matches `ErrNoDTDFound`. The distinction is otherwise only visible through the `ErrorHandler`, which defaults to discarding diagnostics. Individual errors go to the parser's `ErrorHandler` as `*DTDValidationError` (`valid.go`), delivered by `validCtx.addf`. `DTDValidationError{Message, Level}` implements `ErrorLeveler` returning `ErrorLevelError`, so a level-filtered `ErrorCollector` classifies each diagnostic at its true severity (not the plain-error warning default); callers recover it via `errors.As`. `.Error()` returns `Message`, which is byte-identical to the old `fmt.Errorf` text (golden/error-string parity).
+`Parse()` with `ValidateDTD(true)` returns `ErrDTDValidationFailed` sentinel on failure, or `ErrNoDTDFound`
+when the document has neither an internal nor an external subset (VC: Element Declared, XML §3.2; libxml2
+`XML_DTD_NO_DTD` "no DTD found!"). `ErrNoDTDFound` is declared as `fmt.Errorf("%w: no DTD found",
+ErrDTDValidationFailed)`, so `errors.Is` matches BOTH sentinels: a caller checking only
+`ErrDTDValidationFailed` is unaffected, while one that needs to tell "no DTD to validate against" apart from
+"document violates its DTD" matches `ErrNoDTDFound`. The distinction is otherwise only visible through the
+`ErrorHandler`, which defaults to discarding diagnostics. Individual errors go to the parser's `ErrorHandler`
+as `*DTDValidationError` (`valid.go`), delivered by `validCtx.addf`. `DTDValidationError{Message, Level}`
+implements `ErrorLeveler` returning `ErrorLevelError`, so a level-filtered `ErrorCollector` classifies each
+diagnostic at its true severity (not the plain-error warning default); callers recover it via `errors.As`.
+`.Error()` returns `Message`, which is byte-identical to the old `fmt.Errorf` text (golden/error-string
+parity).
 
-DTD-construction sites expose matchable sentinels (`errors.go`): `ErrNoInternalSubset` (`Document.InternalSubset()` when the document has no internal subset), `ErrDuplicateDeclaration` (a second `AddElementDecl`/`AddNotation`/`AddAttributeDecl` for an already-declared element, notation, or `(element, attribute)` pair — wrapped via `%w` into a message naming the kind and name), and `ErrInvalidArgument` (a public builder given an out-of-range enum argument — e.g. an `AddAttributeDecl` attribute type or default kind that is not a defined enum value — or a colon in an `AddNotation` notation name, the one name-grammar rule these caller-trusting builders enforce because a notation name is an XML NCName and the parser rejects a colon-bearing `<!NOTATION>` name). Match with `errors.Is`.
+DTD-construction sites expose matchable sentinels (`errors.go`): `ErrNoInternalSubset`
+(`Document.InternalSubset()` when the document has no internal subset), `ErrDuplicateDeclaration` (a second
+`AddElementDecl`/`AddNotation`/`AddAttributeDecl` for an already-declared element, notation, or `(element,
+attribute)` pair — wrapped via `%w` into a message naming the kind and name), and `ErrInvalidArgument` (a
+public builder given an out-of-range enum argument — e.g. an `AddAttributeDecl` attribute type or default kind
+that is not a defined enum value — or a colon in an `AddNotation` notation name, the one name-grammar rule
+these caller-trusting builders enforce because a notation name is an XML NCName and the parser rejects a
+colon-bearing `<!NOTATION>` name). Match with `errors.Is`.
 
 XSD, RelaxNG, Schematron, and DTD all use sentinel error + ErrorHandler pattern.
 

--- a/.claude/docs/helium-command.md
+++ b/.claude/docs/helium-command.md
@@ -66,15 +66,29 @@ Primary file: `internal/cli/heliumcmd/lint.go`
 
 File output (`--output`/`-o`, not stdout and not `--noout`) is written through a write-to-temp-then-atomic-rename scheme (`pendingOutput` in `safety.go`):
 
-- A temp file (`.helium-out-*`) is created (via `os.OpenFile` with `O_CREATE|O_EXCL`, mode `0666` so the kernel applies umask) in the SAME directory as the target; output is written there, and `os.Rename`d onto the target ONLY after all inputs are processed successfully.
-- When the target is a symlink, the rename target is the resolved real file (`os.Lstat` + `resolveSymlinkTarget`, which follows the chain with `os.Readlink` so even a DANGLING link resolves to its would-be target, where `filepath.EvalSymlinks` would fail), so output is written THROUGH the link (matching `os.Create`) instead of replacing the link with a regular file.
-- If the resolved target already exists, `newPendingOutput` requires it to be a regular, writable file (probed via `os.Stat` + `os.OpenFile(O_WRONLY)`) before proceeding; a read-only (`0444`) or non-regular target is rejected with `ExitErr` and left untouched, since `os.Rename` would otherwise replace it regardless of mode and exit 0.
-- This closes a truncate-before-read hole: `os.Create` on the target would truncate it up front, destroying a resource the same path is read from LATER — e.g. a DTD/entity resolved via `--path` during validation (lint), or a stylesheet read at transform time via `fn:transform(map{'stylesheet-location':...})` through the retained `URIResolver` (xslt).
+- A temp file (`.helium-out-*`) is created (via `os.OpenFile` with `O_CREATE|O_EXCL`, mode `0666` so the
+  kernel applies umask) in the SAME directory as the target; output is written there, and `os.Rename`d onto
+  the target ONLY after all inputs are processed successfully.
+- When the target is a symlink, the rename target is the resolved real file (`os.Lstat` +
+  `resolveSymlinkTarget`, which follows the chain with `os.Readlink` so even a DANGLING link resolves to its
+  would-be target, where `filepath.EvalSymlinks` would fail), so output is written THROUGH the link (matching
+  `os.Create`) instead of replacing the link with a regular file.
+- If the resolved target already exists, `newPendingOutput` requires it to be a regular, writable file (probed
+  via `os.Stat` + `os.OpenFile(O_WRONLY)`) before proceeding; a read-only (`0444`) or non-regular target is
+  rejected with `ExitErr` and left untouched, since `os.Rename` would otherwise replace it regardless of mode
+  and exit 0.
+- This closes a truncate-before-read hole: `os.Create` on the target would truncate it up front, destroying a
+  resource the same path is read from LATER — e.g. a DTD/entity resolved via `--path` during validation
+  (lint), or a stylesheet read at transform time via `fn:transform(map{'stylesheet-location':...})` through
+  the retained `URIResolver` (xslt).
 - On any non-OK exit code the temp file is removed (`Cleanup`) and the target is left untouched.
 - A failed commit (flush/close/rename) folds `ExitErr` into the exit status, so an incomplete write is never reported as success.
 - The pre-flight same-file rejection (`checkOutputCollision`) is kept as a fast/friendly error for the obvious `--output X X` case, but the temp+rename is what actually protects later-resolved reads.
 - stdout output and `--noout` are unaffected (no temp file is created).
-- Output file mode: the temp is created `0666` so the kernel applies the process umask, which already matches `os.Create` for a NEW destination (no chmod). For an EXISTING destination `Commit` chmods the temp to the current mode (`os.Stat` + `chmod`) before the rename. umask is never read in-process (the old `syscall.Umask(0)` read-modify-write was racy and has been removed).
+- Output file mode: the temp is created `0666` so the kernel applies the process umask, which already matches
+  `os.Create` for a NEW destination (no chmod). For an EXISTING destination `Commit` chmods the temp to the
+  current mode (`os.Stat` + `chmod`) before the rename. umask is never read in-process (the old
+  `syscall.Umask(0)` read-modify-write was racy and has been removed).
 
 ### Flag Groups
 
@@ -91,17 +105,32 @@ File output (`--output`/`-o`, not stdout and not `--noout`) is written through a
 - `--valid` → also sets `--loaddtd`
 - `--xpath EXPR` → also sets `--noout`
 - `--pretty N>=1` → also sets `--format`
-- `--loaddtd` / `--dtdattr` / `--valid` / `--noent` → external-loading opt-in: each lifts the parser's default `BlockXXE` block and installs a permissive FS (or the `--path` search FS) so the requested external DTD/entity actually loads. Bare `lint` is safe-by-default (`NewParser` blocks external loading and uses a deny-all FS), matching the library.
-- `--huge` → lifts the tunable parser limits for trusted input: `MaxNameLength(-1)`, `MaxEntityAmplification(-1)`, `MaxContentModelDepth(-1)`, `MaxNodeContentSize(-1)` (disables the 10 MiB cap on both single-construct CDATA/comment/PI/char-data/attribute-value runs and contiguous XML-whitespace blank-skip runs), and `MaxDepth(-1)`. An explicit `--max-depth` still wins (applied after `--huge`).
-- `--xinclude` → `xinclude.NewProcessor()` now denies all FS access by default (safe-by-default, matching the library), so the CLI installs a permissive resolver (`Resolver(NewFSResolver(...))`) backed by the same permissive root — or the `--path` search FS — used by the parser, preserving the historical behavior of reading includes off disk.
+- `--loaddtd` / `--dtdattr` / `--valid` / `--noent` → external-loading opt-in: each lifts the parser's default
+  `BlockXXE` block and installs a permissive FS (or the `--path` search FS) so the requested external
+  DTD/entity actually loads. Bare `lint` is safe-by-default (`NewParser` blocks external loading and uses a
+  deny-all FS), matching the library.
+- `--huge` → lifts the tunable parser limits for trusted input: `MaxNameLength(-1)`,
+  `MaxEntityAmplification(-1)`, `MaxContentModelDepth(-1)`, `MaxNodeContentSize(-1)` (disables the 10 MiB cap
+  on both single-construct CDATA/comment/PI/char-data/attribute-value runs and contiguous XML-whitespace
+  blank-skip runs), and `MaxDepth(-1)`. An explicit `--max-depth` still wins (applied after `--huge`).
+- `--xinclude` → `xinclude.NewProcessor()` now denies all FS access by default (safe-by-default, matching the
+  library), so the CLI installs a permissive resolver (`Resolver(NewFSResolver(...))`) backed by the same
+  permissive root — or the `--path` search FS — used by the parser, preserving the historical behavior of
+  reading includes off disk.
 
 ### Output / Input Safety
 
-- `--output FILE` refers to the same file as an XML input or the `--schema` → rejected (`would overwrite input/schema`, `ExitErr`) before any file is truncated. Same-file detection uses absolute-path equality plus `os.SameFile` (catches `./` prefixes and symlinks).
+- `--output FILE` refers to the same file as an XML input or the `--schema` → rejected (`would overwrite
+  input/schema`, `ExitErr`) before any file is truncated. Same-file detection uses absolute-path equality plus
+  `os.SameFile` (catches `./` prefixes and symlinks).
 - `--output FILE` combined with `--noout` → rejected (`--output cannot be combined with --noout`). Exception: `--xpath` (which also sets `--noout` internally) still writes its result, so it is allowed.
 - The output file is closed explicitly after processing; a close error is folded into the exit status (`ExitErr`).
 - `--max-input-bytes N` caps the bytes read per input (file or stdin); default `DefaultMaxInputBytes` (100 MiB). `0` disables the cap. Exceeding it fails with `input exceeds maximum size` and `ExitReadFile`.
-- `--max-depth N` caps element nesting depth; default `256` (the `NewParser` default), `0` = unlimited. Exceeding it fails the parse (`exceeded max depth`). `--max-depth` (and `--huge`) apply to the **document being processed** (the linted/validated/transformed instance). Schema and stylesheet **compilation** (XSD/RELAX NG/Schematron/XSLT, including nested include/import/module loads) parses with the default parser limits; exposing those compiler-internal limits is intentionally out of scope here and left as a follow-up.
+- `--max-depth N` caps element nesting depth; default `256` (the `NewParser` default), `0` = unlimited.
+  Exceeding it fails the parse (`exceeded max depth`). `--max-depth` (and `--huge`) apply to the **document
+  being processed** (the linted/validated/transformed instance). Schema and stylesheet **compilation**
+  (XSD/RELAX NG/Schematron/XSLT, including nested include/import/module loads) parses with the default parser
+  limits; exposing those compiler-internal limits is intentionally out of scope here and left as a follow-up.
 - `--quiet` suppresses informational output: timing messages are silenced and parser/validator warnings are suppressed.
 - `--path DIRS` (colon-separated) is wired into DTD/entity resolution: a `pathSearchFS` falls back to each listed directory (by base name) when the default loader cannot open a referenced resource.
 
@@ -114,7 +143,9 @@ File output (`--output`/`-o`, not stdout and not `--noout`) is written through a
 ### `--encode ENC`
 
 - Validated at parse time against `internal/encoding.Load`; an unrecognized encoding name is rejected with `--encode: unsupported encoding` and `ExitErr` (no silent fallback).
-- US-ASCII and its aliases (`ascii`, `ANSI_X3.4-1968`, `csASCII`, detected via `internal/encoding.IsASCII`) are rejected with the same `--encode: unsupported encoding` message: `Load`'s strict ASCII encoder delegates to UTF-8, which would emit raw UTF-8 bytes for non-ASCII characters while declaring US-ASCII.
+- US-ASCII and its aliases (`ascii`, `ANSI_X3.4-1968`, `csASCII`, detected via `internal/encoding.IsASCII`)
+  are rejected with the same `--encode: unsupported encoding` message: `Load`'s strict ASCII encoder delegates
+  to UTF-8, which would emit raw UTF-8 bytes for non-ASCII characters while declaring US-ASCII.
 - Cannot be combined with `--xpath`: the XPath path serializes node values without re-encoding, so the combination is rejected at parse time with `--encode cannot be combined with --xpath` and `ExitErr`.
 - Applied to the standard dump path via `doc.SetEncoding`, so the serializer loads the matching encoder and emits the matching encoding declaration.
 - Ignored for C14N modes, which are always UTF-8 per the C14N spec.
@@ -145,7 +176,9 @@ Primary file: `internal/cli/heliumcmd/xsd_validate.go`
 - `--max-input-bytes N` caps bytes read per XML input (file or stdin) via `readInput`/`readInputFile`; default `DefaultMaxInputBytes` (100 MiB), `0` = unlimited; over-cap fails with `ExitReadFile`
 - `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is left untouched; over-cap fails the parse (`ExitErr`)
 - Schema compiled once with `xsd.NewCompiler().Label(schema).ErrorHandler(...).CompileFile(ctx, schema)`; a `compileErrorHandler` streams compilation diagnostics (file/line/detail) to stderr and records whether any FATAL diagnostic was seen
-- The xsd compiler may return a non-nil schema with a nil error for a malformed schema; the CLI folds that into a failure (`errSchemaCompilation`) when the handler saw a fatal diagnostic, so it never validates against a bad schema. Compilation failure → `ExitSchemaComp`
+- The xsd compiler may return a non-nil schema with a nil error for a malformed schema; the CLI folds that
+  into a failure (`errSchemaCompilation`) when the handler saw a fatal diagnostic, so it never validates
+  against a bad schema. Compilation failure → `ExitSchemaComp`
 - Each XML input parsed with `helium.NewParser()` (file inputs get `.BaseURI(name)`) + validated with `xsd.NewValidator(schema).ErrorHandler(...).Validate(ctx, doc)`, diagnostics streamed to stderr via a `writerErrorHandler`
 
 ## `helium relaxng validate`
@@ -156,8 +189,14 @@ Primary file: `internal/cli/heliumcmd/relaxng_validate.go`
 - Schema path mandatory positional arg
 - `--max-input-bytes N` caps bytes read per XML input (file or stdin) via `readInput`/`readInputFile`; default `DefaultMaxInputBytes` (100 MiB), `0` = unlimited; over-cap fails with `ExitReadFile`
 - `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is left untouched; over-cap fails the parse (`ExitErr`)
-- Grammar compiled once with `relaxng.NewCompiler().FS(helium.PermissiveFS()).Label(schema).ErrorHandler(...).CompileFile(ctx, schema)`; `FS(helium.PermissiveFS())` opts back into host-filesystem loading for `include`/`externalRef` (the compiler's FS now defaults to deny-all), mirroring `lint`/`xslt`; a `compileErrorHandler` streams compilation diagnostics (file/line/detail) to stderr and records whether any FATAL diagnostic was seen
-- The RELAX NG compiler may return a non-nil grammar with a nil error (a poisoned `notAllowed` grammar) on a fatal diagnostic; the CLI folds that into a failure (`errSchemaCompilation`) when the handler saw a fatal diagnostic, so it never validates against a bad grammar. Compilation failure → `ExitSchemaComp`
+- Grammar compiled once with
+  `relaxng.NewCompiler().FS(helium.PermissiveFS()).Label(schema).ErrorHandler(...).CompileFile(ctx, schema)`;
+  `FS(helium.PermissiveFS())` opts back into host-filesystem loading for `include`/`externalRef` (the
+  compiler's FS now defaults to deny-all), mirroring `lint`/`xslt`; a `compileErrorHandler` streams
+  compilation diagnostics (file/line/detail) to stderr and records whether any FATAL diagnostic was seen
+- The RELAX NG compiler may return a non-nil grammar with a nil error (a poisoned `notAllowed` grammar) on a
+  fatal diagnostic; the CLI folds that into a failure (`errSchemaCompilation`) when the handler saw a fatal
+  diagnostic, so it never validates against a bad grammar. Compilation failure → `ExitSchemaComp`
 - Each XML input parsed with `helium.NewParser()` (file inputs get `.BaseURI(name)`) + validated with `relaxng.NewValidator(grammar).Label(name).ErrorHandler(...).Validate(ctx, doc)`, diagnostics streamed to stderr via a `writerErrorHandler`
 
 ## `helium schematron validate`
@@ -169,7 +208,9 @@ Primary file: `internal/cli/heliumcmd/schematron_validate.go`
 - `--max-input-bytes N` caps bytes read per XML input (file or stdin) via `readInput`/`readInputFile`; default `DefaultMaxInputBytes` (100 MiB), `0` = unlimited; over-cap fails with `ExitReadFile`
 - `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is left untouched; over-cap fails the parse (`ExitErr`)
 - Schema compiled once with `schematron.NewCompiler().Label(path).CompileFile(ctx, path)`
-- `--query-binding NAME` forces the query language binding (`xslt`, `xslt3`, `xpath3`), overriding the schema's `queryBinding` attribute; an unrecognized name is rejected before compilation. Unset, the attribute decides, and an unsupported attribute value exits `ExitSchemaComp`
+- `--query-binding NAME` forces the query language binding (`xslt`, `xslt3`, `xpath3`), overriding the
+  schema's `queryBinding` attribute; an unrecognized name is rejected before compilation. Unset, the attribute
+  decides, and an unsupported attribute value exits `ExitSchemaComp`
 - Each XML input parsed with `helium.NewParser()` + validated with `schematron.NewValidator(schema).Label(name).Validate(ctx, doc)`
 - Validation passes `.Label(input.name)` so error output names the current XML source
 
@@ -179,12 +220,29 @@ Primary file: `internal/cli/heliumcmd/xslt.go`
 
 - Usage: `helium xslt [options] STYLESHEET [XMLfiles ...]`
 - Stylesheet path mandatory positional arg
-- Stylesheet parsed with the secure `helium.NewParser()` default (no external DTD/entity loading, deny-all FS) — a hostile stylesheet cannot read local files via a SYSTEM entity. `SubstituteEntities(true)` IS enabled by default so the stylesheet's INTERNAL-subset general entities expand (xslt3 only compiles text/CDATA in sequence constructors, so an unexpanded `EntityRefNode` would silently drop the value); `BlockXXE`/`LoadExternalDTD(false)` still block external content, mirroring xslt3's own secure parser (`xslt3/xslt3.go`). External loading is opt-in via `--noent` (substitutes external entities) and/or `--loaddtd` (`LoadExternalDTD`), mirroring `helium lint`'s flag names. `--loaddtd` on its own loads the external DTD subset WITHOUT substituting its general entities (the internal-substitution default is suppressed for `--loaddtd`-without-`--noent`). When opted in, the parser's `BlockXXE` is lifted and the FS is `confinedDirFS` rooted at the **stylesheet's own directory** (not a raw permissive root), so an attacker-controlled SYSTEM identifier (`/etc/passwd`, `../../secret`) still cannot exfiltrate files outside that directory. Compiled once with `xslt3.NewCompiler().URIResolver(fileResolver{}).Compile()`
+- Stylesheet parsed with the secure `helium.NewParser()` default (no external DTD/entity loading, deny-all FS)
+  — a hostile stylesheet cannot read local files via a SYSTEM entity. `SubstituteEntities(true)` IS enabled by
+  default so the stylesheet's INTERNAL-subset general entities expand (xslt3 only compiles text/CDATA in
+  sequence constructors, so an unexpanded `EntityRefNode` would silently drop the value);
+  `BlockXXE`/`LoadExternalDTD(false)` still block external content, mirroring xslt3's own secure parser
+  (`xslt3/xslt3.go`). External loading is opt-in via `--noent` (substitutes external entities) and/or
+  `--loaddtd` (`LoadExternalDTD`), mirroring `helium lint`'s flag names. `--loaddtd` on its own loads the
+  external DTD subset WITHOUT substituting its general entities (the internal-substitution default is
+  suppressed for `--loaddtd`-without-`--noent`). When opted in, the parser's `BlockXXE` is lifted and the FS
+  is `confinedDirFS` rooted at the **stylesheet's own directory** (not a raw permissive root), so an
+  attacker-controlled SYSTEM identifier (`/etc/passwd`, `../../secret`) still cannot exfiltrate files outside
+  that directory. Compiled once with `xslt3.NewCompiler().URIResolver(fileResolver{}).Compile()`
 - A filesystem `URIResolver` is installed so local `xsl:include`/`xsl:import` modules load (the compiler default-denies module loading without one)
-- `fileResolver.Resolve` accepts plain relative/absolute paths AND `file:` URIs (`localFilePath` in `safety.go`): a `file:` URI is parsed, only an empty or `localhost` host is accepted, the path is percent-decoded (and de-slashed before a Windows drive letter); any other scheme (`http`/`https`/...) is rejected so the resolver never reaches the network. A bare Windows drive path (`C:\...`) is not mistaken for a scheme.
+- `fileResolver.Resolve` accepts plain relative/absolute paths AND `file:` URIs (`localFilePath` in
+  `safety.go`): a `file:` URI is parsed, only an empty or `localhost` host is accepted, the path is
+  percent-decoded (and de-slashed before a Windows drive letter); any other scheme (`http`/`https`/...) is
+  rejected so the resolver never reaches the network. A bare Windows drive path (`C:\...`) is not mistaken for
+  a scheme.
 - Each XML input parsed with `helium.NewParser()`, transformed with `ss.Transform(doc).WriteTo(ctx, out)`
 - Flags: `--output FILE` / `-o FILE`, `--param NAME VAL` (XPath), `--stringparam NAME VAL`, `--noout`, `--noent`, `--loaddtd`, `--timing`, `--max-input-bytes N`, `--max-depth N`, `--version`
-- `--noent` / `--loaddtd` → stylesheet-parser external-loading opt-in (off by default): each lifts the parser's default `BlockXXE` and installs `confinedDirFS` (stylesheet directory only). They affect ONLY the stylesheet parse; the source-document parser is always the plain secure `NewParser()` default
+- `--noent` / `--loaddtd` → stylesheet-parser external-loading opt-in (off by default): each lifts the
+  parser's default `BlockXXE` and installs `confinedDirFS` (stylesheet directory only). They affect ONLY the
+  stylesheet parse; the source-document parser is always the plain secure `NewParser()` default
 - `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited) and applies to BOTH the stylesheet parser and the source-document parser; when absent, the `NewParser` default is left untouched
 - Parameters passed via `inv.GlobalParameters()`
 - Same output safety as `helium lint`: `--output` is rejected when it matches an input or the stylesheet, or when combined with `--noout`; close errors fold into the exit status; inputs are read under the `--max-input-bytes` cap

--- a/.claude/docs/libxml2-parity.md
+++ b/.claude/docs/libxml2-parity.md
@@ -59,7 +59,17 @@ single-quoted attributes parse correctly, and the C14N suite runs with no skips.
 Same-element duplicate namespace declarations are a well-formedness error, as in
 libxml2.
 
-1. **External entity resolution** — limited; requires explicit config. `NewParser` is **secure by default**: `BlockXXE` is on, the `FS` is a deny-all FS, and network is off — so external loading is blocked even when `LoadExternalDTD(true)`/`SubstituteEntities(true)` are set, until `BlockXXE(false)` is also set AND an FS is supplied (`helium.PermissiveFS()` or a confined `fs.FS`). External subsets need `LoadExternalDTD(true)`, and inline expansion of parsed external entities needs `SubstituteEntities(true)`. External DTD subsets are read through a strict byte cap (`MaxExternalDTDSize`, 10 MiB default; overridable via `MaxExternalDTDBytes`) enforced against the actual bytes read — not any advisory `Stat` size — and a subset exceeding the cap is rejected with `ErrExternalDTDTooLarge`. The `relaxng.Compiler` mirrors this default: its `include`/`externalRef` fetch `FS` is deny-all by default (opt into host access with `Compiler.FS(helium.PermissiveFS())`), and each target is read under a per-resource byte cap (`relaxng.Compiler.MaxResourceBytes`, 10 MiB default).
+1. **External entity resolution** — limited; requires explicit config. `NewParser` is **secure by default**:
+   `BlockXXE` is on, the `FS` is a deny-all FS, and network is off — so external loading is blocked even when
+   `LoadExternalDTD(true)`/`SubstituteEntities(true)` are set, until `BlockXXE(false)` is also set AND an FS
+   is supplied (`helium.PermissiveFS()` or a confined `fs.FS`). External subsets need `LoadExternalDTD(true)`,
+   and inline expansion of parsed external entities needs `SubstituteEntities(true)`. External DTD subsets are
+   read through a strict byte cap (`MaxExternalDTDSize`, 10 MiB default; overridable via
+   `MaxExternalDTDBytes`) enforced against the actual bytes read — not any advisory `Stat` size — and a subset
+   exceeding the cap is rejected with `ErrExternalDTDTooLarge`. The `relaxng.Compiler` mirrors this default:
+   its `include`/`externalRef` fetch `FS` is deny-all by default (opt into host access with
+   `Compiler.FS(helium.PermissiveFS())`), and each target is read under a per-resource byte cap
+   (`relaxng.Compiler.MaxResourceBytes`, 10 MiB default).
 
 ## Feature Status
 
@@ -143,7 +153,24 @@ libxml2.
 ## Known Issues
 
 - `xinclude/issue733` — DOCTYPE not preserved after XInclude processing
-- DTD element-content validity (VC: Element Valid), character-reference whitespace provenance: whitespace produced by a character reference does NOT match the S nonterminal, so it is not ignorable in element-only content (XML §3.2.1, errata 2e E15). With `SubstituteEntities(true)` the DOM text node is byte-identical to one from literal whitespace, so provenance is reconstructed by a parser flag: `parseReference` marks a `&#N;` delivery (`pctx.charDataFromCharRef`), `TreeBuilder.Characters` stamps the Text node's `fromCharRef` field, and `collectChildElements` (`valid.go`) treats a `fromCharRef` whitespace text node as character data (content-model mismatch). It survives general-entity expansion via the re-parse of the entity replacement text and `replayEntityNode`, distinguishing an entity value of `&#32;` (invalid, `rmt-e2e-15h`) from a literal-space entity value (valid, `rmt-e2e-15e`) or a `&#32;` expanded at DECLARATION time into a literal space (valid, `rmt-e2e-15f`). A direct character reference to a whitespace char in element-only content is likewise invalid (`rmt-e2e-15g`). Separately, a reference is content per XML production [43], so an EMPTY element containing one is invalid even when it expands to nothing (`rmt-e2e-15a`); `parseReference` sets `Element.contentHasReference` and `validateElementContent`'s EMPTY branch reads it. All flags are validity-only — invisible to serialization, C14N, XPath string-value, and node copy. A CDATA section is a distinct node type, so a CDATA section in element-only content — even empty or whitespace-only, never S — IS rejected (`sun/invalid empty`); and an NMTOKENS/IDREFS/ENTITIES token separator is exactly `#x20` (`splitNormalizedTokens`), so a character-reference whitespace char inside a tokenized attribute value is part of the token, making e.g. `abc&#9;xyz` a single invalid NMTOKEN (`rmt-e2e-20`).
+- DTD element-content validity (VC: Element Valid), character-reference whitespace provenance: whitespace
+  produced by a character reference does NOT match the S nonterminal, so it is not ignorable in element-only
+  content (XML §3.2.1, errata 2e E15). With `SubstituteEntities(true)` the DOM text node is byte-identical to
+  one from literal whitespace, so provenance is reconstructed by a parser flag: `parseReference` marks a
+  `&#N;` delivery (`pctx.charDataFromCharRef`), `TreeBuilder.Characters` stamps the Text node's `fromCharRef`
+  field, and `collectChildElements` (`valid.go`) treats a `fromCharRef` whitespace text node as character data
+  (content-model mismatch). It survives general-entity expansion via the re-parse of the entity replacement
+  text and `replayEntityNode`, distinguishing an entity value of `&#32;` (invalid, `rmt-e2e-15h`) from a
+  literal-space entity value (valid, `rmt-e2e-15e`) or a `&#32;` expanded at DECLARATION time into a literal
+  space (valid, `rmt-e2e-15f`). A direct character reference to a whitespace char in element-only content is
+  likewise invalid (`rmt-e2e-15g`). Separately, a reference is content per XML production [43], so an EMPTY
+  element containing one is invalid even when it expands to nothing (`rmt-e2e-15a`); `parseReference` sets
+  `Element.contentHasReference` and `validateElementContent`'s EMPTY branch reads it. All flags are
+  validity-only — invisible to serialization, C14N, XPath string-value, and node copy. A CDATA section is a
+  distinct node type, so a CDATA section in element-only content — even empty or whitespace-only, never S — IS
+  rejected (`sun/invalid empty`); and an NMTOKENS/IDREFS/ENTITIES token separator is exactly `#x20`
+  (`splitNormalizedTokens`), so a character-reference whitespace char inside a tokenized attribute value is
+  part of the token, making e.g. `abc&#9;xyz` a single invalid NMTOKEN (`rmt-e2e-20`).
 - C14N relative namespace URI check uses heuristic (`!strings.Contains(uri, ":")`) not full URI parse
 - HTML attribute deduplication: all kept (libxml2 keeps first)
 - HTML areBlanks heuristic simpler than libxml2's
@@ -158,9 +185,43 @@ These are architectural choices, not bugs:
 - Go interfaces for node types vs xmlNode.type enum switch
 - No global state: explicit context passing
 - Functional options (WithX()) vs bitmask flags
-- XML push parser parses incrementally as chunks arrive; HTML push parser buffers through the initial ~1024-byte charset prescan, then streams only once a streamable encoding is settled (declared/detected charset=utf-8, or a non-UTF-8 head routed to Latin-1). An undeclared input that keeps proving valid UTF-8 stays undecided and buffers (a later non-UTF-8 byte would re-interpret the whole prefix as Latin-1/Windows-1252), but the undecided prefix is BOUNDED at the configured `MaxContentSize` (16 MiB default): each undecided read is capped to the remaining bound so the boundary is chunk-independent. A stream ending with valid UTF-8 at/below the cap is accepted (one-byte EOF probe); if the cap fills and more bytes still follow it fails closed with `ErrContentSizeExceeded` (`html/encoding_reader.go` deferredLatin1Reader).
+- XML push parser parses incrementally as chunks arrive; HTML push parser buffers through the initial
+  ~1024-byte charset prescan, then streams only once a streamable encoding is settled (declared/detected
+  charset=utf-8, or a non-UTF-8 head routed to Latin-1). An undeclared input that keeps proving valid UTF-8
+  stays undecided and buffers (a later non-UTF-8 byte would re-interpret the whole prefix as
+  Latin-1/Windows-1252), but the undecided prefix is BOUNDED at the configured `MaxContentSize` (16 MiB
+  default): each undecided read is capped to the remaining bound so the boundary is chunk-independent. A
+  stream ending with valid UTF-8 at/below the cap is accepted (one-byte EOF probe); if the cap fills and more
+  bytes still follow it fails closed with `ErrContentSizeExceeded` (`html/encoding_reader.go`
+  deferredLatin1Reader).
 - Namespace stack: frame-based visibleNSStack vs flat arrays
-- `xml:id` value normalization: the parser applies tokenized-type (xs:ID) normalization — trim + internal-space collapse — to an `xml:id` attribute even when it is NOT DTD-declared, per the xml:id Recommendation §4 + XML §3.3.3 (so `GetElementByID`/`fn:id`/XPath string-value see the collapsed id). libxml2 normalizes `xml:id` only when it is DTD-declared ID and leaves undeclared-`xml:id` normalization as a documented open issue (it does not do it). This is a DELIBERATE XPath-3.1 / xml:id-§4 conformance choice; it is verified byte-identical on every libxml2-compat / c14n / serialization golden (no parity fixture carries a normalizable-whitespace `xml:id`).
-- Schematron `queryBinding`: helium reads the attribute and refuses a query language binding it does not implement (`ErrUnsupportedQueryBinding`, a fatal compile diagnostic), and evaluates a schema naming `xslt3` or `xpath3` with XPath 3.1. libxml2 ignores the attribute entirely and evaluates every schema as XPath 1.0, so a 2.0-or-later schema silently produces XPath 1.0 answers there. The XPath 1.0 path (an absent attribute, or `xslt`) stays byte-identical to libxml2, and every libxml2-compat schematron golden is unaffected because none of the fixtures carries the attribute.
-- Node-builder colon validation: `Document.CreateElement(name)` and `Document.CreateAttribute(name, ...)` reject a colon in `name` and return an error (the caller supplies a namespaced element/attribute through `Document.CreateElementNS(localname, ns)` / `Element.SetAttributeNS(localname, ...)`). libxml2's `xmlNewNode`/`xmlNewProp` do no validation and let a colon sit in the single name field, producing an unbound prefix that serializes as namespace-ill-formed XML. This is the same namespace-aware strictness the W3C xml-conformance campaign classified as an intentional divergence (colon-in-Name). It changes no parsed-document output: the parser always splits a QName into prefix+local and sets the namespace separately, so every in-tree build/copy call site feeds a bare local name and the rejection never fires.
-- Writer invalid-character default: the `Writer` REJECTS a syntactically valid character or numeric-reference target outside the target XML range (`ErrInvalidXMLChar` / SERE0006) by default, where libxml2 silently replaces it with U+FFFD. `Writer.RejectInvalidChars(false)` restores replacement — as `&#xFFFD;` under `EscapeNonASCII`/US-ASCII output and raw U+FFFD otherwise; reference-less contexts always use raw U+FFFD. Malformed numeric, named, and parameter-entity reference markup always fails with `ErrWriterInvalidName`; it is never repaired. Full DTD Names remain distinct from DOM QNames, entity and notation declarations require NCNames, and enumeration members are checked as distinct Nmtokens or Names before output. A character map is exempt because its replacement string is emitted verbatim (Serialization 3.1 §7). Parsed-document output and serialization goldens remain byte-identical; the divergence only affects malformed in-memory trees.
+- `xml:id` value normalization: the parser applies tokenized-type (xs:ID) normalization — trim +
+  internal-space collapse — to an `xml:id` attribute even when it is NOT DTD-declared, per the xml:id
+  Recommendation §4 + XML §3.3.3 (so `GetElementByID`/`fn:id`/XPath string-value see the collapsed id).
+  libxml2 normalizes `xml:id` only when it is DTD-declared ID and leaves undeclared-`xml:id` normalization as
+  a documented open issue (it does not do it). This is a DELIBERATE XPath-3.1 / xml:id-§4 conformance choice;
+  it is verified byte-identical on every libxml2-compat / c14n / serialization golden (no parity fixture
+  carries a normalizable-whitespace `xml:id`).
+- Schematron `queryBinding`: helium reads the attribute and refuses a query language binding it does not
+  implement (`ErrUnsupportedQueryBinding`, a fatal compile diagnostic), and evaluates a schema naming `xslt3`
+  or `xpath3` with XPath 3.1. libxml2 ignores the attribute entirely and evaluates every schema as XPath 1.0,
+  so a 2.0-or-later schema silently produces XPath 1.0 answers there. The XPath 1.0 path (an absent attribute,
+  or `xslt`) stays byte-identical to libxml2, and every libxml2-compat schematron golden is unaffected because
+  none of the fixtures carries the attribute.
+- Node-builder colon validation: `Document.CreateElement(name)` and `Document.CreateAttribute(name, ...)`
+  reject a colon in `name` and return an error (the caller supplies a namespaced element/attribute through
+  `Document.CreateElementNS(localname, ns)` / `Element.SetAttributeNS(localname, ...)`). libxml2's
+  `xmlNewNode`/`xmlNewProp` do no validation and let a colon sit in the single name field, producing an
+  unbound prefix that serializes as namespace-ill-formed XML. This is the same namespace-aware strictness the
+  W3C xml-conformance campaign classified as an intentional divergence (colon-in-Name). It changes no
+  parsed-document output: the parser always splits a QName into prefix+local and sets the namespace
+  separately, so every in-tree build/copy call site feeds a bare local name and the rejection never fires.
+- Writer invalid-character default: the `Writer` REJECTS a syntactically valid character or numeric-reference
+  target outside the target XML range (`ErrInvalidXMLChar` / SERE0006) by default, where libxml2 silently
+  replaces it with U+FFFD. `Writer.RejectInvalidChars(false)` restores replacement — as `&#xFFFD;` under
+  `EscapeNonASCII`/US-ASCII output and raw U+FFFD otherwise; reference-less contexts always use raw U+FFFD.
+  Malformed numeric, named, and parameter-entity reference markup always fails with `ErrWriterInvalidName`; it
+  is never repaired. Full DTD Names remain distinct from DOM QNames, entity and notation declarations require
+  NCNames, and enumeration members are checked as distinct Nmtokens or Names before output. A character map is
+  exempt because its replacement string is emitted verbatim (Serialization 3.1 §7). Parsed-document output and
+  serialization goldens remain byte-identical; the divergence only affects malformed in-memory trees.

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -53,7 +53,17 @@ Attributes are a **linked list via next/prev** on the Element, NOT children:
 
 ## Node Builders (colon rule)
 
-`Document.CreateElement(name) → (*Element, error)` and `Document.CreateAttribute(name, value, ns) → (*Attribute, error)` REJECT a colon in `name` (the single name field holds a bare local name; a colon there is an unbound prefix that would serialize as namespace-ill-formed XML). Supply a namespaced name through the `NS` siblings instead: `Document.CreateElementNS(localname, ns) → (*Element, error)` rejects a colon in `localname`, allocates the element via `CreateElement`, then installs `ns` as the active namespace with `SetNamespace` (so `Name()` renders `prefix:localname` and the cached qname is invalidated; if `ns` is slab-backed by another document `SetNamespace` marks that source escaped — Cross-Document Slab Safety below); `Element.SetAttributeNS(localname, value, ns)` is the attribute counterpart. A nil receiver allocates a standalone (heap, non-slab) element/attribute. Neither builder checks the rest of the XML Name/NCName grammar. The parser/copy code never passes a colon — it splits a QName into prefix+local and sets the namespace via `SetActiveNamespace`/`SetNamespace` — so the rejection only guards hand-built trees.
+`Document.CreateElement(name) → (*Element, error)` and `Document.CreateAttribute(name, value, ns) →
+(*Attribute, error)` REJECT a colon in `name` (the single name field holds a bare local name; a colon there is
+an unbound prefix that would serialize as namespace-ill-formed XML). Supply a namespaced name through the `NS`
+siblings instead: `Document.CreateElementNS(localname, ns) → (*Element, error)` rejects a colon in
+`localname`, allocates the element via `CreateElement`, then installs `ns` as the active namespace with
+`SetNamespace` (so `Name()` renders `prefix:localname` and the cached qname is invalidated; if `ns` is
+slab-backed by another document `SetNamespace` marks that source escaped — Cross-Document Slab Safety below);
+`Element.SetAttributeNS(localname, value, ns)` is the attribute counterpart. A nil receiver allocates a
+standalone (heap, non-slab) element/attribute. Neither builder checks the rest of the XML Name/NCName grammar.
+The parser/copy code never passes a colon — it splits a QName into prefix+local and sets the namespace via
+`SetActiveNamespace`/`SetNamespace` — so the rejection only guards hand-built trees.
 
 ## ElementType Enum (21 values)
 
@@ -91,34 +101,132 @@ NamespaceDeclNode(18) XIncludeStartNode(19) XIncludeEndNode(20) NamespaceNode(21
 `Text.AddSibling(Text)` → content merged instead of creating sibling. Prevents whitespace node bloat. Mirrors libxml2 TEXT consolidation.
 
 ### PI Content Is A String, Not Children
-A `ProcessingInstruction` stores its content in the `data` string field (mirrors libxml2's XML_PI_NODE, whose content is the node's content string). It has NO element/text children. `AppendText` and an `AddChild` of a Text/CDATA node append the text to `data`; `AddChild` of any other node type is rejected (so the tree cannot be corrupted and serialization stays `<?target data?>`). The serializer reads `pi.data` directly.
+A `ProcessingInstruction` stores its content in the `data` string field (mirrors libxml2's XML_PI_NODE, whose
+content is the node's content string). It has NO element/text children. `AppendText` and an `AddChild` of a
+Text/CDATA node append the text to `data`; `AddChild` of any other node type is rejected (so the tree cannot
+be corrupted and serialization stays `<?target data?>`). The serializer reads `pi.data` directly.
 
 ### DTD Map Keys
 - Elements: `name:prefix` (string)
 - Attributes: `attrDeclKey{local, prefix, elem}` (struct, scoped to element)
 - Entities: `name` (flat)
 
-Attribute declarations are ALSO held in two registration-order sequences: `attrDecls []*AttributeDecl` (every declaration in the subset) and `attrsByElem map[string][]*AttributeDecl` (the same declarations keyed by owning element name). Registration order is declaration order — the `<!ATTLIST>` order, or the `AddAttributeDecl` call order — and it is the order every consumer sees, so DTD validation reports attribute diagnostics in declaration order instead of a per-run random one: the element-keyed readers (`AttributesForElement`, `validateElementAttributes`, `checkStandaloneExternalDefaults`, `GetElementByID`) range `attrsByElem`, and the subset-wide declaration-consistency checks (`validateDTDDeclarations`, `validateOneIDPerElement`) range `attrDecls`. Neither ranges the `attributes` map, whose Go iteration order is randomized per run. `AttributesForElement(elem)` returns a `slices.Clone` of the index slice, so the caller gets a fresh copy and cannot mutate the DTD's own declarations. `registerAttribute` is the single entry point that keeps `attributes`, `attrDecls`, and `attrsByElem` in sync; `copy_dtd.go`'s deep-copy path writes them directly since it does not go through `registerAttribute`, and it rebuilds the two sequences from the SOURCE's `attrDecls`, translating each source declaration through an original->copy correspondence. The child list it walks carries the serialization order, which relinking a declaration (`AttributeDecl.AddSibling`) changes without re-registering it, so the two orders are independent.
+Attribute declarations are ALSO held in two registration-order sequences: `attrDecls []*AttributeDecl` (every
+declaration in the subset) and `attrsByElem map[string][]*AttributeDecl` (the same declarations keyed by
+owning element name). Registration order is declaration order — the `<!ATTLIST>` order, or the
+`AddAttributeDecl` call order — and it is the order every consumer sees, so DTD validation reports attribute
+diagnostics in declaration order instead of a per-run random one: the element-keyed readers
+(`AttributesForElement`, `validateElementAttributes`, `checkStandaloneExternalDefaults`, `GetElementByID`)
+range `attrsByElem`, and the subset-wide declaration-consistency checks (`validateDTDDeclarations`,
+`validateOneIDPerElement`) range `attrDecls`. Neither ranges the `attributes` map, whose Go iteration order is
+randomized per run. `AttributesForElement(elem)` returns a `slices.Clone` of the index slice, so the caller
+gets a fresh copy and cannot mutate the DTD's own declarations. `registerAttribute` is the single entry point
+that keeps `attributes`, `attrDecls`, and `attrsByElem` in sync; `copy_dtd.go`'s deep-copy path writes them
+directly since it does not go through `registerAttribute`, and it rebuilds the two sequences from the SOURCE's
+`attrDecls`, translating each source declaration through an original->copy correspondence. The child list it
+walks carries the serialization order, which relinking a declaration (`AttributeDecl.AddSibling`) changes
+without re-registering it, so the two orders are independent.
 
-The QName→(name, prefix) split (`AddElementDecl`/`GetElementDesc`/`AddAttributeDecl`) splits on the FIRST colon but treats a LEADING colon as part of the local name (mirrors libxml2 `xmlSplitQName3`): `:x` keys as `(name=":x", prefix="")`, distinct from the unprefixed `x` (`(name="x", prefix="")`), so a leading-colon element declaration is not a spurious redefinition of the unprefixed one (a leading colon is a legal XML 1.0 Name start character even though it is not a valid QName prefix). The attribute lookup table is keyed by an `attrDeclKey{local, prefix, elem}` struct. A `local + ":" + prefix + ":" + elem` string would collide distinct triples: name `"b:a"` on element `"c:d"` (local `a`, prefix `b`, elem `c:d`) and name `"c:a:b"` on element `"d"` (local `a:b`, prefix `c`, elem `d`) both flatten to `a:b:c:d`; the struct key keeps them distinct, mirroring the parser's `specialAttrKey`.
+The QName→(name, prefix) split (`AddElementDecl`/`GetElementDesc`/`AddAttributeDecl`) splits on the FIRST
+colon but treats a LEADING colon as part of the local name (mirrors libxml2 `xmlSplitQName3`): `:x` keys as
+`(name=":x", prefix="")`, distinct from the unprefixed `x` (`(name="x", prefix="")`), so a leading-colon
+element declaration is not a spurious redefinition of the unprefixed one (a leading colon is a legal XML 1.0
+Name start character even though it is not a valid QName prefix). The attribute lookup table is keyed by an
+`attrDeclKey{local, prefix, elem}` struct. A `local + ":" + prefix + ":" + elem` string would collide distinct
+triples: name `"b:a"` on element `"c:d"` (local `a`, prefix `b`, elem `c:d`) and name `"c:a:b"` on element
+`"d"` (local `a:b`, prefix `c`, elem `d`) both flatten to `a:b:c:d`; the struct key keeps them distinct,
+mirroring the parser's `specialAttrKey`.
 
-The `DTD.Add*` builders (`AddEntity`/`AddNotation`/`AddElementDecl`/`AddAttributeDecl`) build a declaration from public parameters, register it in the lookup table, AND link it into the DTD child list so it serializes. `AddAttributeDecl(elem, name, atype, def, defvalue, enumValues)` is the `<!ATTLIST>` counterpart; the low-level table-only `registerAttribute` is unexported. Like its sibling constructors, `AddAttributeDecl` validates only the enum parameters (`atype` must be a defined `enum.Attr*` value, `def` a defined `enum.AttrDefault*` kind — both `ErrInvalidArgument` otherwise) and rejects a duplicate (`ErrDuplicateDeclaration`); it splits `name` into prefix+local on the first colon exactly as `AddElementDecl` does, and clones `enumValues` before storing (a later caller mutation cannot corrupt the stored decl). It TRUSTS the caller for well-formed names, default values, and namespace/URI syntax — it does NOT validate them against the parser's Name/URI grammar, character ranges, or cross-declaration validity constraints (those are enforced by `ValidateDTD` when the document is validated), matching how `AddNotation`/`AddEntity`/`AddElementDecl` trust the caller. `AddNotation` enforces exactly one narrow name rule on top of that trust: it rejects a colon in the notation name (`ErrInvalidArgument`), because a notation name is an XML NCName and the parser rejects a colon-bearing `<!NOTATION>` name (`parser_dtd_attr.go` "colons are forbidden from notation names"), so a colon would serialize to un-reparseable output.
+The `DTD.Add*` builders (`AddEntity`/`AddNotation`/`AddElementDecl`/`AddAttributeDecl`) build a declaration
+from public parameters, register it in the lookup table, AND link it into the DTD child list so it serializes.
+`AddAttributeDecl(elem, name, atype, def, defvalue, enumValues)` is the `<!ATTLIST>` counterpart; the
+low-level table-only `registerAttribute` is unexported. Like its sibling constructors, `AddAttributeDecl`
+validates only the enum parameters (`atype` must be a defined `enum.Attr*` value, `def` a defined
+`enum.AttrDefault*` kind — both `ErrInvalidArgument` otherwise) and rejects a duplicate
+(`ErrDuplicateDeclaration`); it splits `name` into prefix+local on the first colon exactly as `AddElementDecl`
+does, and clones `enumValues` before storing (a later caller mutation cannot corrupt the stored decl). It
+TRUSTS the caller for well-formed names, default values, and namespace/URI syntax — it does NOT validate them
+against the parser's Name/URI grammar, character ranges, or cross-declaration validity constraints (those are
+enforced by `ValidateDTD` when the document is validated), matching how
+`AddNotation`/`AddEntity`/`AddElementDecl` trust the caller. `AddNotation` enforces exactly one narrow name
+rule on top of that trust: it rejects a colon in the notation name (`ErrInvalidArgument`), because a notation
+name is an XML NCName and the parser rejects a colon-bearing `<!NOTATION>` name (`parser_dtd_attr.go` "colons
+are forbidden from notation names"), so a colon would serialize to un-reparseable output.
 
-`DTD.RemoveElement(name, prefix) → *ElementDecl` deletes the lookup-table entry AND unlinks the `ElementDecl` node from the DTD child list (via `unlinkNode`), so a removed declaration is no longer serialized; it returns the removed decl (nil if none). `AddElementDecl` uses it internally to drop an `UndefinedElementType` placeholder while completing a real declaration.
+`DTD.RemoveElement(name, prefix) → *ElementDecl` deletes the lookup-table entry AND unlinks the `ElementDecl`
+node from the DTD child list (via `unlinkNode`), so a removed declaration is no longer serialized; it returns
+the removed decl (nil if none). `AddElementDecl` uses it internally to drop an `UndefinedElementType`
+placeholder while completing a real declaration.
 
 ### ElementContent (content-model tree)
-`ElementContent` is the binary content-model tree of an `ElementDecl` (fields all private): leaves are `ElementContentElement` (named reference, carries name/prefix) or `ElementContentPCDATA`; interior nodes are `ElementContentSeq` (,) or `ElementContentOr` (|), each requiring BOTH `c1` and `c2`. Every node has an occurrence indicator (`ElementContentOnce`/`Opt`/`Mult`/`Plus`). The serializer (`writer_dtd.go`) and the matcher (`valid.go`) dereference `c1`/`c2` for seq/choice nodes, so a structurally-incomplete node (a seq/choice with nil children) would nil-deref. `AddElementDecl` rejects such a model up front (`validateElementContentModel`, `valid.go`) before storing it, so no stored model can panic serialization. Safe public composition: `Document.CreateElementContent(name, etype)` (leaf), `Document.CreateElementContentSeq(c1, c2, occur)` / `Document.CreateElementContentChoice(c1, c2, occur)` (validated interior nodes), and `ElementContent.SetOccurrence(occur)`.
+`ElementContent` is the binary content-model tree of an `ElementDecl` (fields all private): leaves are
+`ElementContentElement` (named reference, carries name/prefix) or `ElementContentPCDATA`; interior nodes are
+`ElementContentSeq` (,) or `ElementContentOr` (|), each requiring BOTH `c1` and `c2`. Every node has an
+occurrence indicator (`ElementContentOnce`/`Opt`/`Mult`/`Plus`). The serializer (`writer_dtd.go`) and the
+matcher (`valid.go`) dereference `c1`/`c2` for seq/choice nodes, so a structurally-incomplete node (a
+seq/choice with nil children) would nil-deref. `AddElementDecl` rejects such a model up front
+(`validateElementContentModel`, `valid.go`) before storing it, so no stored model can panic serialization.
+Safe public composition: `Document.CreateElementContent(name, etype)` (leaf),
+`Document.CreateElementContentSeq(c1, c2, occur)` / `Document.CreateElementContentChoice(c1, c2, occur)`
+(validated interior nodes), and `ElementContent.SetOccurrence(occur)`.
 
 ### Document ID Lookup
-`Document.GetElementByID(id)` — `idsSkip` is authoritative and checked FIRST: when `SkipIDs()` is true it returns nil immediately, resolving NO ids regardless of the `ids` table or DTD subsets. Otherwise it is O(1) via `ids map[string]*Element` (populated during parse), falling back to an O(n) tree walk if the map is empty. The fallback walk consults ID-typed attribute declarations in BOTH the internal and external DTD subsets (`intSubset`, `extSubset`). `Document.SkipIDs()`/`SetSkipIDs(bool)` read/write the `idsSkip` flag (set from parser `SkipIDs(true)`); because it is checked before the table, `SetSkipIDs(true)` suppresses resolution even on a doc with a populated ID table, and `SetSkipIDs(false)` restores it. Carry the flag onto derived docs so id() semantics match the source. `Document.IDTable()` returns the document's own `ids` map (read-only; nil for API-built docs without an interned table) so a derived doc can rebuild an equivalent table by translating each entry's element through an original->copy correspondence. `helium.CopyDoc` does exactly this for a full document copy: it rebuilds the copy's ID table by translating each source entry through the source->copy element correspondence recorded during the deep copy (via the `deepCopier` onCopy hook), and carries over the `idsSkip` flag — so a SkipIDs source yields a copy that resolves NO ids, and a parsed source's ids resolve to the COPY's own elements (never aliasing the source map). The xsl:strip-space copy (`xslt3` copyAndStrip) does the same from `src.IDTable()`, preserving the source's interned ID-table identity — the copy resolves ids to elements corresponding exactly to the source's, and at O(1). Re-deriving them would fall back to the lazy O(n) walk. The fallback walk consults ID-typed ATTLIST declarations by their raw qualified name (prefix+local), so it correctly resolves a prefixed element's qualified ATTLIST (`<!ATTLIST a:item eid ID>`) — but rebuilding from the source table is still preferred for identity and cost fidelity. `CopyDoc` also DEEP-COPIES the source's external subset (via `CopyExtSubset`), so the copy's fallback walk sees the same ID-typed ATTLIST decls as the source. `helium.CopyExtSubset(src, dst *Document)` DEEP-COPIES the source's external subset into `dst` (independent `*DTD`; mutating one never affects the other); `CopyDTDInfo`, by contrast, copies only the internal subset and links it into the document tree (and returns an error when `dst` already has one).
+`Document.GetElementByID(id)` — `idsSkip` is authoritative and checked FIRST: when `SkipIDs()` is true it
+returns nil immediately, resolving NO ids regardless of the `ids` table or DTD subsets. Otherwise it is O(1)
+via `ids map[string]*Element` (populated during parse), falling back to an O(n) tree walk if the map is empty.
+The fallback walk consults ID-typed attribute declarations in BOTH the internal and external DTD subsets
+(`intSubset`, `extSubset`). `Document.SkipIDs()`/`SetSkipIDs(bool)` read/write the `idsSkip` flag (set from
+parser `SkipIDs(true)`); because it is checked before the table, `SetSkipIDs(true)` suppresses resolution even
+on a doc with a populated ID table, and `SetSkipIDs(false)` restores it. Carry the flag onto derived docs so
+id() semantics match the source. `Document.IDTable()` returns the document's own `ids` map (read-only; nil for
+API-built docs without an interned table) so a derived doc can rebuild an equivalent table by translating each
+entry's element through an original->copy correspondence. `helium.CopyDoc` does exactly this for a full
+document copy: it rebuilds the copy's ID table by translating each source entry through the source->copy
+element correspondence recorded during the deep copy (via the `deepCopier` onCopy hook), and carries over the
+`idsSkip` flag — so a SkipIDs source yields a copy that resolves NO ids, and a parsed source's ids resolve to
+the COPY's own elements (never aliasing the source map). The xsl:strip-space copy (`xslt3` copyAndStrip) does
+the same from `src.IDTable()`, preserving the source's interned ID-table identity — the copy resolves ids to
+elements corresponding exactly to the source's, and at O(1). Re-deriving them would fall back to the lazy O(n)
+walk. The fallback walk consults ID-typed ATTLIST declarations by their raw qualified name (prefix+local), so
+it correctly resolves a prefixed element's qualified ATTLIST (`<!ATTLIST a:item eid ID>`) — but rebuilding
+from the source table is still preferred for identity and cost fidelity. `CopyDoc` also DEEP-COPIES the
+source's external subset (via `CopyExtSubset`), so the copy's fallback walk sees the same ID-typed ATTLIST
+decls as the source. `helium.CopyExtSubset(src, dst *Document)` DEEP-COPIES the source's external subset into
+`dst` (independent `*DTD`; mutating one never affects the other); `CopyDTDInfo`, by contrast, copies only the
+internal subset and links it into the document tree (and returns an error when `dst` already has one).
 
 ### Document Encoding (defaulted vs raw)
-`Document.Encoding()` returns `"utf8"` when the `encoding` field is empty (no encoding recorded); `Document.RawEncoding()` returns the field verbatim (empty = none recorded). The XML serializer (`writer.go`) emits `encoding="..."` ONLY when the raw encoding is non-empty, so a faithful document copy must propagate `RawEncoding()` — using `Encoding()` would make the copy serialize a spurious `encoding="utf8"` that was not recorded. `CopyDoc` reads the raw field directly (same package); cross-package copiers (e.g. the xsl:strip-space copy in `xslt3`) use `RawEncoding()`. `Version()` and `Standalone()` already return raw, unsynthesized values.
+`Document.Encoding()` returns `"utf8"` when the `encoding` field is empty (no encoding recorded);
+`Document.RawEncoding()` returns the field verbatim (empty = none recorded). The XML serializer (`writer.go`)
+emits `encoding="..."` ONLY when the raw encoding is non-empty, so a faithful document copy must propagate
+`RawEncoding()` — using `Encoding()` would make the copy serialize a spurious `encoding="utf8"` that was not
+recorded. `CopyDoc` reads the raw field directly (same package); cross-package copiers (e.g. the
+xsl:strip-space copy in `xslt3`) use `RawEncoding()`. `Version()` and `Standalone()` already return raw,
+unsynthesized values.
 
 ### Content() Default
-`docnode.Content()` walks children and concatenates (returns a fresh buffer). Overridden by Text, CDATA, Comment, PI, EntityRef. It has a POINTER receiver (`*docnode`) so the receiver is the real owning node — every `Node` is a pointer (the sealed `baseDocNode()` interface method is itself pointer-receiver), so this changes nothing for callers. The aggregation runs through the private `aggregateOwnedContent` helper, which advances between children with the OWNED-BOUNDARY rule (`nextOwnedChild`): a foreign child — an entity reference's shared Entity child, owned by the DTD, whose sibling pointers belong to the DTD declaration list — ends the aggregation instead of spilling into another list's siblings, and a per-list seen set terminates a cyclic sibling pointer. The recursion into a container child's subtree carries an ACTIVE-PATH set (the container docnodes currently being aggregated, receiver inclusive): a child already on that path is a back-edge and is skipped, so a pure child-pointer cycle (`element -> element -> element`, NOT routed through an Entity's terminating stored-text `Content()`) terminates instead of recursing forever. A leaf child (Text/Comment/CDATA/PI/Entity/NamespaceNodeWrapper — `aggregatesOwnContent` returns false) is self-contained and called directly; every other node type recurses under the guard. The active-path set is not a global visited set, so a shared DAG node reached on a different path is re-aggregated per occurrence.
+`docnode.Content()` walks children and concatenates (returns a fresh buffer). Overridden by Text, CDATA,
+Comment, PI, EntityRef. It has a POINTER receiver (`*docnode`) so the receiver is the real owning node — every
+`Node` is a pointer (the sealed `baseDocNode()` interface method is itself pointer-receiver), so this changes
+nothing for callers. The aggregation runs through the private `aggregateOwnedContent` helper, which advances
+between children with the OWNED-BOUNDARY rule (`nextOwnedChild`): a foreign child — an entity reference's
+shared Entity child, owned by the DTD, whose sibling pointers belong to the DTD declaration list — ends the
+aggregation instead of spilling into another list's siblings, and a per-list seen set terminates a cyclic
+sibling pointer. The recursion into a container child's subtree carries an ACTIVE-PATH set (the container
+docnodes currently being aggregated, receiver inclusive): a child already on that path is a back-edge and is
+skipped, so a pure child-pointer cycle (`element -> element -> element`, NOT routed through an Entity's
+terminating stored-text `Content()`) terminates instead of recursing forever. A leaf child
+(Text/Comment/CDATA/PI/Entity/NamespaceNodeWrapper — `aggregatesOwnContent` returns false) is self-contained
+and called directly; every other node type recurses under the guard. The active-path set is not a global
+visited set, so a shared DAG node reached on a different path is re-aggregated per occurrence.
 
-The text-bearing leaves (Text, Comment, CDATASection) store content in an internal mutable `content []byte`. Their exported `Content()` returns a **defensive copy** (`bytes.Clone`) so a caller mutating the result cannot corrupt the DOM. Internal read-only hot paths (serializers in `writer.go`/`writer_xhtml.go`) use the package-level `rawContent(Node)` helper — backed by an unexported `rawContent()` method on each of those three leaf types — to get the raw slice without the copy. The `rawContentNode` interface gates the no-copy path; for any other node `rawContent` falls back to `Content()`. PI/EntityRef/Entity/NamespaceNodeWrapper already returned string-derived copies and are unaffected.
+The text-bearing leaves (Text, Comment, CDATASection) store content in an internal mutable `content []byte`.
+Their exported `Content()` returns a **defensive copy** (`bytes.Clone`) so a caller mutating the result cannot
+corrupt the DOM. Internal read-only hot paths (serializers in `writer.go`/`writer_xhtml.go`) use the
+package-level `rawContent(Node)` helper — backed by an unexported `rawContent()` method on each of those three
+leaf types — to get the raw slice without the copy. The `rawContentNode` interface gates the no-copy path; for
+any other node `rawContent` falls back to `Content()`. PI/EntityRef/Entity/NamespaceNodeWrapper already
+returned string-derived copies and are unaffected.
 
 ### Predefined Entities
 5 unexported singletons: `entityLT`, `entityGT`, `entityAmpersand`, `entityApostrophe`, `entityQuote` (resolved by name through `resolvePredefinedEntity`). Type `InternalPredefinedEntity`. Cannot be redeclared.
@@ -127,33 +235,320 @@ The text-bearing leaves (Text, Comment, CDATASection) store content in an intern
 Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
 
 ### Tree Operations
-- `addChild(parent, child)` — append to end of children. Attribute-aware, BEFORE the generic child-splice: an `*Attribute` operand is never an ordinary child — on an `*Element` parent it is routed into the properties list via `addProperty` (running the preflight first for cross-document escape marking and auto-unlink from any prior parent/property chain, then replacing a same-named attribute in place, mirroring libxml2 `xmlAddChild`), so `elem.AddChild(attr)` serializes as an attribute and never appears in `Children()`; on ANY other parent (Document, Text, Comment, PI, EntityRef, Attribute, …) an attribute has no valid placement and is rejected with a `%w`-wrapped `ErrInvalidOperation`. A non-attribute child takes the ordinary child-list path (a `*Document` accepts multiple element children — it is an XDM document node, not a well-formed-document constraint; single-root enforcement lives in `SetDocumentElement`, mirroring libxml2's `xmlDocSetRootElement`).
-- `addSibling(node, sibling)` — append to end of siblings. The tree an append leaves behind is always the one the plain `NextSibling()` walk from the anchor produces, INCLUDING every `parent.lastChild` write, which is unconditional exactly as it is in that walk. What changes is how the append point is REACHED: the generic child-list branch resolves it from `parent.lastChild` without walking whenever `tailJumpTarget` (`node.go`) can prove that record is the very node the walk would have found, and otherwise walks. The proof needs two facts. (1) The ANCHOR is a member of the chain `parent` owns — `chainMember` (`node.go`) answers in a pointer comparison when the anchor is `parent.firstChild`, and otherwise walks `prev` to the head of the anchor's own chain and compares it against `parent.firstChild`. (An anchor that is `parent.lastChild` never reaches `chainMember`: `tailJumpTarget` has already declined, because the anchor and the recorded tail are the same node.) That walk is bounded by the anchor's distance BEHIND it, never by the chain ahead of it, so it can never cost more than the `NextSibling()` walk it replaces; it carries a `siblingCycleGuard` so a corrupt `prev` chain terminates instead of spinning, and it crosses only RECIPROCAL `prev` edges (`reciprocalPrev` — the `prev` node points forward at the node again), so a one-way edge cannot carry it out of the anchor's own chain. There is no raw `prev` setter, but a one-way `prev` edge survives whenever a node is spliced out of a chain from the FRONT, so the check is not hypothetical. (2) `parent.lastChild` is the final node of that same chain. NO local read can establish (2): two trees can have pointer-identical neighborhoods around `parent` and `lastChild` and differ only in a `next` pointer an unbounded distance forward from `firstChild`. It holds instead as an INVARIANT of the guarded paths, each of which moves `lastChild` only to a node it has just linked onto the chain, so what is checked is that this document holds no node claiming a parent it is not a child of: `Document.offChainClaims` (`document.go`). `noteOrphanedChildClaim` records the one such claim the GUARDED paths create, which is how an ordinary caller reaches one: a parent holding a `firstChild` with NO `lastChild` — the shape `Document.stringToNodeList` leaves behind on an entity referenced from an attribute value — makes `addChild`/`appendFastChild` take their empty-parent branch, which OVERWRITES `firstChild` and detaches the child that was there while it goes on claiming the parent. An append through that detached child then moves the parent's recorded tail off the child list. Recording the claim at the moment it is created is what keeps the later append byte-identical to the walk. Each claim is recorded on the document owning the parent whose chain is at stake and on the document owning the detached child, each resolved through `owningDocument` so a `*Document` names ITSELF (a document node's own `doc` pointer is nil because it IS the owner). Once set it stays set, and appends for that document walk — which is what every other tree operation does unconditionally. The record FOLLOWS THE TREE, not only the document it was first made on, because a subtree can change owning document afterwards, and a claim made on a still-DETACHED subtree has no document to be recorded on at all. `adoptOffChainClaims` (`node.go`) carries it across every change of owner — `docnode.SetOwnerDocument`, `setTreeDoc`'s attribute write, `setListDoc`'s direct write, and `noteCrossDocumentEscape` — and the unattributable case lands on the package-level `unownedOffChainClaim` (an `atomic.Bool`), which a document inherits when it adopts a subtree that arrives owning no document. That global is the ONE package-wide part; the flag itself stays per-DOCUMENT, because one claim must not slow every other document in the process. `TestAdoptOffChainClaimWithoutOwner` (`node_sibling_internal_test.go`) pins the unowned case. A `*Document` parent is NOT declined by type. Its owning document is read through `owningDocument`, so it names itself, and a document's child list is an ordinary sibling chain that an append walks exactly like any other. A document is claimed off-chain by `CopyExtSubset`, which gives the copied EXTERNAL subset the destination document as its parent and then leaves it reachable only through `ExtSubset`, never from the child list, so an append through that subset records a tail off the child list. That is a CONDITION, not a type, and `Document.offChainChildClaim` (`document.go`, set by `CopyExtSubset`) records it separately from `offChainClaims` so it declines only for the `*Document` parent handed the claimant, not for every parent in that document. (`CreateInternalSubset` also gives a `DTD` the document as its parent, but it splices that `DTD` into the child list, so it creates no claim.) `TestTailJumpTargetDocumentParent` (`node_sibling_internal_test.go`) pins all three outcomes. `tailJumpTarget` then makes three cheap confirmations that the record is usable (`tail != anchor`, `tail.next == nil`, `tail.parent` is this parent); they cannot fail on a document holding no recorded claim, and are kept because a tree may span documents (`noteCrossDocumentEscape`) while the record does not, so an uncovered corner degrades to the walk instead of splicing onto the wrong node. They also keep the stale-`lastChild` repair path `addChild`/`appendFastChild` depend on: they call `AddSibling` on `parent.lastChild` precisely when that node's `next` is non-nil, so the resolution declines and the walk finds and repairs the true tail. WHAT THE O(1) RESOLUTION IS WORTH DEPENDS ON THE ANCHOR: appending through `parent.firstChild`, or at the true tail (where the anchor's `next` is nil and `addSibling` links directly without consulting `tailJumpTarget` at all), is O(1) per call and LINEAR over N appends (105µs vs 49.5ms at N=4000, a ~470x win), while appending through a MIDDLE anchor stays QUADRATIC — `chainMember`'s `prev` walk grows with the chain — and gains a ~3.8x constant factor instead (26.5ms vs 99.6ms at N=4000). `BenchmarkAddSibling` (`node_sibling_bench_test.go`) measures five arms: `tail`, `nontail` (= first child) and `middle` on an `*Element` parent, plus `docnontail` and `docmiddle` on a `*Document` parent, which track the element arms to within noise. The attribute-chain branch (an anchor genuinely reachable from its owning `*Element`'s `properties` chain) resolves its tail by walking, bounded by the attribute count, because the `properties` membership test already costs that walk. A node can claim a parent without being a member of that parent's child list — the detached-child shape above, `CopyExtSubset`'s copied external subset, or a package-private `unsafeSetParent` write. An append through such a node records its own result as the parent's `lastChild`, moving that record off the child list, after which `AddSibling` (which walks from its anchor) lands at the end of the REACHABLE children while `AddChild` and `UnsafeAppendChild` (which start from the record) land after the off-chain node. `TestAddSiblingOffChainParentClaim`, `TestAddSiblingCopiedExternalSubsetClaim` and `TestAddSiblingCorruptShapesMatchWalk` (`node_sibling_test.go`) pin those shapes; every expectation in them holds for the walk-only implementation too, which is what makes them a differential check. The raw setters record NOTHING, so a tree corrupted through them is outside this agreement — they already document the tree as inconsistent afterwards, and no importer and no production path can reach them.
-- `replaceNode(old, new)` — swap in same position. Attribute-aware: replacing an `Attribute` updates the owning `Element.properties` head/chain (NOT `firstChild`/`lastChild`), and an attribute may only be replaced by attribute node(s) (non-attribute replacement is rejected)
-- `appendFastChild(parent, child)` (`tree_fastpath.go`) — package-private no-preflight append: links child as last child WITHOUT the cycle-guard / duplicate-attr checks. The caller guarantees an acyclic, dup-free child (deep copies, freshly-built trees). Ordinary code uses `AddChild`. It backs the parser's fast SAX path in-package; `xslt3`'s strip-space copier reaches it through the `internal/nodelink` hook `AppendFastChild`, and the external `helium_test` package through `UnsafeAppendChildForTesting` in `export_test.go`.
-- `appendCopiedChild(parent, child)` (`copy_deep.go`) — the deep-copy core's own no-preflight link, used by `copyChildren` in place of `AddChild`. It mirrors `addChild`'s linking rules exactly, INCLUDING the adjacent-Text merge and the `pdn.lastChild` correction that follows a merge, but skips `addChild`'s `wouldCreateCycle` preflight. This is what makes `CopyNode`/`CopyDoc` linear instead of quadratic in tree depth: bottom-up child-linking through `AddChild` runs `childReaches` over each already-built child subtree as it is attached, so linking a deep chain one level at a time costs the sum of all subtree sizes. Skipping the preflight is sound here — never elsewhere — because every node `copyNode` returns is freshly allocated in `dc.dst` and has never been linked anywhere: `CreateCharRef` (the `EntityRefNode` branch) creates a childless `EntityRef` with no shared-Entity foreign link, unlike `CreateReference`, so a copied subtree can never carry the one production foreign-link source `wouldCreateCycle` exists to catch. `appendCopiedChild` is distinct from `appendFastChild` — it is not used outside the copier — because `appendFastChild` also backs `xslt3`'s strip-space copier, and widening its linking rule to add a merge check would change behavior for that unrelated caller too.
-- `DeclareNamespace(prefix, uri)` / `AddNamespaceDecl(ns)` — do NOT themselves add a second declaration for a prefix in `nsDefs`, and NEVER touch the node's active namespace (`n.ns`) or expanded name. `DeclareNamespace` allocates a fresh `*Namespace`; `AddNamespaceDecl` attaches the caller's existing object (no alloc), so a tree-builder can reuse one Namespace as both a declaration and an element's active ns. Both apply the same rule keyed on the prefix. The CONFLICT test runs FIRST and is ELEMENT-scoped: on a non-element node (Text, Comment, CDATASection, …) `n.ns` is never serialized, so there is never a conflict — the node skips straight to the dedup step below (never rejecting; `AddNamespaceDecl` installs on case 1/3 and keeps the existing slot on a same-URI no-op). On an element node, whether or not an nsDefs entry exists: if the prefix is in use by `n.ns` or a NON-empty-prefix attribute's `ns` at a URI DIFFERENT from the requested URI, that is a genuine conflict and the tree is unchanged (both `DeclareNamespace` and `AddNamespaceDecl` return the same `%w`-wrapped `ErrInvalidOperation`, matchable with `errors.Is`). This covers both the fresh-append path (`SetActiveNamespace("p",X)` then `DeclareNamespace("p",Y)` with `Y≠X` — no nsDefs entry yet, but declaring `p→Y` while the reconciler synthesizes `p→X` would emit two `xmlns:p`) and the existing-entry path. An EMPTY-prefix attribute never uses the default namespace (an unprefixed attribute name is in no namespace) and the serializer skips its namespace (`reconcileOne` returns early for `prefix==""` && !isElement), so it is NOT counted as a conflict for the empty/default prefix — a real default-namespace element name via `n.ns` still counts. A use at the SAME URI is not a conflict (the reconciler finds the prefix already bound to that URI and synthesizes nothing). When there is no conflict: (1) no existing entry → append; (2) existing entry, same URI → no-op; (3) existing entry, different URI → COLLAPSE (replace the single slot in place: `DeclareNamespace` installs a FRESH `*Namespace`, `AddNamespaceDecl` installs the CALLER's object; the old slot object is left unmutated, so an aliasing `n.ns`/`attr.ns` or a caller-retained handle is unaffected). When `AddNamespaceDecl` RETAINS the caller's object (case 1 append and case 3 collapse) and that object is slab-backed by a different document than the node's owner, the source document is marked `slabEscaped` (Cross-Document Slab Safety below), mirroring a cross-document node move. A caller that rebinds an in-use prefix must clear the use itself (reassign `n.ns` via `SetActiveNamespace`/`SetNamespace` and any prefixed attribute); `RemoveNamespaceByPrefix` alone drops only the nsDefs entry, not the use, so a rebind still rejects while the use remains. These methods do NOT reconcile a conflict introduced AFTER declaration by `SetActiveNamespace`/`SetNamespace` (which set the active namespace independently); guaranteeing at most one `xmlns:prefix` per element ACROSS all mutators is a serializer-level concern, outside these mutators' scope. The serializer enforces it: `writer.go` `dropConflictingActiveNS` drops any `nsDefs` declaration for the ACTIVE namespace's prefix at a different URI (the general form of the default-namespace `xmlns=""` precedent — the active binding qualifies the element name, so it wins), and `reconcileNamespaces` carries a per-element `emitted` prefix set so no prefix is declared twice on one start tag even when two sources (name vs attribute) bind it to different URIs — the first occupant wins (the element's own declarations, then its name, before attributes). Both are no-ops for parsed documents (a real parse never binds one prefix to two URIs on an element), so no golden output changes. Residual limitation: when the element NAME needs prefix `p` at URI Y and an ATTRIBUTE on the same element needs `p` at a different URI X, one prefix cannot serve both; the writer keeps the output well-formed by letting the NAME win (emits `xmlns:p="Y"` once, suppresses the attribute's `X`), which mis-binds the attribute. Synthesizing a fresh prefix to preserve both faithfully would need `xmlReconciliateNs`-style prefix generation, out of scope here. `AddNamespaceDecl(nil)` returns `ErrNilNode` and leaves `nsDefs` unchanged (a nil declaration is rejected, not appended); the dedup scan still skips any nil `nsDefs` slot injected by an in-package field write.
+- `addChild(parent, child)` — append to end of children. Attribute-aware, BEFORE the generic child-splice: an
+  `*Attribute` operand is never an ordinary child — on an `*Element` parent it is routed into the properties
+  list via `addProperty` (running the preflight first for cross-document escape marking and auto-unlink from
+  any prior parent/property chain, then replacing a same-named attribute in place, mirroring libxml2
+  `xmlAddChild`), so `elem.AddChild(attr)` serializes as an attribute and never appears in `Children()`; on
+  ANY other parent (Document, Text, Comment, PI, EntityRef, Attribute, …) an attribute has no valid placement
+  and is rejected with a `%w`-wrapped `ErrInvalidOperation`. A non-attribute child takes the ordinary
+  child-list path (a `*Document` accepts multiple element children — it is an XDM document node, not a
+  well-formed-document constraint; single-root enforcement lives in `SetDocumentElement`, mirroring libxml2's
+  `xmlDocSetRootElement`).
+- `addSibling(node, sibling)` — append to end of siblings. The tree an append leaves behind is always the one
+  the plain `NextSibling()` walk from the anchor produces, INCLUDING every `parent.lastChild` write, which is
+  unconditional exactly as it is in that walk. What changes is how the append point is REACHED: the generic
+  child-list branch resolves it from `parent.lastChild` without walking whenever `tailJumpTarget` (`node.go`)
+  can prove that record is the very node the walk would have found, and otherwise walks. The proof needs two
+  facts. (1) The ANCHOR is a member of the chain `parent` owns — `chainMember` (`node.go`) answers in a
+  pointer comparison when the anchor is `parent.firstChild`, and otherwise walks `prev` to the head of the
+  anchor's own chain and compares it against `parent.firstChild`. (An anchor that is `parent.lastChild` never
+  reaches `chainMember`: `tailJumpTarget` has already declined, because the anchor and the recorded tail are
+  the same node.) That walk is bounded by the anchor's distance BEHIND it, never by the chain ahead of it, so
+  it can never cost more than the `NextSibling()` walk it replaces; it carries a `siblingCycleGuard` so a
+  corrupt `prev` chain terminates instead of spinning, and it crosses only RECIPROCAL `prev` edges
+  (`reciprocalPrev` — the `prev` node points forward at the node again), so a one-way edge cannot carry it out
+  of the anchor's own chain. There is no raw `prev` setter, but a one-way `prev` edge survives whenever a node
+  is spliced out of a chain from the FRONT, so the check is not hypothetical. (2) `parent.lastChild` is the
+  final node of that same chain. NO local read can establish (2): two trees can have pointer-identical
+  neighborhoods around `parent` and `lastChild` and differ only in a `next` pointer an unbounded distance
+  forward from `firstChild`. It holds instead as an INVARIANT of the guarded paths, each of which moves
+  `lastChild` only to a node it has just linked onto the chain, so what is checked is that this document holds
+  no node claiming a parent it is not a child of: `Document.offChainClaims` (`document.go`).
+  `noteOrphanedChildClaim` records the one such claim the GUARDED paths create, which is how an ordinary
+  caller reaches one: a parent holding a `firstChild` with NO `lastChild` — the shape
+  `Document.stringToNodeList` leaves behind on an entity referenced from an attribute value — makes
+  `addChild`/`appendFastChild` take their empty-parent branch, which OVERWRITES `firstChild` and detaches the
+  child that was there while it goes on claiming the parent. An append through that detached child then moves
+  the parent's recorded tail off the child list. Recording the claim at the moment it is created is what keeps
+  the later append byte-identical to the walk. Each claim is recorded on the document owning the parent whose
+  chain is at stake and on the document owning the detached child, each resolved through `owningDocument` so a
+  `*Document` names ITSELF (a document node's own `doc` pointer is nil because it IS the owner). Once set it
+  stays set, and appends for that document walk — which is what every other tree operation does
+  unconditionally. The record FOLLOWS THE TREE, not only the document it was first made on, because a subtree
+  can change owning document afterwards, and a claim made on a still-DETACHED subtree has no document to be
+  recorded on at all. `adoptOffChainClaims` (`node.go`) carries it across every change of owner —
+  `docnode.SetOwnerDocument`, `setTreeDoc`'s attribute write, `setListDoc`'s direct write, and
+  `noteCrossDocumentEscape` — and the unattributable case lands on the package-level `unownedOffChainClaim`
+  (an `atomic.Bool`), which a document inherits when it adopts a subtree that arrives owning no document. That
+  global is the ONE package-wide part; the flag itself stays per-DOCUMENT, because one claim must not slow
+  every other document in the process. `TestAdoptOffChainClaimWithoutOwner` (`node_sibling_internal_test.go`)
+  pins the unowned case. A `*Document` parent is NOT declined by type. Its owning document is read through
+  `owningDocument`, so it names itself, and a document's child list is an ordinary sibling chain that an
+  append walks exactly like any other. A document is claimed off-chain by `CopyExtSubset`, which gives the
+  copied EXTERNAL subset the destination document as its parent and then leaves it reachable only through
+  `ExtSubset`, never from the child list, so an append through that subset records a tail off the child list.
+  That is a CONDITION, not a type, and `Document.offChainChildClaim` (`document.go`, set by `CopyExtSubset`)
+  records it separately from `offChainClaims` so it declines only for the `*Document` parent handed the
+  claimant, not for every parent in that document. (`CreateInternalSubset` also gives a `DTD` the document as
+  its parent, but it splices that `DTD` into the child list, so it creates no claim.)
+  `TestTailJumpTargetDocumentParent` (`node_sibling_internal_test.go`) pins all three outcomes.
+  `tailJumpTarget` then makes three cheap confirmations that the record is usable (`tail != anchor`,
+  `tail.next == nil`, `tail.parent` is this parent); they cannot fail on a document holding no recorded claim,
+  and are kept because a tree may span documents (`noteCrossDocumentEscape`) while the record does not, so an
+  uncovered corner degrades to the walk instead of splicing onto the wrong node. They also keep the
+  stale-`lastChild` repair path `addChild`/`appendFastChild` depend on: they call `AddSibling` on
+  `parent.lastChild` precisely when that node's `next` is non-nil, so the resolution declines and the walk
+  finds and repairs the true tail. WHAT THE O(1) RESOLUTION IS WORTH DEPENDS ON THE ANCHOR: appending through
+  `parent.firstChild`, or at the true tail (where the anchor's `next` is nil and `addSibling` links directly
+  without consulting `tailJumpTarget` at all), is O(1) per call and LINEAR over N appends (105µs vs 49.5ms at
+  N=4000, a ~470x win), while appending through a MIDDLE anchor stays QUADRATIC — `chainMember`'s `prev` walk
+  grows with the chain — and gains a ~3.8x constant factor instead (26.5ms vs 99.6ms at N=4000).
+  `BenchmarkAddSibling` (`node_sibling_bench_test.go`) measures five arms: `tail`, `nontail` (= first child)
+  and `middle` on an `*Element` parent, plus `docnontail` and `docmiddle` on a `*Document` parent, which track
+  the element arms to within noise. The attribute-chain branch (an anchor genuinely reachable from its owning
+  `*Element`'s `properties` chain) resolves its tail by walking, bounded by the attribute count, because the
+  `properties` membership test already costs that walk. A node can claim a parent without being a member of
+  that parent's child list — the detached-child shape above, `CopyExtSubset`'s copied external subset, or a
+  package-private `unsafeSetParent` write. An append through such a node records its own result as the
+  parent's `lastChild`, moving that record off the child list, after which `AddSibling` (which walks from its
+  anchor) lands at the end of the REACHABLE children while `AddChild` and `UnsafeAppendChild` (which start
+  from the record) land after the off-chain node. `TestAddSiblingOffChainParentClaim`,
+  `TestAddSiblingCopiedExternalSubsetClaim` and `TestAddSiblingCorruptShapesMatchWalk`
+  (`node_sibling_test.go`) pin those shapes; every expectation in them holds for the walk-only implementation
+  too, which is what makes them a differential check. The raw setters record NOTHING, so a tree corrupted
+  through them is outside this agreement — they already document the tree as inconsistent afterwards, and no
+  importer and no production path can reach them.
+- `replaceNode(old, new)` — swap in same position. Attribute-aware: replacing an `Attribute` updates the
+  owning `Element.properties` head/chain (NOT `firstChild`/`lastChild`), and an attribute may only be replaced
+  by attribute node(s) (non-attribute replacement is rejected)
+- `appendFastChild(parent, child)` (`tree_fastpath.go`) — package-private no-preflight append: links child as
+  last child WITHOUT the cycle-guard / duplicate-attr checks. The caller guarantees an acyclic, dup-free child
+  (deep copies, freshly-built trees). Ordinary code uses `AddChild`. It backs the parser's fast SAX path
+  in-package; `xslt3`'s strip-space copier reaches it through the `internal/nodelink` hook `AppendFastChild`,
+  and the external `helium_test` package through `UnsafeAppendChildForTesting` in `export_test.go`.
+- `appendCopiedChild(parent, child)` (`copy_deep.go`) — the deep-copy core's own no-preflight link, used by
+  `copyChildren` in place of `AddChild`. It mirrors `addChild`'s linking rules exactly, INCLUDING the
+  adjacent-Text merge and the `pdn.lastChild` correction that follows a merge, but skips `addChild`'s
+  `wouldCreateCycle` preflight. This is what makes `CopyNode`/`CopyDoc` linear instead of quadratic in tree
+  depth: bottom-up child-linking through `AddChild` runs `childReaches` over each already-built child subtree
+  as it is attached, so linking a deep chain one level at a time costs the sum of all subtree sizes. Skipping
+  the preflight is sound here — never elsewhere — because every node `copyNode` returns is freshly allocated
+  in `dc.dst` and has never been linked anywhere: `CreateCharRef` (the `EntityRefNode` branch) creates a
+  childless `EntityRef` with no shared-Entity foreign link, unlike `CreateReference`, so a copied subtree can
+  never carry the one production foreign-link source `wouldCreateCycle` exists to catch. `appendCopiedChild`
+  is distinct from `appendFastChild` — it is not used outside the copier — because `appendFastChild` also
+  backs `xslt3`'s strip-space copier, and widening its linking rule to add a merge check would change behavior
+  for that unrelated caller too.
+- `DeclareNamespace(prefix, uri)` / `AddNamespaceDecl(ns)` — do NOT themselves add a second declaration for a
+  prefix in `nsDefs`, and NEVER touch the node's active namespace (`n.ns`) or expanded name.
+  `DeclareNamespace` allocates a fresh `*Namespace`; `AddNamespaceDecl` attaches the caller's existing object
+  (no alloc), so a tree-builder can reuse one Namespace as both a declaration and an element's active ns. Both
+  apply the same rule keyed on the prefix. The CONFLICT test runs FIRST and is ELEMENT-scoped: on a
+  non-element node (Text, Comment, CDATASection, …) `n.ns` is never serialized, so there is never a conflict —
+  the node skips straight to the dedup step below (never rejecting; `AddNamespaceDecl` installs on case 1/3
+  and keeps the existing slot on a same-URI no-op). On an element node, whether or not an nsDefs entry exists:
+  if the prefix is in use by `n.ns` or a NON-empty-prefix attribute's `ns` at a URI DIFFERENT from the
+  requested URI, that is a genuine conflict and the tree is unchanged (both `DeclareNamespace` and
+  `AddNamespaceDecl` return the same `%w`-wrapped `ErrInvalidOperation`, matchable with `errors.Is`). This
+  covers both the fresh-append path (`SetActiveNamespace("p",X)` then `DeclareNamespace("p",Y)` with `Y≠X` —
+  no nsDefs entry yet, but declaring `p→Y` while the reconciler synthesizes `p→X` would emit two `xmlns:p`)
+  and the existing-entry path. An EMPTY-prefix attribute never uses the default namespace (an unprefixed
+  attribute name is in no namespace) and the serializer skips its namespace (`reconcileOne` returns early for
+  `prefix==""` && !isElement), so it is NOT counted as a conflict for the empty/default prefix — a real
+  default-namespace element name via `n.ns` still counts. A use at the SAME URI is not a conflict (the
+  reconciler finds the prefix already bound to that URI and synthesizes nothing). When there is no conflict:
+  (1) no existing entry → append; (2) existing entry, same URI → no-op; (3) existing entry, different URI →
+  COLLAPSE (replace the single slot in place: `DeclareNamespace` installs a FRESH `*Namespace`,
+  `AddNamespaceDecl` installs the CALLER's object; the old slot object is left unmutated, so an aliasing
+  `n.ns`/`attr.ns` or a caller-retained handle is unaffected). When `AddNamespaceDecl` RETAINS the caller's
+  object (case 1 append and case 3 collapse) and that object is slab-backed by a different document than the
+  node's owner, the source document is marked `slabEscaped` (Cross-Document Slab Safety below), mirroring a
+  cross-document node move. A caller that rebinds an in-use prefix must clear the use itself (reassign `n.ns`
+  via `SetActiveNamespace`/`SetNamespace` and any prefixed attribute); `RemoveNamespaceByPrefix` alone drops
+  only the nsDefs entry, not the use, so a rebind still rejects while the use remains. These methods do NOT
+  reconcile a conflict introduced AFTER declaration by `SetActiveNamespace`/`SetNamespace` (which set the
+  active namespace independently); guaranteeing at most one `xmlns:prefix` per element ACROSS all mutators is
+  a serializer-level concern, outside these mutators' scope. The serializer enforces it: `writer.go`
+  `dropConflictingActiveNS` drops any `nsDefs` declaration for the ACTIVE namespace's prefix at a different
+  URI (the general form of the default-namespace `xmlns=""` precedent — the active binding qualifies the
+  element name, so it wins), and `reconcileNamespaces` carries a per-element `emitted` prefix set so no prefix
+  is declared twice on one start tag even when two sources (name vs attribute) bind it to different URIs — the
+  first occupant wins (the element's own declarations, then its name, before attributes). Both are no-ops for
+  parsed documents (a real parse never binds one prefix to two URIs on an element), so no golden output
+  changes. Residual limitation: when the element NAME needs prefix `p` at URI Y and an ATTRIBUTE on the same
+  element needs `p` at a different URI X, one prefix cannot serve both; the writer keeps the output
+  well-formed by letting the NAME win (emits `xmlns:p="Y"` once, suppresses the attribute's `X`), which
+  mis-binds the attribute. Synthesizing a fresh prefix to preserve both faithfully would need
+  `xmlReconciliateNs`-style prefix generation, out of scope here. `AddNamespaceDecl(nil)` returns `ErrNilNode`
+  and leaves `nsDefs` unchanged (a nil declaration is rejected, not appended); the dedup scan still skips any
+  nil `nsDefs` slot injected by an in-package field write.
 - `UnlinkNode(n)` — detach a `MutableNode` from parent and siblings (delegates to the internal `unlinkNode(Node)`)
-- `unlinkNode(n)` — internal detach that works for ANY sealed node via `baseDocNode()`, including non-`MutableNode` nodes like `NamespaceNodeWrapper`. Attribute-aware: an `Attribute` under an `*Element` is detached via `spliceOutAttribute`, repairing `Element.properties`
+- `unlinkNode(n)` — internal detach that works for ANY sealed node via `baseDocNode()`, including
+  non-`MutableNode` nodes like `NamespaceNodeWrapper`. Attribute-aware: an `Attribute` under an `*Element` is
+  detached via `spliceOutAttribute`, repairing `Element.properties`
 
-The `MutableNode` interface exposes ONLY guarded/whole-value mutation (`AddChild`, `AddSibling`, `Replace`, `AppendText`, `SetLine`, `SetOwnerDocument`, `SetTreeDoc`). Raw single-pointer linkage that updates just one of `parent`/`next` — with none of the cycle detection, auto-unlinking, or reciprocal back-pointer maintenance — is NOT on the interface and NOT a method on the node types. Two package-private functions in `node.go` provide it, both writing `n.baseDocNode().<field>` directly: `unsafeSetNextSibling(n Node, next Node)` and `unsafeSetParent(n Node, parent Node)`. Neither is exported. The external `helium_test` package reaches them through `UnsafeSetNextSiblingForTesting` / `UnsafeSetParentForTesting` in `export_test.go` (test builds only), and the cycle-guard tests in `xsd` and `xmldsig1` reach `unsafeSetNextSibling` through the `internal/nodelink` hooks `CorruptSelfNextSibling` (writes `n.next = n`) and `CorruptTypedNilNextSibling` (writes `n.next` = a typed-nil `*Element`), which exist for those corrupt-tree fixtures and nothing else. There is no `prev`-pointer setter. Both can leave the tree inconsistent or cyclic; they exist for low-level construction and for tests that must build a deliberately corrupt tree to exercise the traversal cycle guards. Ordinary code uses `AddChild`/`AddSibling`/`Replace`/`UnlinkNode`. In-package tree builders write the docnode fields directly (e.g. `attr.parent = n`). Neither setter records anything: `addSibling`'s O(1) append-point resolution (see `addSibling` above) is not promised to match its walk on a tree corrupted through them.
+The `MutableNode` interface exposes ONLY guarded/whole-value mutation (`AddChild`, `AddSibling`, `Replace`,
+`AppendText`, `SetLine`, `SetOwnerDocument`, `SetTreeDoc`). Raw single-pointer linkage that updates just one
+of `parent`/`next` — with none of the cycle detection, auto-unlinking, or reciprocal back-pointer maintenance
+— is NOT on the interface and NOT a method on the node types. Two package-private functions in `node.go`
+provide it, both writing `n.baseDocNode().<field>` directly: `unsafeSetNextSibling(n Node, next Node)` and
+`unsafeSetParent(n Node, parent Node)`. Neither is exported. The external `helium_test` package reaches them
+through `UnsafeSetNextSiblingForTesting` / `UnsafeSetParentForTesting` in `export_test.go` (test builds only),
+and the cycle-guard tests in `xsd` and `xmldsig1` reach `unsafeSetNextSibling` through the `internal/nodelink`
+hooks `CorruptSelfNextSibling` (writes `n.next = n`) and `CorruptTypedNilNextSibling` (writes `n.next` = a
+typed-nil `*Element`), which exist for those corrupt-tree fixtures and nothing else. There is no
+`prev`-pointer setter. Both can leave the tree inconsistent or cyclic; they exist for low-level construction
+and for tests that must build a deliberately corrupt tree to exercise the traversal cycle guards. Ordinary
+code uses `AddChild`/`AddSibling`/`Replace`/`UnlinkNode`. In-package tree builders write the docnode fields
+directly (e.g. `attr.parent = n`). Neither setter records anything: `addSibling`'s O(1) append-point
+resolution (see `addSibling` above) is not promised to match its walk on a tree corrupted through them.
 
-`Document.SetDocumentElement(root MutableNode)` requires `root` to be an element: a non-element kind (Text/Comment/DTD/NamespaceDecl/…) is rejected with `ErrInvalidOperation` and the document is left untouched, a nil (or typed-nil) `root` returns `ErrNilNode`, and a nil receiver returns `ErrNilNode` (not a silent success). An existing document element is replaced via `Replace`; otherwise the new root is appended via `AddChild`, so the cycle/self preflight still runs before linking.
+`Document.SetDocumentElement(root MutableNode)` requires `root` to be an element: a non-element kind
+(Text/Comment/DTD/NamespaceDecl/…) is rejected with `ErrInvalidOperation` and the document is left untouched,
+a nil (or typed-nil) `root` returns `ErrNilNode`, and a nil receiver returns `ErrNilNode` (not a silent
+success). An existing document element is replaced via `Replace`; otherwise the new root is appended via
+`AddChild`, so the cycle/self preflight still runs before linking.
 
-All three insertion paths share `wouldCreateCycle(parent, cur)`: they reject inserting a node into itself or into one of its own descendants (which would put an ancestor below itself). The guard has TWO parts: an ANCESTOR walk (parent's parent chain, inclusive, looking for cur) that catches every cycle at O(depth) when parent/child links are consistent; and, ONLY when cur has children, a CHILD-pointer reachability search (`childReaches`, an ITERATIVE stack-based DFS with a per-call visited set) that catches a cycle formed through a FOREIGN child link. A foreign link is a child whose own parent pointer points elsewhere — an entity reference's child is the shared Entity node, whose parent stays the DTD — so `ent.AddChild(ref)` where ref's child is ent forms a child-pointer cycle the ancestor walk cannot see. `childReaches` enumerates each node's OWN children via `nextOwnedSibling` (a foreign child's `next` belongs to another list, so it is not followed as a sibling) and descends fully (it does NOT skip foreign subtrees, since a live insertion parent CAN legitimately lie inside a shared entity expansion). It is iterative (no goroutine-stack overflow on a deep tree) and has NO depth cap — the popped-node visited set alone bounds it (each node visited once), so it is SOUND at any depth: a depth cap would fail OPEN and admit a cycle deeper than the cap. The popped-node visited set (`childReachesVisited`) starts as a fixed 64-entry array scanned linearly — no allocation — and promotes itself to a map once a call pops more than 64 distinct nodes, from which point the map is authoritative; the 64-entry cap selects a DATA STRUCTURE only, never a search cutoff, so a call past the cap keeps searching exactly as before, backed by a map. The INNER sibling enumeration is bounded by `siblingCycleGuard` (the same allocation-free Brent's-algorithm guard `Children`/`ChildElements`/`Descendants` use, described below) rather than a per-call sibling-seen set: a seen set would stop at the exact first repeat, while `siblingCycleGuard` stops within a small multiple of the cycle length, so on a corrupt sibling list a few nodes may be pushed onto the stack more than once — harmless, since the popped-node visited set deduplicates the extra pushes on pop, and termination is unconditional either way. The childless-cur fast path (the parser hot path appends fresh leaves) skips the search entirely, so plain parsing is unaffected; it only runs for a subtree/entity-ref insertion. addChild/addSibling auto-unlink an already-linked incoming node before relinking so it never lives in two places; rejection leaves the tree untouched. The shared guard + auto-unlink is factored into `addChildPreflight`/`addSiblingPreflight`. Leaf `AddChild`/`AddSibling` overrides that take a content-merge fast path (Text, Comment, and ProcessingInstruction — whose `AddChild` merges a Text/CDATA operand's content into the PI data string) run the matching preflight BEFORE merging, so `txt.AddChild(txt)`/`comment.AddChild(comment)` are rejected instead of doubling content, and an already-linked incoming leaf (including a Text/CDATA node merged into a PI) is unlinked from its old parent before its content is merged. These overrides also reject a nil or typed-nil operand with `ErrNilNode` before any method call on the operand, since a typed nil reaching the type switch / merge path would panic.
+All three insertion paths share `wouldCreateCycle(parent, cur)`: they reject inserting a node into itself or
+into one of its own descendants (which would put an ancestor below itself). The guard has TWO parts: an
+ANCESTOR walk (parent's parent chain, inclusive, looking for cur) that catches every cycle at O(depth) when
+parent/child links are consistent; and, ONLY when cur has children, a CHILD-pointer reachability search
+(`childReaches`, an ITERATIVE stack-based DFS with a per-call visited set) that catches a cycle formed through
+a FOREIGN child link. A foreign link is a child whose own parent pointer points elsewhere — an entity
+reference's child is the shared Entity node, whose parent stays the DTD — so `ent.AddChild(ref)` where ref's
+child is ent forms a child-pointer cycle the ancestor walk cannot see. `childReaches` enumerates each node's
+OWN children via `nextOwnedSibling` (a foreign child's `next` belongs to another list, so it is not followed
+as a sibling) and descends fully (it does NOT skip foreign subtrees, since a live insertion parent CAN
+legitimately lie inside a shared entity expansion). It is iterative (no goroutine-stack overflow on a deep
+tree) and has NO depth cap — the popped-node visited set alone bounds it (each node visited once), so it is
+SOUND at any depth: a depth cap would fail OPEN and admit a cycle deeper than the cap. The popped-node visited
+set (`childReachesVisited`) starts as a fixed 64-entry array scanned linearly — no allocation — and promotes
+itself to a map once a call pops more than 64 distinct nodes, from which point the map is authoritative; the
+64-entry cap selects a DATA STRUCTURE only, never a search cutoff, so a call past the cap keeps searching
+exactly as before, backed by a map. The INNER sibling enumeration is bounded by `siblingCycleGuard` (the same
+allocation-free Brent's-algorithm guard `Children`/`ChildElements`/`Descendants` use, described below) rather
+than a per-call sibling-seen set: a seen set would stop at the exact first repeat, while `siblingCycleGuard`
+stops within a small multiple of the cycle length, so on a corrupt sibling list a few nodes may be pushed onto
+the stack more than once — harmless, since the popped-node visited set deduplicates the extra pushes on pop,
+and termination is unconditional either way. The childless-cur fast path (the parser hot path appends fresh
+leaves) skips the search entirely, so plain parsing is unaffected; it only runs for a subtree/entity-ref
+insertion. addChild/addSibling auto-unlink an already-linked incoming node before relinking so it never lives
+in two places; rejection leaves the tree untouched. The shared guard + auto-unlink is factored into
+`addChildPreflight`/`addSiblingPreflight`. Leaf `AddChild`/`AddSibling` overrides that take a content-merge
+fast path (Text, Comment, and ProcessingInstruction — whose `AddChild` merges a Text/CDATA operand's content
+into the PI data string) run the matching preflight BEFORE merging, so
+`txt.AddChild(txt)`/`comment.AddChild(comment)` are rejected instead of doubling content, and an
+already-linked incoming leaf (including a Text/CDATA node merged into a PI) is unlinked from its old parent
+before its content is merged. These overrides also reject a nil or typed-nil operand with `ErrNilNode` before
+any method call on the operand, since a typed nil reaching the type switch / merge path would panic.
 
-The read-only traversal APIs (`Walk`, `Children`, `ChildElements`, `Descendants`, and the aggregating `Content()`) share the same two safety properties, so a hand-built or foreign-linked graph cannot make them wander or loop. (1) OWNED BOUNDARY: they advance between siblings via `nextOwnedChild(owner, child)` (returns `child.NextSibling()` only when `child.Parent()` is `owner`), so a foreign child — an entity reference's shared Entity child, owned by the DTD — ends that child list instead of spilling into the DTD's unrelated declaration siblings. (2) CYCLE SAFETY: `Walk` carries the set of nodes currently ON the DFS stack (the active path, O(depth)) and returns the `ErrWalkCycle` sentinel when it would descend into a node already on that path (a child-pointer back-edge, e.g. an Entity whose child links back to its reference); it also carries a PER-FRAME `seenChildren` set that returns `ErrWalkCycle` when a child repeats within one sibling list — this covers BOTH a one-node self-loop (`child.next == child`) and a longer sibling cycle (`a -> b -> a`), which the active-path set misses because each child is popped before its next sibling is examined. `nextWalkSibling` does NOT special-case the self-loop: it lets the duplicate flow back so `seenChildren` reports `ErrWalkCycle`. Special-casing it would silently terminate and report a corrupt one-node cycle as fully traversed. `Descendants` mirrors this with an active-path set threaded through its recursion (visits a back-edge node once, does not descend through it) plus a per-list sibling guard; `Children`/`ChildElements` use that same per-list sibling guard. That guard is `siblingCycleGuard` (`iter.go`), Brent's cycle detection over the sibling chain: three words of state and no allocation, so a well-formed list — every list the parser builds — pays nothing for a check that fires only on a corrupt graph, where a seen set costs a map plus one insert per child on EVERY list. The trade is where the walk stops: a seen set stops at the exact first repeat, Brent stops once the chasing pointer catches its checkpoint, within a small multiple of the cycle length, so a cyclic list can yield some of its nodes more than once before terminating. Termination is unconditional either way, which is the property the iterators promise. `Walk` keeps its per-frame `seenChildren` set because it must REPORT the cycle as `ErrWalkCycle`, not merely survive it. None of them uses a GLOBAL visited set, so a shared DAG node reached on two different paths (e.g. `&e;&e;` — two references to one Entity) is still visited on EACH occurrence; only same-path back-edges are cut. On an acyclic, parent-consistent tree behavior is byte-identical to a naive descent — `Walk` returns nil, so its error return is a non-nil `ErrWalkCycle` ONLY on a corrupt (cyclic) tree the guarded insertion API refuses to build. Production `Walk` callers with an error/validity channel propagate a non-nil return (a cyclic document is not valid / a failed serialization check); the few callers with no channel (a best-effort id lookup, a result-tree mutation over a freshly-built acyclic tree) document why the error is safely ignored. `Walk` is the exported cycle-DETECTION primitive: only it carries an error channel. The `iter.Seq` range-over-func iterators (`Children`, `ChildElements`, `Descendants`) cannot report an error to the range loop, so on a detected cycle they terminate and yield the PARTIAL set gathered up to that point with no signal; their doc comments point a caller who needs to detect (not merely survive) a cycle at `Walk`/`ErrWalkCycle`. No separate validation helper exists or is needed — a `Walk` with a no-op visitor already returns `ErrWalkCycle` on a corrupt tree.
+The read-only traversal APIs (`Walk`, `Children`, `ChildElements`, `Descendants`, and the aggregating
+`Content()`) share the same two safety properties, so a hand-built or foreign-linked graph cannot make them
+wander or loop. (1) OWNED BOUNDARY: they advance between siblings via `nextOwnedChild(owner, child)` (returns
+`child.NextSibling()` only when `child.Parent()` is `owner`), so a foreign child — an entity reference's
+shared Entity child, owned by the DTD — ends that child list instead of spilling into the DTD's unrelated
+declaration siblings. (2) CYCLE SAFETY: `Walk` carries the set of nodes currently ON the DFS stack (the active
+path, O(depth)) and returns the `ErrWalkCycle` sentinel when it would descend into a node already on that path
+(a child-pointer back-edge, e.g. an Entity whose child links back to its reference); it also carries a
+PER-FRAME `seenChildren` set that returns `ErrWalkCycle` when a child repeats within one sibling list — this
+covers BOTH a one-node self-loop (`child.next == child`) and a longer sibling cycle (`a -> b -> a`), which the
+active-path set misses because each child is popped before its next sibling is examined. `nextWalkSibling`
+does NOT special-case the self-loop: it lets the duplicate flow back so `seenChildren` reports `ErrWalkCycle`.
+Special-casing it would silently terminate and report a corrupt one-node cycle as fully traversed.
+`Descendants` mirrors this with an active-path set threaded through its recursion (visits a back-edge node
+once, does not descend through it) plus a per-list sibling guard; `Children`/`ChildElements` use that same
+per-list sibling guard. That guard is `siblingCycleGuard` (`iter.go`), Brent's cycle detection over the
+sibling chain: three words of state and no allocation, so a well-formed list — every list the parser builds —
+pays nothing for a check that fires only on a corrupt graph, where a seen set costs a map plus one insert per
+child on EVERY list. The trade is where the walk stops: a seen set stops at the exact first repeat, Brent
+stops once the chasing pointer catches its checkpoint, within a small multiple of the cycle length, so a
+cyclic list can yield some of its nodes more than once before terminating. Termination is unconditional either
+way, which is the property the iterators promise. `Walk` keeps its per-frame `seenChildren` set because it
+must REPORT the cycle as `ErrWalkCycle`, not merely survive it. None of them uses a GLOBAL visited set, so a
+shared DAG node reached on two different paths (e.g. `&e;&e;` — two references to one Entity) is still visited
+on EACH occurrence; only same-path back-edges are cut. On an acyclic, parent-consistent tree behavior is
+byte-identical to a naive descent — `Walk` returns nil, so its error return is a non-nil `ErrWalkCycle` ONLY
+on a corrupt (cyclic) tree the guarded insertion API refuses to build. Production `Walk` callers with an
+error/validity channel propagate a non-nil return (a cyclic document is not valid / a failed serialization
+check); the few callers with no channel (a best-effort id lookup, a result-tree mutation over a freshly-built
+acyclic tree) document why the error is safely ignored. `Walk` is the exported cycle-DETECTION primitive: only
+it carries an error channel. The `iter.Seq` range-over-func iterators (`Children`, `ChildElements`,
+`Descendants`) cannot report an error to the range loop, so on a detected cycle they terminate and yield the
+PARTIAL set gathered up to that point with no signal; their doc comments point a caller who needs to detect
+(not merely survive) a cycle at `Walk`/`ErrWalkCycle`. No separate validation helper exists or is needed — a
+`Walk` with a no-op visitor already returns `ErrWalkCycle` on a corrupt tree.
 
-Every internal traversal that a corrupt (cyclic) tree could otherwise stall on routes through a cycle-safe scan, never a raw `NextSibling()` walk, so a hang cannot precede the `Walk`-based cycle guards in validation — with one exception: `addSibling`'s fallback walk (above) is a raw, unbounded `NextSibling()` walk, so calling `AddSibling` through a node whose sibling list is cyclic hangs forever. The document root-element scans (`Document.DocumentElement`/`SetDocumentElement`/`CreateInternalSubset`) and the deep-copy (`copyChildren`, `copyDTDChildren`) and serializer child descents iterate the SOURCE through `Children` (bounding a corrupt source sibling list); `copyChildren` links each copied child into the destination via `appendCopiedChild` (above), not `Children`; `setListDoc` (the `SetTreeDoc` sibling walker) and the serializer's attribute-chain walk each carry a per-list seen guard (the latter also terminates a non-`*Attribute` successor that would otherwise leave the cursor unadvanced). The element attribute-lookup hot paths (`addProperty`/`HasAttribute`/`Attributes`/`ForEachAttribute`) traverse the `properties` chain with a plain `NextAttribute` loop and NO guard: that chain is built exclusively through the guarded property-splice / `AddSibling` paths (which reject self/cycle insertion and install no foreign link), so a well-formed chain is a short, self-owned, acyclic list.
+Every internal traversal that a corrupt (cyclic) tree could otherwise stall on routes through a cycle-safe
+scan, never a raw `NextSibling()` walk, so a hang cannot precede the `Walk`-based cycle guards in validation —
+with one exception: `addSibling`'s fallback walk (above) is a raw, unbounded `NextSibling()` walk, so calling
+`AddSibling` through a node whose sibling list is cyclic hangs forever. The document root-element scans
+(`Document.DocumentElement`/`SetDocumentElement`/`CreateInternalSubset`) and the deep-copy (`copyChildren`,
+`copyDTDChildren`) and serializer child descents iterate the SOURCE through `Children` (bounding a corrupt
+source sibling list); `copyChildren` links each copied child into the destination via `appendCopiedChild`
+(above), not `Children`; `setListDoc` (the `SetTreeDoc` sibling walker) and the serializer's attribute-chain
+walk each carry a per-list seen guard (the latter also terminates a non-`*Attribute` successor that would
+otherwise leave the cursor unadvanced). The element attribute-lookup hot paths
+(`addProperty`/`HasAttribute`/`Attributes`/`ForEachAttribute`) traverse the `properties` chain with a plain
+`NextAttribute` loop and NO guard: that chain is built exclusively through the guarded property-splice /
+`AddSibling` paths (which reject self/cycle insertion and install no foreign link), so a well-formed chain is
+a short, self-owned, acyclic list.
 
-The auto-unlink and `replaceNode`'s splice operate through `unlinkNode`/`baseDocNode()` links, never per-pointer setters. A non-`MutableNode` operand (e.g. a public `NamespaceNodeWrapper`, which embeds `docnode` directly) is therefore detached and spliced safely: the preflights perform the unlink through those links (leaving no stale old-parent links) and `replaceNode` splices without a `MutableNode` force-cast (which would panic on such an operand). `setListDoc(Node, doc)` (the `SetTreeDoc` sibling walker) likewise accepts any `Node`: a non-`MutableNode` sibling has its `doc` set directly via `baseDocNode()` instead of a `MutableNode` force-cast, so `SetTreeDoc` over a tree containing a `NamespaceNodeWrapper` does not panic.
+The auto-unlink and `replaceNode`'s splice operate through `unlinkNode`/`baseDocNode()` links, never
+per-pointer setters. A non-`MutableNode` operand (e.g. a public `NamespaceNodeWrapper`, which embeds `docnode`
+directly) is therefore detached and spliced safely: the preflights perform the unlink through those links
+(leaving no stale old-parent links) and `replaceNode` splices without a `MutableNode` force-cast (which would
+panic on such an operand). `setListDoc(Node, doc)` (the `SetTreeDoc` sibling walker) likewise accepts any
+`Node`: a non-`MutableNode` sibling has its `doc` set directly via `baseDocNode()` instead of a `MutableNode`
+force-cast, so `SetTreeDoc` over a tree containing a `NamespaceNodeWrapper` does not panic.
 
-`addChild`/`addSibling`/`replaceNode` reject a nil or typed-nil operand (every replacement operand is checked) with `ErrNilNode` BEFORE any `baseDocNode()` dereference, so the call returns an error and leaves the tree untouched instead of panicking. The same typed-nil guard (`isNilNode`) covers the public read helpers so a typed-nil node — notably the `*Element` `Document.DocumentElement()` returns for a rootless document, wrapped in a non-nil `Node` interface — never panics: `AsNode` returns `(zero, false)` (never `(nil, true)`); `Children`/`ChildElements`/`Descendants` yield nothing; `Walk`, `CopyNode`, and `Parser.ParseInNodeContext` return `ErrNilNode`; `UnlinkNode` is a no-op.
+`addChild`/`addSibling`/`replaceNode` reject a nil or typed-nil operand (every replacement operand is checked)
+with `ErrNilNode` BEFORE any `baseDocNode()` dereference, so the call returns an error and leaves the tree
+untouched instead of panicking. The same typed-nil guard (`isNilNode`) covers the public read helpers so a
+typed-nil node — notably the `*Element` `Document.DocumentElement()` returns for a rootless document, wrapped
+in a non-nil `Node` interface — never panics: `AsNode` returns `(zero, false)` (never `(nil, true)`);
+`Children`/`ChildElements`/`Descendants` yield nothing; `Walk`, `CopyNode`, and `Parser.ParseInNodeContext`
+return `ErrNilNode`; `UnlinkNode` is a no-op.
 
-The guarded mutation ops return matchable sentinels (`errors.Is`): a `wouldCreateCycle` rejection in `addChild`/`addSibling`/`replaceNode` is `ErrCyclicNode` (wrapped via `%w`); an empty `Replace()` is `ErrInvalidOperation` (matching `Document.Replace` — use `UnlinkNode` to delete a node); and the structural rejections (a non-attribute sibling/replacement of a property attribute, duplicate replacement operands) wrap `ErrInvalidOperation`. An `addChild` `*Attribute` operand on a non-element parent also wraps `ErrInvalidOperation`. A leaf-node `AddChild` (`Text`, `Comment`, `CDATASection`, `ProcessingInstruction`) that rejects a non-mergeable operand — anything but the same-kind content merge (`ProcessingInstruction` merges a Text/CDATA operand into its `data`) — likewise wraps `ErrInvalidOperation` with a descriptive `cannot add a <kind> as a child of a <kind> node` message, so the leaf rejections match `errors.Is` uniformly with the shared-path ones. A leaf self-add (`Text`, `Comment`, `ProcessingInstruction`, `EntityRef`) is `ErrCyclicNode` instead — `Text`/`Comment`/`EntityRef` catch it via the shared cycle guard, and `ProcessingInstruction` detects it by identity (direct pointer comparison of the operand against the receiver — never dereferencing the receiver, so a typed-nil PI receiver still gets the plain rejection error instead of a panic) before its type rejection so `pi.AddChild(pi)` matches every other leaf self-add. An ancestor operand is NOT a self-add: `pi.AddChild(parentElement)` (or the owning document) wraps `ErrInvalidOperation` with the shared shape, matching the other strict leaves.
+The guarded mutation ops return matchable sentinels (`errors.Is`): a `wouldCreateCycle` rejection in
+`addChild`/`addSibling`/`replaceNode` is `ErrCyclicNode` (wrapped via `%w`); an empty `Replace()` is
+`ErrInvalidOperation` (matching `Document.Replace` — use `UnlinkNode` to delete a node); and the structural
+rejections (a non-attribute sibling/replacement of a property attribute, duplicate replacement operands) wrap
+`ErrInvalidOperation`. An `addChild` `*Attribute` operand on a non-element parent also wraps
+`ErrInvalidOperation`. A leaf-node `AddChild` (`Text`, `Comment`, `CDATASection`, `ProcessingInstruction`)
+that rejects a non-mergeable operand — anything but the same-kind content merge (`ProcessingInstruction`
+merges a Text/CDATA operand into its `data`) — likewise wraps `ErrInvalidOperation` with a descriptive `cannot
+add a <kind> as a child of a <kind> node` message, so the leaf rejections match `errors.Is` uniformly with the
+shared-path ones. A leaf self-add (`Text`, `Comment`, `ProcessingInstruction`, `EntityRef`) is `ErrCyclicNode`
+instead — `Text`/`Comment`/`EntityRef` catch it via the shared cycle guard, and `ProcessingInstruction`
+detects it by identity (direct pointer comparison of the operand against the receiver — never dereferencing
+the receiver, so a typed-nil PI receiver still gets the plain rejection error instead of a panic) before its
+type rejection so `pi.AddChild(pi)` matches every other leaf self-add. An ancestor operand is NOT a self-add:
+`pi.AddChild(parentElement)` (or the owning document) wraps `ErrInvalidOperation` with the shared shape,
+matching the other strict leaves.
 
 ### Cross-Document Slab Safety
 
-`Document` allocates its high-frequency nodes (`Element`, `Text`, `Namespace`, `Attribute`) and parsed text-content bytes from per-document SLAB allocators backed by process-global `sync.Pool`s (`document.go`). `Document.Free()` returns those chunks to the pools for reuse by a later parse. A node's struct and content bytes therefore physically live in its owning document's slab, so recycling a chunk that a still-live node references would let a subsequent parse overwrite that node.
+`Document` allocates its high-frequency nodes (`Element`, `Text`, `Namespace`, `Attribute`) and parsed
+text-content bytes from per-document SLAB allocators backed by process-global `sync.Pool`s (`document.go`).
+`Document.Free()` returns those chunks to the pools for reuse by a later parse. A node's struct and content
+bytes therefore physically live in its owning document's slab, so recycling a chunk that a still-live node
+references would let a subsequent parse overwrite that node.
 
-The insertion paths (`addChildPreflight`/`addSiblingPreflight`/`replaceNode`, via `noteCrossDocumentEscape`) permit linking a node into a DIFFERENT document than the one that owns it — XInclude merges an included subtree into the main document, and xslt3 moves result-tree nodes into result documents — but they mark the SOURCE document's `slabEscaped` flag when they do. `AddNamespaceDecl` and `SetNamespace` apply the same guard for the namespace slab (via `noteCrossDocumentNamespaceEscape`): `AddNamespaceDecl` when it RETAINS the caller's `*Namespace` (case 1 append, case 3 collapse), and `SetNamespace` when it installs the caller's `*Namespace` as the node's active namespace (`CreateElementNS` reaches this path), mark the source document escaped when that Namespace is slab-backed by a document other than the receiver's owner (`Namespace.context` non-nil and != the node's doc), so a later `Free` cannot recycle the namespace chunk out from under the retained reference. A same-document or heap-allocated Namespace, and `AddNamespaceDecl`'s non-retaining cases (a same-URI no-op, a declined conflict), mark nothing. `SetActiveNamespace` creates its Namespace from the node's own document, so it is always same-document and marks nothing. `Free` is a no-op on a document whose `slabEscaped` is set: its chunks are not returned to the pool, and GC reclaims them once the moved nodes are no longer referenced. A node with a nil owner (created with a nil `Document` receiver — heap-allocated, not slab-backed) triggers no marking. A same-document reparent does not mark the flag, so the common parse-then-`Free` fast path still recycles. Insertion does NOT rewrite the moved node's `OwnerDocument`; use `CopyNode(src, targetDoc)` to import a subtree whose storage is owned by the destination document.
+The insertion paths (`addChildPreflight`/`addSiblingPreflight`/`replaceNode`, via `noteCrossDocumentEscape`)
+permit linking a node into a DIFFERENT document than the one that owns it — XInclude merges an included
+subtree into the main document, and xslt3 moves result-tree nodes into result documents — but they mark the
+SOURCE document's `slabEscaped` flag when they do. `AddNamespaceDecl` and `SetNamespace` apply the same guard
+for the namespace slab (via `noteCrossDocumentNamespaceEscape`): `AddNamespaceDecl` when it RETAINS the
+caller's `*Namespace` (case 1 append, case 3 collapse), and `SetNamespace` when it installs the caller's
+`*Namespace` as the node's active namespace (`CreateElementNS` reaches this path), mark the source document
+escaped when that Namespace is slab-backed by a document other than the receiver's owner (`Namespace.context`
+non-nil and != the node's doc), so a later `Free` cannot recycle the namespace chunk out from under the
+retained reference. A same-document or heap-allocated Namespace, and `AddNamespaceDecl`'s non-retaining cases
+(a same-URI no-op, a declined conflict), mark nothing. `SetActiveNamespace` creates its Namespace from the
+node's own document, so it is always same-document and marks nothing. `Free` is a no-op on a document whose
+`slabEscaped` is set: its chunks are not returned to the pool, and GC reclaims them once the moved nodes are
+no longer referenced. A node with a nil owner (created with a nil `Document` receiver — heap-allocated, not
+slab-backed) triggers no marking. A same-document reparent does not mark the flag, so the common
+parse-then-`Free` fast path still recycles. Insertion does NOT rewrite the moved node's `OwnerDocument`; use
+`CopyNode(src, targetDoc)` to import a subtree whose storage is owned by the destination document.

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -6,74 +6,437 @@ Go implementation of libxml2. Module: `github.com/lestrrat-go/helium`
 
 XML parsing, DOM tree, serialization. Entry point for all XML processing.
 
-- **NewParser() → Parser** — create fluent builder for XML parsing (clone-on-write value type). **Secure by default** for untrusted input: `BlockXXE` on (no external entity/DTD loading), `AllowNetwork` off, `FS` is a deny-all FS (`internal/iofs.DenyAll` — opens nothing), and element depth is capped at 256 (`MaxDepth`). Entity substitution, external-DTD loading, XInclude, and DTD validation are all off by default. Opt back in explicitly, e.g. `NewParser().BlockXXE(false).LoadExternalDTD(true).FS(helium.PermissiveFS())`.
-  - Flag methods: `RecoverOnError(bool)`, `SubstituteEntities(bool)`, `LoadExternalDTD(bool)`, `DefaultDTDAttributes(bool)`, `ValidateDTD(bool)`, `SuppressErrors(bool)`, `SuppressWarnings(bool)`, `PedanticErrors(bool)`, `StripBlanks(bool)`, `AllowNetwork(bool)` (default false), `CleanNamespaces(bool)`, `MergeCDATA(bool)`, `FixBaseURIs(bool)`, `IgnoreEncoding(bool)`, `BlockXXE(bool)` (default true), `SkipIDs(bool)`, `LenientXMLDecl(bool)`
-  - Per-limit knobs (each takes an int, `0` = default, negative = no limit): `MaxNameLength(int)` (default `DefaultMaxNameLength` 50000), `MaxEntityAmplification(int)` (default `DefaultMaxEntityAmplification` 5; 1 GiB hard ceiling always applies), `MaxContentModelDepth(int)` (default `DefaultMaxContentModelDepth` 128), `MaxNodeContentSize(int)` (default `DefaultMaxNodeContentSize` 10 MiB) — caps a single indivisible content run (CDATA section / comment body / PI body / char-data run / attribute value); the SAME cap also bounds a single contiguous run of XML whitespace (a blank skip — prolog/epilogue/inter-root, and the blank skips inside the external DTD subset and INCLUDE sections), so an unbounded whitespace run cannot grow the cursor buffer; over-cap → `ErrNodeContentTooLarge`, fired during accumulation. A negative value (`MaxNodeContentSize(-1)`) disables BOTH the node-content and the blank-run cap. A streaming SAX consumer with `CharBufferSize > 0` receives char data in bounded chunks and is exempt from the char-data cap (its CDATA/comment/PI runs are still capped)
-  - Config methods: `SAXHandler(sax.SAX2Handler)`, `BaseURI(string)`, `CharBufferSize(int)`, `MaxDepth(int)` (default 256; `0` = default, negative = no cap), `MaxExternalDTDBytes(int)` (default `MaxExternalDTDSize` 10 MiB; `0` = default, negative = no cap), `Catalog(CatalogResolver)`, `FS(fs.FS)`, `ErrorHandler(ErrorHandler)`, `XInclude(XIncludeProcessor)`
-  - `Parser.SAXHandler(sax.SAX2Handler)` — sets the handler receiving parse events; the most recent call wins. The default (and what a nil value restores, as with `Parser.FS`) is `NewTreeBuilder()`, so under the default or a nil-restored handler a successful `Parse` returns a built `*Document` and a caller forwarding an optional handler through cannot silently lose all output. To consume events without building a tree, pass a handler that ignores them
-  - `Parser.XInclude(XIncludeProcessor)` — inject an XInclude processor (the `XIncludeProcessor` interface: `Process(context.Context, *Document) (int, error)`, satisfied by `xinclude.Processor`). When set, `Parse`/`ParseReader`/`ParseFile` run it over the built tree so the returned document has `xi:include` elements expanded; if `ValidateDTD` is also set, the expanded tree is validated. Off by default (nil disables). The interface is the dependency-inversion seam: the root package cannot import `xinclude` (which imports `helium`), so the caller builds and injects a configured processor
+- **NewParser() → Parser** — create fluent builder for XML parsing (clone-on-write value type). **Secure by
+  default** for untrusted input: `BlockXXE` on (no external entity/DTD loading), `AllowNetwork` off, `FS` is a
+  deny-all FS (`internal/iofs.DenyAll` — opens nothing), and element depth is capped at 256 (`MaxDepth`).
+  Entity substitution, external-DTD loading, XInclude, and DTD validation are all off by default. Opt back in
+  explicitly, e.g. `NewParser().BlockXXE(false).LoadExternalDTD(true).FS(helium.PermissiveFS())`.
+  - Flag methods: `RecoverOnError(bool)`, `SubstituteEntities(bool)`, `LoadExternalDTD(bool)`,
+    `DefaultDTDAttributes(bool)`, `ValidateDTD(bool)`, `SuppressErrors(bool)`, `SuppressWarnings(bool)`,
+    `PedanticErrors(bool)`, `StripBlanks(bool)`, `AllowNetwork(bool)` (default false),
+    `CleanNamespaces(bool)`, `MergeCDATA(bool)`, `FixBaseURIs(bool)`, `IgnoreEncoding(bool)`, `BlockXXE(bool)`
+    (default true), `SkipIDs(bool)`, `LenientXMLDecl(bool)`
+  - Per-limit knobs (each takes an int, `0` = default, negative = no limit): `MaxNameLength(int)` (default
+    `DefaultMaxNameLength` 50000), `MaxEntityAmplification(int)` (default `DefaultMaxEntityAmplification` 5; 1
+    GiB hard ceiling always applies), `MaxContentModelDepth(int)` (default `DefaultMaxContentModelDepth` 128),
+    `MaxNodeContentSize(int)` (default `DefaultMaxNodeContentSize` 10 MiB) — caps a single indivisible content
+    run (CDATA section / comment body / PI body / char-data run / attribute value); the SAME cap also bounds a
+    single contiguous run of XML whitespace (a blank skip — prolog/epilogue/inter-root, and the blank skips
+    inside the external DTD subset and INCLUDE sections), so an unbounded whitespace run cannot grow the
+    cursor buffer; over-cap → `ErrNodeContentTooLarge`, fired during accumulation. A negative value
+    (`MaxNodeContentSize(-1)`) disables BOTH the node-content and the blank-run cap. A streaming SAX consumer
+    with `CharBufferSize > 0` receives char data in bounded chunks and is exempt from the char-data cap (its
+    CDATA/comment/PI runs are still capped)
+  - Config methods: `SAXHandler(sax.SAX2Handler)`, `BaseURI(string)`, `CharBufferSize(int)`, `MaxDepth(int)`
+    (default 256; `0` = default, negative = no cap), `MaxExternalDTDBytes(int)` (default `MaxExternalDTDSize`
+    10 MiB; `0` = default, negative = no cap), `Catalog(CatalogResolver)`, `FS(fs.FS)`,
+    `ErrorHandler(ErrorHandler)`, `XInclude(XIncludeProcessor)`
+  - `Parser.SAXHandler(sax.SAX2Handler)` — sets the handler receiving parse events; the most recent call wins.
+    The default (and what a nil value restores, as with `Parser.FS`) is `NewTreeBuilder()`, so under the
+    default or a nil-restored handler a successful `Parse` returns a built `*Document` and a caller forwarding
+    an optional handler through cannot silently lose all output. To consume events without building a tree,
+    pass a handler that ignores them
+  - `Parser.XInclude(XIncludeProcessor)` — inject an XInclude processor (the `XIncludeProcessor` interface:
+    `Process(context.Context, *Document) (int, error)`, satisfied by `xinclude.Processor`). When set,
+    `Parse`/`ParseReader`/`ParseFile` run it over the built tree so the returned document has `xi:include`
+    elements expanded; if `ValidateDTD` is also set, the expanded tree is validated. Off by default (nil
+    disables). The interface is the dependency-inversion seam: the root package cannot import `xinclude`
+    (which imports `helium`), so the caller builds and injects a configured processor
   - **PermissiveFS() → fs.FS** — returns `internal/iofs.PermissiveRoot` (opens any path via `os.Open`), the public escape hatch for restoring host-filesystem access that `NewParser` does not grant by default
-  - **DirFS(root string) → fs.FS** — returns `internal/iofs.ConfinedDir`, a confined FS that opens external resources only at or below `root`. Refuses a `../`- or absolute-path escape AND an in-root symlink pointing outside `root` (enforced with `os.Root`/`os.OpenRoot`, Go 1.24+ — stronger than `os.DirFS`, which is path-escape-safe but follows an escaping symlink), and rejects a non-`file` URI scheme so it never reaches the network. Unlike a bare `os.DirFS`/`os.Root.FS` passed to `Parser.FS`, it serves an in-root ABSOLUTE name directly (no reliance on the base-relative retry), so `root` may be ANY trusted directory, not only the document's own directory. The internal `ConfinedDir` is the shared implementation behind the CLI's `newConfinedDirFS` (the xslt command's stylesheet-directory FS)
-  - `Parser.FS(fs.FS)` — sets the `fs.FS` used to load external resources referenced by the document: external DTD subsets (`LoadExternalDTD`) and external general entities resolved through `TreeBuilder.ResolveEntity`. The default (and what a nil value restores) is `internal/iofs.DenyAll`, which refuses every open. Pass `helium.PermissiveFS()` (any `os.Open` path) or a confined FS to enable loading; to confine to an arbitrary trusted directory prefer `helium.DirFS(root)` — it serves an in-root absolute name directly (so `root` need not be the document's own directory) and refuses a symlink escape. A bare `os.Root.FS`/`os.DirFS` passed here only enforces `fs.ValidPath`, so an absolute/`file:` SYSTEM id is rejected and only the document-directory base-relative retry (below) recovers it; between the two, `os.Root.FS` refuses a symlink escape whereas `os.DirFS` follows an in-root symlink out of its root (path-escape-safe, not a symlink sandbox). A relative SYSTEM id is resolved against the document's base URI (absolute whenever set — `ParseFile` uses the file's absolute path); the direct entity/DTD paths hand the FS the raw resolved name first (a `file:` URI verbatim, so `PermissiveRoot`/os.Open and a file-URI-keyed FS are unchanged) and, on an `fs.ErrInvalid` rejection from an `fs.ValidPath`-enforcing FS (`os.DirFS`/`os.Root.FS`/`fs.Sub`), retry with the name made relative to the **fixed top-level document base**'s directory (`parserCtx.documentBaseURI`, captured once at parse start; `openExternalResource`/`baseRelativeFSName` in `tree_builder.go`), so a confined FS rooted at the document's directory resolves the reference — including a nested resource in a subdirectory, which relativizes against the document root, not its own moving base. The retry fires **only for an originally-relative reference** (`systemIDRetryEligible` on the SYSTEM id as declared, before URI resolution / catalog mapping): ineligible when the id is absolute, carries a URI scheme, or has a colon anywhere in its first path segment (catching a one-letter RFC 3986 scheme like `x:opaque` and a bare drive letter), so an absolute, `file:`-URI, or otherwise scheme-carrying SYSTEM id is never retried, even one naming an in-root file. The supported confined-FS document base is an **absolute path or `file:` URI**; a relative document base is out of scope (`BuildURI` yields a valid-but-absent relative path that fails with `fs.ErrNotExist`, not `fs.ErrInvalid`, so the retry never fires — `helium.DirFS(root)`, which serves an in-root absolute name directly, is the general fix for an FS rooted elsewhere than the document directory). The retry is a validated `fs.ValidPath` (leading `/` or surviving `..` disqualifies it → blocks `../`/absolute path escape, but does NOT confine symlinks). `openExternalResource` is the single network-guard enforcement point: a network-scheme name is refused (`ErrNetworkAccessForbidden`) before **either** open — primary or retry
-  - `Parser.ErrorHandler(ErrorHandler)` — sets the handler for validation errors produced during DTD validation (`ValidateDTD`); individual errors are delivered as they occur and `Parse` returns `ErrDTDValidationFailed` on failure (or `ErrNoDTDFound`, which wraps it, when the document carries no DTD at all). If the handler is an `io.Closer`, it is closed only after the DTD validation pass runs (i.e. when `ValidateDTD` is enabled and the document was parsed); it is not auto-closed for non-validating parses or for parse errors that abort before validation
-  - Terminal methods: `Parse(ctx, []byte) → (*Document, error)`, `ParseReader(ctx, io.Reader) → (*Document, error)`, `ParseFile(ctx, string) → (*Document, error)`, `ParseInNodeContext(ctx, Node, []byte) → (Node, error)`, `NewPushParser(ctx) → *PushParser`
+  - **DirFS(root string) → fs.FS** — returns `internal/iofs.ConfinedDir`, a confined FS that opens external
+    resources only at or below `root`. Refuses a `../`- or absolute-path escape AND an in-root symlink
+    pointing outside `root` (enforced with `os.Root`/`os.OpenRoot`, Go 1.24+ — stronger than `os.DirFS`, which
+    is path-escape-safe but follows an escaping symlink), and rejects a non-`file` URI scheme so it never
+    reaches the network. Unlike a bare `os.DirFS`/`os.Root.FS` passed to `Parser.FS`, it serves an in-root
+    ABSOLUTE name directly (no reliance on the base-relative retry), so `root` may be ANY trusted directory,
+    not only the document's own directory. The internal `ConfinedDir` is the shared implementation behind the
+    CLI's `newConfinedDirFS` (the xslt command's stylesheet-directory FS)
+  - `Parser.FS(fs.FS)` — sets the `fs.FS` used to load external resources referenced by the document: external
+    DTD subsets (`LoadExternalDTD`) and external general entities resolved through
+    `TreeBuilder.ResolveEntity`. The default (and what a nil value restores) is `internal/iofs.DenyAll`, which
+    refuses every open. Pass `helium.PermissiveFS()` (any `os.Open` path) or a confined FS to enable loading;
+    to confine to an arbitrary trusted directory prefer `helium.DirFS(root)` — it serves an in-root absolute
+    name directly (so `root` need not be the document's own directory) and refuses a symlink escape. A bare
+    `os.Root.FS`/`os.DirFS` passed here only enforces `fs.ValidPath`, so an absolute/`file:` SYSTEM id is
+    rejected and only the document-directory base-relative retry (below) recovers it; between the two,
+    `os.Root.FS` refuses a symlink escape whereas `os.DirFS` follows an in-root symlink out of its root
+    (path-escape-safe, not a symlink sandbox). A relative SYSTEM id is resolved against the document's base
+    URI (absolute whenever set — `ParseFile` uses the file's absolute path); the direct entity/DTD paths hand
+    the FS the raw resolved name first (a `file:` URI verbatim, so `PermissiveRoot`/os.Open and a
+    file-URI-keyed FS are unchanged) and, on an `fs.ErrInvalid` rejection from an `fs.ValidPath`-enforcing FS
+    (`os.DirFS`/`os.Root.FS`/`fs.Sub`), retry with the name made relative to the **fixed top-level document
+    base**'s directory (`parserCtx.documentBaseURI`, captured once at parse start;
+    `openExternalResource`/`baseRelativeFSName` in `tree_builder.go`), so a confined FS rooted at the
+    document's directory resolves the reference — including a nested resource in a subdirectory, which
+    relativizes against the document root, not its own moving base. The retry fires **only for an
+    originally-relative reference** (`systemIDRetryEligible` on the SYSTEM id as declared, before URI
+    resolution / catalog mapping): ineligible when the id is absolute, carries a URI scheme, or has a colon
+    anywhere in its first path segment (catching a one-letter RFC 3986 scheme like `x:opaque` and a bare drive
+    letter), so an absolute, `file:`-URI, or otherwise scheme-carrying SYSTEM id is never retried, even one
+    naming an in-root file. The supported confined-FS document base is an **absolute path or `file:` URI**; a
+    relative document base is out of scope (`BuildURI` yields a valid-but-absent relative path that fails with
+    `fs.ErrNotExist`, not `fs.ErrInvalid`, so the retry never fires — `helium.DirFS(root)`, which serves an
+    in-root absolute name directly, is the general fix for an FS rooted elsewhere than the document
+    directory). The retry is a validated `fs.ValidPath` (leading `/` or surviving `..` disqualifies it →
+    blocks `../`/absolute path escape, but does NOT confine symlinks). `openExternalResource` is the single
+    network-guard enforcement point: a network-scheme name is refused (`ErrNetworkAccessForbidden`) before
+    **either** open — primary or retry
+  - `Parser.ErrorHandler(ErrorHandler)` — sets the handler for validation errors produced during DTD
+    validation (`ValidateDTD`); individual errors are delivered as they occur and `Parse` returns
+    `ErrDTDValidationFailed` on failure (or `ErrNoDTDFound`, which wraps it, when the document carries no DTD
+    at all). If the handler is an `io.Closer`, it is closed only after the DTD validation pass runs (i.e. when
+    `ValidateDTD` is enabled and the document was parsed); it is not auto-closed for non-validating parses or
+    for parse errors that abort before validation
+  - Terminal methods: `Parse(ctx, []byte) → (*Document, error)`, `ParseReader(ctx, io.Reader) → (*Document,
+    error)`, `ParseFile(ctx, string) → (*Document, error)`, `ParseInNodeContext(ctx, Node, []byte) → (Node,
+    error)`, `NewPushParser(ctx) → *PushParser`
   - XML 1.1 literal-character validation — see `parser-internals.md` “XML 1.1 Version-Gated Rules”
 - **NewWriter() → Writer** — create fluent XML writer builder
-  - Writer markup validation: DOM element and attribute names use QNames; DTD element, ATTLIST, content-model, NDATA, named-reference, and NOTATION-list names use full XML Names; entity and notation declarations use NCNames. EntityValue scanning rejects malformed numeric, named, and parsed parameter-entity references. Its numeric-reference parser is shared with `CreateCharRef`; only a syntactically valid target outside the selected XML character range follows `RejectInvalidChars` replacement. External-ID literal validation applies to entity types that emit an external ID; unused IDs stored on internal entities do not affect Writer output. Enumeration members are non-empty, distinct Nmtokens or Names and are checked before output.
-  - Writer validation is atomic: `WriteTo` first runs the complete serialization to `io.Discard`. A validation error returns without calling the supplied writer; valid serialization then runs to the supplied writer, preserving that writer's I/O-error behavior.
-  - Writer methods: `Format(bool)`, `IndentString(string)` (per-level indent used when `Format` is on; an explicit `""` requests newlines with NO indentation, while leaving it unset uses the two-space default), `SelfCloseEmptyElements(bool)`, `XMLDeclaration(bool)`, `IncludeDTD(bool)`, `EscapeNonASCII(bool)`, `AllowPrefixUndeclarations(bool)`, `RejectInvalidChars(bool)` (**default true**: a character invalid in the target XML version — e.g. a C0/C1 control char in XML 1.0 output — fails serialization with `ErrInvalidXMLChar`, the XSLT SERE0006 error; a zero-value `Writer`/`NewWriter()` rejects. `RejectInvalidChars(false)` opts into U+FFFD replacement instead: the `&#xFFFD;` reference under `EscapeNonASCII`/US-ASCII output (matching libxml2), the raw U+FFFD character otherwise — an out-of-range char never serializes as a bogus numeric reference like `&#x1;`. The policy covers every serialization context except the character-map exemption below: text/attribute values (the check is folded into the escape pass ahead of every emission branch, so it adds no extra traversal); the reference-less contexts — comment text, PI data, CDATA-section content, and DTD literals (entity values, external-ID system/public literals, enumeration tokens), each validated via `serializeRefFree`/`dtdLiteral` against the XML 1.0 Char range; every verbatim NAME — the DOCTYPE, `<!ENTITY>`, `<!NOTATION>`, `<!ELEMENT>`/`<!ATTLIST>` and content-model names, the NDATA notation name, element/attribute names, and a named entity reference's name — validated against the XML Name grammar (`checkVerbatimName`/`checkElementName`; the grammar subsumes the char check, so an invalid name is REJECTED in both modes with `ErrWriterInvalidName`, having no U+FFFD form); and numeric character-reference TARGETS — a `CreateCharRef("#N")` node (`writeCharRef`) and a `&#N;` reference inside an entity value (`entityValueLiteral`/`screenCharRefs`) — validated against `isSerializableChar(cp, xml11)`, so version-sensitively (e.g. `&#1;` is invalid for XML 1.0 output but a legal RestrictedChar reference for XML 1.1); an invalid target rejects (default) or has its reference replaced by U+FFFD. In text/attribute values a valid XML 1.1 restricted character is exempt from the char check — it serializes as a decimal character reference in either mode; in a reference-less context it has no character-reference form, so it is rejected/replaced there too (`serializeRefFree` uses `isInCharacterRange`, NOT `isSerializableChar`). A `CharacterMap` is the one exemption: it is applied BEFORE the check (Serialization 3.1 §5.1.11), so a mapped-away invalid character is not rejected — SERE0006 is defined on the serialized result, which no longer contains it — and a replacement string is emitted verbatim per §7. Internally the field is `replaceInvalidChars` so the safe reject behavior is the zero value), plus the serialization-parameter knobs `OutputVersion(string)` (override the effective output XML version — empty keeps the document's version, byte-identical — driving BOTH the declaration text AND the XML 1.1 escaping/undeclaration rules; the effective version must be a valid `VersionNum` `'1.' [0-9]+`, else serialization fails with `ErrInvalidOutputVersion` before any output byte), `OutputEncoding(string)` (override the encoding pseudo-attribute of the XML declaration — empty keeps the document's own encoding, byte-identical; the encoding pseudo-attribute is omitted only when the resulting effective encoding is empty. A non-empty effective encoding must be a well-formed `EncName`, else serialization fails with `ErrUnsupportedOutputEncoding` before any output byte (validated ahead of the transcoding encoder, so no BOM leaks). Affects the **Document serialization path only**: a bare element/fragment carries no declaration, so `asciiOutput` stays off and fragment bytes are byte-identical to output without an override. When set on a `WriteTo`-to-io.Writer Document path the emitted octets are RE-ENCODED to the effective encoding so the bytes agree with the declaration, and an effective encoding the writer cannot emit — one the internal encoder table can't load and that is not UTF-8/US-ASCII — fails with `ErrUnsupportedOutputEncoding`; this hard error is scoped to the override, a document's own unloadable parsed encoding stays declaration-only. An explicit US-ASCII override — matched by ANY IANA alias via `internal/encoding.IsASCII` (`us-ascii`, `ascii`, `csASCII`, `ANSI_X3.4-1968`, `ANSI_X3.4-1986`, `iso-ir-6`, `ISO646-US`, `us`, `IBM367`, `cp367`) — installs no encoder but escapes EVERY non-ASCII character — the full Unicode range, not just the Latin-1 that `EscapeNonASCII` covers — as a numeric character reference (`&#xNNNN;`), so the octets are pure US-ASCII and agree with the declaration. Text and attribute values character-reference fine; ANY other non-ASCII byte reaching the output has no faithful US-ASCII serialization and fails with `ErrUnsupportedOutputEncoding` — a name, comment, CDATA, PI target/data, namespace prefix, DTD-internal name (DOCTYPE, `<!ELEMENT>`/`<!ATTLIST>`/`<!ENTITY>` names, enumeration tokens), a character-map replacement, a DTD external/system/public-ID literal, an entity/notation value/name, or any future raw-write site. Per-site guards give early labelled errors on the common paths and an exhaustive output-writer net (`asciiRejectWriter`) rejects any surviving byte ≥ 0x80. Without an override a document's own US-ASCII encoding stays byte-identical. fn:serialize uses an internal declaration-only mode instead, keeping octets UTF-8 with char-reference escaping — a US-ASCII encoding there still character-references non-ASCII text/attr values, but keeps reference-less content and character-map replacements RAW (the result is a UTF-8 string), so the net and guards key on `asciiOutput && !declOnlyEncoding`), `Standalone(bool)` / `OmitStandalone()` (force the declaration's standalone pseudo-attribute to yes/no, or force its omission, overriding the document's own standalone status), `CharacterMap(map[rune]string)` (substitute a mapped rune with its raw replacement in text/attribute content — XSLT/XQuery Serialization 3.1 §7), `Normalization(string)` (the normalization-form serialization parameter — `"NFC"`/`"NFD"`/`"NFKC"`/`"NFKD"` normalize text-node and attribute-value character content; `""`/`"none"` disable it; ANY OTHER value is an error: `WriteTo` fails with `ErrUnsupportedNormalizationForm` before any output byte, so an out-of-range form never silently disables normalization), `CDATASectionElements(map[string]struct{})` (emit the named elements' direct text children as CDATA), and `SuppressIndentElements(map[string]struct{})` (serialize the named subtrees without indentation even when `Format` is on) — the last two match by EXACT expanded `{uri}local` name
-  - XML 1.1 output: when the effective output version is `"1.1"` — either the serialized document declares version `"1.1"` (`Document.Version() == "1.1"`, set via `Document.SetVersion`) or `OutputVersion("1.1")` overrides it — the writer emits the XML 1.1 **restricted** control characters (`#x1-#x8`, `#xB-#xC`, `#xE-#x1F`, `#x7F-#x84`, `#x86-#x9F`; §2.11, tab/LF/CR excluded) **plus the two end-of-line characters NEL `#x85` and LINE SEPARATOR `#x2028`** (excluded from `RestrictedChar` but normalized to `#xA` on §2.11 input, so they must be char-ref'd to round-trip — the serialization set is `isXML11SerializeAsCharRef` = `isXML11RestrictedChar` ∪ {`#x85`, `#x2028`}) as **decimal** character references (`&#N;`) in text and attribute content instead of hex (`escapeNonASCII`) or U+FFFD replacement/`SERE0006` rejection. Gated on the document version, so XML 1.0 output is byte-identical (the `xml11` branch sits after the `RejectInvalidChars` check and before the `escapeNonASCII` hex branch, so it adds no extra walk; in XML 1.0 NEL/LS are ordinary characters written literally). The `stream.Writer` has the parallel `XMLVersion("1.1")` fluent method (also set by `StartDocument` when the declaration version is `1.1`): its text/attribute validation admits the restricted chars and `writeEscaped` serializes the same `isXML11SerializeAsCharRef` set as decimal refs (comment/PI/CDATA content, which cannot carry a reference, stay strictly rejected)
-  - XML 1.1 DTD literals: `EntityValue` validates and preserves existing named and numeric references, then converts each raw `isXML11SerializeAsCharRef` character to a decimal character reference. It is the one DTD literal grammar that can carry a character reference. Comment text, PI data, CDATA content, and external DTD public/system literals cannot carry one, so `serializeRefFree`/`dtdLiteral` reject XML 1.1 serialization-only characters by default or replace them with raw U+FFFD in replacement mode. XML 1.0 continues to write U+007F, NEL, and LINE SEPARATOR literally in these paths.
+  - Writer markup validation: DOM element and attribute names use QNames; DTD element, ATTLIST, content-model,
+    NDATA, named-reference, and NOTATION-list names use full XML Names; entity and notation declarations use
+    NCNames. EntityValue scanning rejects malformed numeric, named, and parsed parameter-entity references.
+    Its numeric-reference parser is shared with `CreateCharRef`; only a syntactically valid target outside the
+    selected XML character range follows `RejectInvalidChars` replacement. External-ID literal validation
+    applies to entity types that emit an external ID; unused IDs stored on internal entities do not affect
+    Writer output. Enumeration members are non-empty, distinct Nmtokens or Names and are checked before
+    output.
+  - Writer validation is atomic: `WriteTo` first runs the complete serialization to `io.Discard`. A validation
+    error returns without calling the supplied writer; valid serialization then runs to the supplied writer,
+    preserving that writer's I/O-error behavior.
+  - Writer methods: `Format(bool)`, `IndentString(string)` (per-level indent used when `Format` is on; an
+    explicit `""` requests newlines with NO indentation, while leaving it unset uses the two-space default),
+    `SelfCloseEmptyElements(bool)`, `XMLDeclaration(bool)`, `IncludeDTD(bool)`, `EscapeNonASCII(bool)`,
+    `AllowPrefixUndeclarations(bool)`, `RejectInvalidChars(bool)` (**default true**: a character invalid in
+    the target XML version — e.g. a C0/C1 control char in XML 1.0 output — fails serialization with
+    `ErrInvalidXMLChar`, the XSLT SERE0006 error; a zero-value `Writer`/`NewWriter()` rejects.
+    `RejectInvalidChars(false)` opts into U+FFFD replacement instead: the `&#xFFFD;` reference under
+    `EscapeNonASCII`/US-ASCII output (matching libxml2), the raw U+FFFD character otherwise — an out-of-range
+    char never serializes as a bogus numeric reference like `&#x1;`. The policy covers every serialization
+    context except the character-map exemption below: text/attribute values (the check is folded into the
+    escape pass ahead of every emission branch, so it adds no extra traversal); the reference-less contexts —
+    comment text, PI data, CDATA-section content, and DTD literals (entity values, external-ID system/public
+    literals, enumeration tokens), each validated via `serializeRefFree`/`dtdLiteral` against the XML 1.0 Char
+    range; every verbatim NAME — the DOCTYPE, `<!ENTITY>`, `<!NOTATION>`, `<!ELEMENT>`/`<!ATTLIST>` and
+    content-model names, the NDATA notation name, element/attribute names, and a named entity reference's name
+    — validated against the XML Name grammar (`checkVerbatimName`/`checkElementName`; the grammar subsumes the
+    char check, so an invalid name is REJECTED in both modes with `ErrWriterInvalidName`, having no U+FFFD
+    form); and numeric character-reference TARGETS — a `CreateCharRef("#N")` node (`writeCharRef`) and a
+    `&#N;` reference inside an entity value (`entityValueLiteral`/`screenCharRefs`) — validated against
+    `isSerializableChar(cp, xml11)`, so version-sensitively (e.g. `&#1;` is invalid for XML 1.0 output but a
+    legal RestrictedChar reference for XML 1.1); an invalid target rejects (default) or has its reference
+    replaced by U+FFFD. In text/attribute values a valid XML 1.1 restricted character is exempt from the char
+    check — it serializes as a decimal character reference in either mode; in a reference-less context it has
+    no character-reference form, so it is rejected/replaced there too (`serializeRefFree` uses
+    `isInCharacterRange`, NOT `isSerializableChar`). A `CharacterMap` is the one exemption: it is applied
+    BEFORE the check (Serialization 3.1 §5.1.11), so a mapped-away invalid character is not rejected —
+    SERE0006 is defined on the serialized result, which no longer contains it — and a replacement string is
+    emitted verbatim per §7. Internally the field is `replaceInvalidChars` so the safe reject behavior is the
+    zero value), plus the serialization-parameter knobs `OutputVersion(string)` (override the effective output
+    XML version — empty keeps the document's version, byte-identical — driving BOTH the declaration text AND
+    the XML 1.1 escaping/undeclaration rules; the effective version must be a valid `VersionNum` `'1.'
+    [0-9]+`, else serialization fails with `ErrInvalidOutputVersion` before any output byte),
+    `OutputEncoding(string)` (override the encoding pseudo-attribute of the XML declaration — empty keeps the
+    document's own encoding, byte-identical; the encoding pseudo-attribute is omitted only when the resulting
+    effective encoding is empty. A non-empty effective encoding must be a well-formed `EncName`, else
+    serialization fails with `ErrUnsupportedOutputEncoding` before any output byte (validated ahead of the
+    transcoding encoder, so no BOM leaks). Affects the **Document serialization path only**: a bare
+    element/fragment carries no declaration, so `asciiOutput` stays off and fragment bytes are byte-identical
+    to output without an override. When set on a `WriteTo`-to-io.Writer Document path the emitted octets are
+    RE-ENCODED to the effective encoding so the bytes agree with the declaration, and an effective encoding
+    the writer cannot emit — one the internal encoder table can't load and that is not UTF-8/US-ASCII — fails
+    with `ErrUnsupportedOutputEncoding`; this hard error is scoped to the override, a document's own
+    unloadable parsed encoding stays declaration-only. An explicit US-ASCII override — matched by ANY IANA
+    alias via `internal/encoding.IsASCII` (`us-ascii`, `ascii`, `csASCII`, `ANSI_X3.4-1968`, `ANSI_X3.4-1986`,
+    `iso-ir-6`, `ISO646-US`, `us`, `IBM367`, `cp367`) — installs no encoder but escapes EVERY non-ASCII
+    character — the full Unicode range, not just the Latin-1 that `EscapeNonASCII` covers — as a numeric
+    character reference (`&#xNNNN;`), so the octets are pure US-ASCII and agree with the declaration. Text and
+    attribute values character-reference fine; ANY other non-ASCII byte reaching the output has no faithful
+    US-ASCII serialization and fails with `ErrUnsupportedOutputEncoding` — a name, comment, CDATA, PI
+    target/data, namespace prefix, DTD-internal name (DOCTYPE, `<!ELEMENT>`/`<!ATTLIST>`/`<!ENTITY>` names,
+    enumeration tokens), a character-map replacement, a DTD external/system/public-ID literal, an
+    entity/notation value/name, or any future raw-write site. Per-site guards give early labelled errors on
+    the common paths and an exhaustive output-writer net (`asciiRejectWriter`) rejects any surviving byte ≥
+    0x80. Without an override a document's own US-ASCII encoding stays byte-identical. fn:serialize uses an
+    internal declaration-only mode instead, keeping octets UTF-8 with char-reference escaping — a US-ASCII
+    encoding there still character-references non-ASCII text/attr values, but keeps reference-less content and
+    character-map replacements RAW (the result is a UTF-8 string), so the net and guards key on `asciiOutput
+    && !declOnlyEncoding`), `Standalone(bool)` / `OmitStandalone()` (force the declaration's standalone
+    pseudo-attribute to yes/no, or force its omission, overriding the document's own standalone status),
+    `CharacterMap(map[rune]string)` (substitute a mapped rune with its raw replacement in text/attribute
+    content — XSLT/XQuery Serialization 3.1 §7), `Normalization(string)` (the normalization-form serialization
+    parameter — `"NFC"`/`"NFD"`/`"NFKC"`/`"NFKD"` normalize text-node and attribute-value character content;
+    `""`/`"none"` disable it; ANY OTHER value is an error: `WriteTo` fails with
+    `ErrUnsupportedNormalizationForm` before any output byte, so an out-of-range form never silently disables
+    normalization), `CDATASectionElements(map[string]struct{})` (emit the named elements' direct text children
+    as CDATA), and `SuppressIndentElements(map[string]struct{})` (serialize the named subtrees without
+    indentation even when `Format` is on) — the last two match by EXACT expanded `{uri}local` name
+  - XML 1.1 output: when the effective output version is `"1.1"` — either the serialized document declares
+    version `"1.1"` (`Document.Version() == "1.1"`, set via `Document.SetVersion`) or `OutputVersion("1.1")`
+    overrides it — the writer emits the XML 1.1 **restricted** control characters (`#x1-#x8`, `#xB-#xC`,
+    `#xE-#x1F`, `#x7F-#x84`, `#x86-#x9F`; §2.11, tab/LF/CR excluded) **plus the two end-of-line characters NEL
+    `#x85` and LINE SEPARATOR `#x2028`** (excluded from `RestrictedChar` but normalized to `#xA` on §2.11
+    input, so they must be char-ref'd to round-trip — the serialization set is `isXML11SerializeAsCharRef` =
+    `isXML11RestrictedChar` ∪ {`#x85`, `#x2028`}) as **decimal** character references (`&#N;`) in text and
+    attribute content instead of hex (`escapeNonASCII`) or U+FFFD replacement/`SERE0006` rejection. Gated on
+    the document version, so XML 1.0 output is byte-identical (the `xml11` branch sits after the
+    `RejectInvalidChars` check and before the `escapeNonASCII` hex branch, so it adds no extra walk; in XML
+    1.0 NEL/LS are ordinary characters written literally). The `stream.Writer` has the parallel
+    `XMLVersion("1.1")` fluent method (also set by `StartDocument` when the declaration version is `1.1`): its
+    text/attribute validation admits the restricted chars and `writeEscaped` serializes the same
+    `isXML11SerializeAsCharRef` set as decimal refs (comment/PI/CDATA content, which cannot carry a reference,
+    stay strictly rejected)
+  - XML 1.1 DTD literals: `EntityValue` validates and preserves existing named and numeric references, then
+    converts each raw `isXML11SerializeAsCharRef` character to a decimal character reference. It is the one
+    DTD literal grammar that can carry a character reference. Comment text, PI data, CDATA content, and
+    external DTD public/system literals cannot carry one, so `serializeRefFree`/`dtdLiteral` reject XML 1.1
+    serialization-only characters by default or replace them with raw U+FFFD in replacement mode. XML 1.0
+    continues to write U+007F, NEL, and LINE SEPARATOR literally in these paths.
   - Terminal method: `WriteTo(io.Writer, Node) → error`
 - **Write(io.Writer, Node) → error** — serialize node with default settings
 - **WriteString(Node) → (string, error)** — serialize node to string with default settings
 - **Element.FindAttribute(AttributePredicate) → (*Attribute, bool)** — attribute-node lookup by matcher; built-in matchers: `QNamePredicate`, `LocalNamePredicate`, `NSPredicate`
 - **Element.GetAttribute(qname) → (string, bool)** / **Element.GetAttributeNS(local, nsURI) → (string, bool)** — attribute value lookup by QName or expanded name
 - Element attribute setters (all return only `error`, create-or-replace-in-place by expanded name/QName via `addProperty`, and reject a colon in the name/local name):
-  - **Element.SetAttribute(name, value) / Element.SetAttributeNS(localname, value, ns)** — **LITERAL**: store `value` verbatim as a text child WITHOUT parsing entity references (mirrors libxml2 `xmlSetProp`). `"A&B"` stays the three characters `A&B`; `"&amp;"` stays five characters. The writer escapes on output, so a verbatim `&` round-trips as `&amp;`. An empty value creates an empty text child, distinguishing it from a boolean attribute. This is the default setter — use it for already-literal text (attr values, computed strings, resolved URIs, HTML/parser-resolved values).
-  - **Element.SetParsedAttribute(name, value) / Element.SetParsedAttributeNS(localname, value, ns)** — **PARSED**: parse `value` for entity references into the attribute's child node list via `Document.CreateAttribute` (mirrors libxml2 `xmlNewDocProp`). `"&amp;"` resolves to a single `&`; a malformed reference (e.g. a bare `&` in `"A&B"`) is an error. For callers building the DOM from unresolved attribute source text (the parser's `TreeBuilder` non-`replaceEntities` path).
+  - **Element.SetAttribute(name, value) / Element.SetAttributeNS(localname, value, ns)** — **LITERAL**: store
+    `value` verbatim as a text child WITHOUT parsing entity references (mirrors libxml2 `xmlSetProp`). `"A&B"`
+    stays the three characters `A&B`; `"&amp;"` stays five characters. The writer escapes on output, so a
+    verbatim `&` round-trips as `&amp;`. An empty value creates an empty text child, distinguishing it from a
+    boolean attribute. This is the default setter — use it for already-literal text (attr values, computed
+    strings, resolved URIs, HTML/parser-resolved values).
+  - **Element.SetParsedAttribute(name, value) / Element.SetParsedAttributeNS(localname, value, ns)** —
+    **PARSED**: parse `value` for entity references into the attribute's child node list via
+    `Document.CreateAttribute` (mirrors libxml2 `xmlNewDocProp`). `"&amp;"` resolves to a single `&`; a
+    malformed reference (e.g. a bare `&` in `"A&B"`) is an error. For callers building the DOM from unresolved
+    attribute source text (the parser's `TreeBuilder` non-`replaceEntities` path).
   - **Element.SetBooleanAttribute(name)** — name-only attribute with NO children (distinct from an empty-string value).
 - **Document.CreateAttribute(name, value, ns) → (*Attribute, error)** — builds an attribute node with `value` PARSED into its child list (mirrors `xmlNewDocProp`); backs `SetParsedAttribute`/`SetParsedAttributeNS`. Rejects a colon in `name`.
 - Key types: `Document`, `Element`, `Attribute`, `Namespace`, `DTD`, `Entity`, `Text`, `CDATASection`, `Comment`, `PI`
 - `Node` interface — common for all node types; use ElementType enum to distinguish
 - Parse flags configured via fluent methods on Parser (internal bitset, not public)
-- `ErrorHandler` interface — delivers compilation/validation errors (synchronously unless the handler is `Sink`-backed); retained by reference and shared across operations, a nil handler is treated as `NilErrorHandler` (discard). The root `Parser` consults it only during DTD validation (see `Parser.ErrorHandler` above)
+- `ErrorHandler` interface — delivers compilation/validation errors (synchronously unless the handler is
+  `Sink`-backed); retained by reference and shared across operations, a nil handler is treated as
+  `NilErrorHandler` (discard). The root `Parser` consults it only during DTD validation (see
+  `Parser.ErrorHandler` above)
 - `ErrorLeveler` interface — optional `ErrorLevel() ErrorLevel` an error implements to report its severity; `ErrorCollector`'s level filter reads it via `errors.As` (default `ErrorLevelWarning`)
-- `DTDValidationError{Message, Level}` (`valid.go`) — structured DTD-validation diagnostic delivered to the `ErrorHandler` under `ValidateDTD(true)`; implements `ErrorLeveler` returning `ErrorLevelError`, so a level-filtered `ErrorCollector` keeps it. Recover via `errors.As`; `.Error()` returns `Message` (byte-identical to the prior `fmt.Errorf` text)
+- `DTDValidationError{Message, Level}` (`valid.go`) — structured DTD-validation diagnostic delivered to the
+  `ErrorHandler` under `ValidateDTD(true)`; implements `ErrorLeveler` returning `ErrorLevelError`, so a
+  level-filtered `ErrorCollector` keeps it. Recover via `errors.As`; `.Error()` returns `Message`
+  (byte-identical to the prior `fmt.Errorf` text)
 - `CatalogResolver` interface — public interface for custom catalog resolvers (`Resolve(ctx, pubID, sysID)`, `ResolveURI(ctx, uri)`)
 - `ErrNoInternalSubset` — sentinel returned by `Document.InternalSubset()` when the document has no internal DTD subset (`IntSubset()` returns nil for the same condition); match with `errors.Is`
-- `ErrDuplicateDeclaration` — sentinel returned when a DTD declaration collides with an existing one of the same kind and name: a second `AddElementDecl`, `AddNotation`, or `AddAttributeDecl` for an already-declared element, notation, or `(element, attribute)` pair. Wrapped (via `%w`) into a message naming the kind and name; match with `errors.Is`
-- `ErrInvalidArgument` — sentinel returned when a public builder is given an out-of-range enum argument (e.g. an `AddAttributeDecl` attribute type or default kind that is not a defined enum value) OR a colon in a `AddNotation` notation name (a notation name is an XML NCName; the colon is the one name-grammar rule these otherwise caller-trusting builders enforce, because the parser rejects a colon-bearing `<!NOTATION>` name). Wrapped (via `%w`) into a message describing the violation; match with `errors.Is`
+- `ErrDuplicateDeclaration` — sentinel returned when a DTD declaration collides with an existing one of the
+  same kind and name: a second `AddElementDecl`, `AddNotation`, or `AddAttributeDecl` for an already-declared
+  element, notation, or `(element, attribute)` pair. Wrapped (via `%w`) into a message naming the kind and
+  name; match with `errors.Is`
+- `ErrInvalidArgument` — sentinel returned when a public builder is given an out-of-range enum argument (e.g.
+  an `AddAttributeDecl` attribute type or default kind that is not a defined enum value) OR a colon in a
+  `AddNotation` notation name (a notation name is an XML NCName; the colon is the one name-grammar rule these
+  otherwise caller-trusting builders enforce, because the parser rejects a colon-bearing `<!NOTATION>` name).
+  Wrapped (via `%w`) into a message describing the violation; match with `errors.Is`
 - `ErrExternalDTDTooLarge` — sentinel error returned when a loaded external DTD subset exceeds the byte cap; enforced against actual bytes read, never the advisory `fs.FileInfo.Size()`
-- `ErrUnsupportedXMLVersion` — sentinel returned when a document's XML declaration declares a VersionNum outside the 1.x family (e.g. `"0.0"`, `"2.0"`), which XML 1.0 5th ed. makes fatal (§2.8; libxml2 `XML_ERR_UNKNOWN_VERSION`). Wrapped (via `%w`) into a message naming the version, then into `ErrParseError`; match with `errors.Is`. A `1.x` version other than `1.0`/`1.1` warns instead and parses (see `parser-internals.md`)
-- `ErrNodeContentTooLarge` — sentinel returned when a single CDATA/comment/PI/char-data run or attribute value — or a single contiguous run of XML whitespace (a blank skip) — exceeds `MaxNodeContentSize` (or `DefaultMaxNodeContentSize`); match with `errors.Is`
-- `ErrUnsupportedOutputEncoding` — sentinel returned by the writer for an effective `OutputEncoding` that cannot be emitted faithfully, in three cases: (0) the effective encoding is a non-empty label that is NOT a well-formed XML `EncName` (`[A-Za-z] ([A-Za-z0-9._] | '-')*`, checked via `xmlchar.IsValidEncName` at the `writeDoc` entry before any output byte is written, ahead of the transcoding encoder so no BOM leaks) — a label carrying a quote or other illegal character would inject markup into the encoding pseudo-attribute; (1) the encoding is a well-formed label that is not UTF-8/US-ASCII and not loadable by the internal encoder table; (2) the encoding is US-ASCII (any alias) on the octet-producing WriteTo path and a non-ASCII byte reaches the output where no character reference can represent it — text and attribute values are always char-referenced, so ANY OTHER non-ASCII byte fails (names, comment, CDATA, PI, namespace prefix, DTD-internal names, character-map replacement, DTD external/system/public-ID literals, entity/notation value/name), caught by per-site guards plus an exhaustive `asciiRejectWriter` net; fn:serialize's declaration-only mode is excluded (keeps reference-less content raw in its UTF-8 string). The label-well-formedness check (case 0) also fires on a document's OWN encoding (`Document.SetEncoding`), since a malformed EncName cannot be faithfully emitted from any source; the transcoding cases (1)/(2) stay scoped to the override so a document's own unloadable parsed encoding stays declaration-only (default output byte-identical); match with `errors.Is`
-- `ErrInvalidOutputVersion` — sentinel returned by the writer when the effective output XML version (the `OutputVersion` override, or the document's own version via `Document.SetVersion`) is not a valid XML `VersionNum` production `'1.' [0-9]+` (XML §2.8, e.g. `1.0`/`1.1`; a non-`1.x` version like `2.0` is also rejected). The version is emitted raw between the double quotes of the declaration's version pseudo-attribute, so the writer validates it (via `isValidXMLVersion`) before writing any output byte and fails closed on a value carrying a quote/illegal character (markup injection) or a malformed value (unparseable declaration), emitting nothing. A non-empty `OutputVersion` override is validated at the `WriteTo` entry ahead of the node-type branch, so a bare element/fragment is rejected the same as a Document (the override drives the XML 1.1 escaping rules there too); the document's own version is validated at the `writeDoc` entry. Valid `1.x` versions are byte-identical; match with `errors.Is`
-- Writer structural-serialization sentinels (errors.go) — each flags a DOM the writer cannot serialize into well-formed XML and is wrapped with %w for errors.Is: ErrWriterReservedElementName, ErrWriterReservedAttributeName, ErrWriterReservedNamespacePrefix, ErrWriterInvalidElementName, ErrWriterInvalidAttributeName, ErrWriterInvalidNamespacePrefix, ErrWriterUnboundNamespacePrefix, ErrWriterInvalidName, ErrWriterInvalidComment, ErrWriterInvalidPITarget, ErrWriterInvalidPIContent, and ErrWriterInvalidDTDNode. ErrWriterUnboundNamespacePrefix covers a non-empty element or attribute prefix with no namespace URI; ErrWriterInvalidName covers malformed EntityValue markup, DTD Name or NCName grammar failures, and invalid enumeration tokens in either replacement mode; and ErrWriterInvalidDTDNode covers an empty DOCTYPE name, a non-PubidChar public identifier, or a DOCTYPE, external-entity, or notation system literal containing both quote characters. The checks preserve an earlier I/O error.
-- `ErrUnsupportedNormalizationForm` — sentinel returned by `Writer.WriteTo` when `Writer.Normalization` was given a value outside `{"", "none", "NFC", "NFD", "NFKC", "NFKD"}`. `Normalization` stores the raw form and the check is deferred to `WriteTo` (covering both the Document and bare-element paths), which fails closed before any output byte instead of silently disabling normalization; match with `errors.Is`
-- `DefaultMaxNodeContentSize` — default single-construct content byte cap (10 MiB), also bounding a contiguous blank-skip run; used when `MaxNodeContentSize` is unset (0); a negative `MaxNodeContentSize` disables both the node-content and the blank-run cap
+- `ErrUnsupportedXMLVersion` — sentinel returned when a document's XML declaration declares a VersionNum
+  outside the 1.x family (e.g. `"0.0"`, `"2.0"`), which XML 1.0 5th ed. makes fatal (§2.8; libxml2
+  `XML_ERR_UNKNOWN_VERSION`). Wrapped (via `%w`) into a message naming the version, then into `ErrParseError`;
+  match with `errors.Is`. A `1.x` version other than `1.0`/`1.1` warns instead and parses (see
+  `parser-internals.md`)
+- `ErrNodeContentTooLarge` — sentinel returned when a single CDATA/comment/PI/char-data run or attribute value
+  — or a single contiguous run of XML whitespace (a blank skip) — exceeds `MaxNodeContentSize` (or
+  `DefaultMaxNodeContentSize`); match with `errors.Is`
+- `ErrUnsupportedOutputEncoding` — sentinel returned by the writer for an effective `OutputEncoding` that
+  cannot be emitted faithfully, in three cases: (0) the effective encoding is a non-empty label that is NOT a
+  well-formed XML `EncName` (`[A-Za-z] ([A-Za-z0-9._] | '-')*`, checked via `xmlchar.IsValidEncName` at the
+  `writeDoc` entry before any output byte is written, ahead of the transcoding encoder so no BOM leaks) — a
+  label carrying a quote or other illegal character would inject markup into the encoding pseudo-attribute;
+  (1) the encoding is a well-formed label that is not UTF-8/US-ASCII and not loadable by the internal encoder
+  table; (2) the encoding is US-ASCII (any alias) on the octet-producing WriteTo path and a non-ASCII byte
+  reaches the output where no character reference can represent it — text and attribute values are always
+  char-referenced, so ANY OTHER non-ASCII byte fails (names, comment, CDATA, PI, namespace prefix,
+  DTD-internal names, character-map replacement, DTD external/system/public-ID literals, entity/notation
+  value/name), caught by per-site guards plus an exhaustive `asciiRejectWriter` net; fn:serialize's
+  declaration-only mode is excluded (keeps reference-less content raw in its UTF-8 string). The
+  label-well-formedness check (case 0) also fires on a document's OWN encoding (`Document.SetEncoding`), since
+  a malformed EncName cannot be faithfully emitted from any source; the transcoding cases (1)/(2) stay scoped
+  to the override so a document's own unloadable parsed encoding stays declaration-only (default output
+  byte-identical); match with `errors.Is`
+- `ErrInvalidOutputVersion` — sentinel returned by the writer when the effective output XML version (the
+  `OutputVersion` override, or the document's own version via `Document.SetVersion`) is not a valid XML
+  `VersionNum` production `'1.' [0-9]+` (XML §2.8, e.g. `1.0`/`1.1`; a non-`1.x` version like `2.0` is also
+  rejected). The version is emitted raw between the double quotes of the declaration's version
+  pseudo-attribute, so the writer validates it (via `isValidXMLVersion`) before writing any output byte and
+  fails closed on a value carrying a quote/illegal character (markup injection) or a malformed value
+  (unparseable declaration), emitting nothing. A non-empty `OutputVersion` override is validated at the
+  `WriteTo` entry ahead of the node-type branch, so a bare element/fragment is rejected the same as a Document
+  (the override drives the XML 1.1 escaping rules there too); the document's own version is validated at the
+  `writeDoc` entry. Valid `1.x` versions are byte-identical; match with `errors.Is`
+- Writer structural-serialization sentinels (errors.go) — each flags a DOM the writer cannot serialize into
+  well-formed XML and is wrapped with %w for errors.Is: ErrWriterReservedElementName,
+  ErrWriterReservedAttributeName, ErrWriterReservedNamespacePrefix, ErrWriterInvalidElementName,
+  ErrWriterInvalidAttributeName, ErrWriterInvalidNamespacePrefix, ErrWriterUnboundNamespacePrefix,
+  ErrWriterInvalidName, ErrWriterInvalidComment, ErrWriterInvalidPITarget, ErrWriterInvalidPIContent, and
+  ErrWriterInvalidDTDNode. ErrWriterUnboundNamespacePrefix covers a non-empty element or attribute prefix with
+  no namespace URI; ErrWriterInvalidName covers malformed EntityValue markup, DTD Name or NCName grammar
+  failures, and invalid enumeration tokens in either replacement mode; and ErrWriterInvalidDTDNode covers an
+  empty DOCTYPE name, a non-PubidChar public identifier, or a DOCTYPE, external-entity, or notation system
+  literal containing both quote characters. The checks preserve an earlier I/O error.
+- `ErrUnsupportedNormalizationForm` — sentinel returned by `Writer.WriteTo` when `Writer.Normalization` was
+  given a value outside `{"", "none", "NFC", "NFD", "NFKC", "NFKD"}`. `Normalization` stores the raw form and
+  the check is deferred to `WriteTo` (covering both the Document and bare-element paths), which fails closed
+  before any output byte instead of silently disabling normalization; match with `errors.Is`
+- `DefaultMaxNodeContentSize` — default single-construct content byte cap (10 MiB), also bounding a contiguous
+  blank-skip run; used when `MaxNodeContentSize` is unset (0); a negative `MaxNodeContentSize` disables both
+  the node-content and the blank-run cap
 - `MaxExternalDTDSize` — default external-DTD byte cap (10 MiB), used when `MaxExternalDTDBytes` is unset or `0`
 - `Parser.MaxExternalDTDBytes(n int)` — override the external-DTD byte cap (`0` → `MaxExternalDTDSize`; negative disables the cap)
-- `AsNode[T Node](n Node) (T, bool)` — generic safe type assertion for Node types. A typed-nil pointer wrapped in a non-nil `Node` interface (Go's interface nil trap — e.g. the `*Element` `Document.DocumentElement()` returns for a rootless document) reports `(zero, false)`, never `(nil, true)`, so a caller with `ok == true` can always dereference the result. The typed-nil (`isNilNode`) check runs only when the assertion already matched, so ordinary calls do not pay the reflect cost
-- `Document.GetElementByID(id)` — O(1) via hash table, O(n) fallback; nil if no match. In a valid document an ID is unique, so at most one match. Duplicate IDs make a document invalid, not not-well-formed (it still parses with `DocWellFormed` set). If several elements share an ID the table path returns the last-registered element (RegisterID overwrites by call order, NOT necessarily last in document order) and the fallback walk the first — don't rely on either
-- `Document.RegisterID(id, *Element)` / `Document.IDTable() → map[string]*Element` — register an ID->element entry / read the interned ID table (own map, read-only — mutating it corrupts the ID index; nil for API-built docs). `IDTable` lets a derived doc (e.g. an xsl:strip-space copy) rebuild a faithful ID table by translating each entry's element through an original->copy map, preserving the interned table's identity and O(1) fidelity. Re-deriving ids would fall back to the lazy O(n) `GetElementByID` walk (which itself resolves prefixed elements' qualified ATTLIST correctly)
-- `Document.SkipIDs() → bool` / `Document.SetSkipIDs(bool)` — get/set the document's ID-skip state (mirrors the parser `SkipIDs` option). While true, `GetElementByID`/`fn:id` resolve no ids without an O(n) walk, even if an ID table exists; used when producing a derived document (e.g. an xsl:strip-space copy) that must mirror the source's ID semantics
-- `Document.Encoding() → string` vs `Document.RawEncoding() → string` — `Encoding()` returns `"utf8"` when the recorded encoding is empty; `RawEncoding()` returns the recorded value verbatim (empty = none recorded). The serializer emits `encoding="..."` only when the raw encoding is non-empty, so a faithful document copy must propagate `RawEncoding()`, not `Encoding()`
-- `Walk(doc, fn)`, `Children(node)`, `Descendants(node)` — tree traversal. All accept a typed-nil node (e.g. `Document.DocumentElement()` of a rootless doc) without panicking: the iterators (`Children`/`ChildElements`/`Descendants`) yield nothing; `Walk` returns `ErrNilNode`
+- `AsNode[T Node](n Node) (T, bool)` — generic safe type assertion for Node types. A typed-nil pointer wrapped
+  in a non-nil `Node` interface (Go's interface nil trap — e.g. the `*Element` `Document.DocumentElement()`
+  returns for a rootless document) reports `(zero, false)`, never `(nil, true)`, so a caller with `ok == true`
+  can always dereference the result. The typed-nil (`isNilNode`) check runs only when the assertion already
+  matched, so ordinary calls do not pay the reflect cost
+- `Document.GetElementByID(id)` — O(1) via hash table, O(n) fallback; nil if no match. In a valid document an
+  ID is unique, so at most one match. Duplicate IDs make a document invalid, not not-well-formed (it still
+  parses with `DocWellFormed` set). If several elements share an ID the table path returns the last-registered
+  element (RegisterID overwrites by call order, NOT necessarily last in document order) and the fallback walk
+  the first — don't rely on either
+- `Document.RegisterID(id, *Element)` / `Document.IDTable() → map[string]*Element` — register an ID->element
+  entry / read the interned ID table (own map, read-only — mutating it corrupts the ID index; nil for
+  API-built docs). `IDTable` lets a derived doc (e.g. an xsl:strip-space copy) rebuild a faithful ID table by
+  translating each entry's element through an original->copy map, preserving the interned table's identity and
+  O(1) fidelity. Re-deriving ids would fall back to the lazy O(n) `GetElementByID` walk (which itself resolves
+  prefixed elements' qualified ATTLIST correctly)
+- `Document.SkipIDs() → bool` / `Document.SetSkipIDs(bool)` — get/set the document's ID-skip state (mirrors
+  the parser `SkipIDs` option). While true, `GetElementByID`/`fn:id` resolve no ids without an O(n) walk, even
+  if an ID table exists; used when producing a derived document (e.g. an xsl:strip-space copy) that must
+  mirror the source's ID semantics
+- `Document.Encoding() → string` vs `Document.RawEncoding() → string` — `Encoding()` returns `"utf8"` when the
+  recorded encoding is empty; `RawEncoding()` returns the recorded value verbatim (empty = none recorded). The
+  serializer emits `encoding="..."` only when the raw encoding is non-empty, so a faithful document copy must
+  propagate `RawEncoding()`, not `Encoding()`
+- `Walk(doc, fn)`, `Children(node)`, `Descendants(node)` — tree traversal. All accept a typed-nil node (e.g.
+  `Document.DocumentElement()` of a rootless doc) without panicking: the iterators
+  (`Children`/`ChildElements`/`Descendants`) yield nothing; `Walk` returns `ErrNilNode`
 - `CopyNode(src, targetDoc)` — deep copy across documents; a nil or typed-nil `src` returns `ErrNilNode` instead of panicking
-- `CopyDoc(src) → (*Document, error)` / `CopyDTDInfo(src, dst) → error` / `CopyExtSubset(src, dst)` — document-level deep copy: `CopyDoc` is a COMPLETE independent copy — the whole tree, BOTH DTD subsets, and the document-level state a caller relies on (version/encoding/standalone, URL, property flags, SkipIDs, and the interned ID table rebuilt against the copy's own elements; no mutable map or DTD is aliased); `CopyDTDInfo` copies the INTERNAL subset's metadata + entities/elements/attributes/notations into `dst` and RETURNS an error (notably when `dst` already has an internal subset); `CopyExtSubset` gives `dst` its own independent deep copy of the source's EXTERNAL DTD subset (`copy.go` / `copy_dtd.go` / `dtd.go`)
-- No-preflight child linkage and raw single-pointer linkage are package-private: `appendFastChild(parent MutableNode, child Node) → error` (`tree_fastpath.go`) links `child` into `parent`'s child slice bypassing the per-node cycle/duplicate-attribute preflight that `AddChild` runs, and `unsafeSetNextSibling(n, next Node)` / `unsafeSetParent(n, parent Node)` (`node.go`) set ONLY the named pointer with no cycle detection, auto-unlinking, or reciprocal back-pointer maintenance. They are deliberately NOT on the `MutableNode` interface (which exposes only guarded mutation: `AddChild`/`AddSibling`/`Replace`/`AppendText`/`SetLine`/`SetOwnerDocument`/`SetTreeDoc`), so ordinary tree mutation cannot reach them by accident, and there is no public entry point to any of them. Sibling packages in this module reach them through the `internal/nodelink` hooks (`AppendFastChild` for `xslt3`'s strip-space copier; `CorruptSelfNextSibling` and `CorruptTypedNilNextSibling` for the `xsd`/`xmldsig1` corrupt-tree cycle-guard fixtures only); the external `helium_test` package reaches them through the `*ForTesting` wrappers in `export_test.go`. There is no `prev`-pointer setter
-- `Document.SetDocumentElement(root MutableNode) → error` — sets/replaces the document element; `root` must be an element (non-element kind → `ErrInvalidOperation`, nil/typed-nil root or nil receiver → `ErrNilNode`), leaving the document untouched on rejection
-- Element/attribute node builders — `Document.CreateElement(name) → (*Element, error)` and `Document.CreateAttribute(name, value, ns) → (*Attribute, error)` REJECT a colon in `name` (error message points the caller at the namespaced form); `name` is not otherwise checked against the XML Name/NCName grammar. This is a deliberate namespace-aware divergence from libxml2's `xmlNewNode`/`xmlNewProp`, which do no validation — a colon in the single name field yields an unbound prefix that serializes as namespace-ill-formed XML. Supply a namespaced element through `Document.CreateElementNS(localname, ns) → (*Element, error)` (rejects a colon in `localname`, then sets `ns` as the element's active namespace via `SetNamespace`, so `Name()` renders `prefix:localname`); it is the element analogue of the `SetAttribute` / `SetAttributeNS` pairing. A nil receiver allocates a standalone (heap, non-slab) element for either. All in-tree parser/build/copy call sites feed a pre-split local name (the parser splits the QName and sets the namespace via `SetActiveNamespace`), so the rejection never fires on a well-formed parse (`document.go`)
-  <!-- A review finding claimed html/tree.go now routes raw colon-bearing HTML attributes into SetAttribute/SetBooleanAttribute, contradicting the never-fires claim above. It does not: "the rejection" in this bullet is the Document.CreateElement/CreateElementNS/CreateAttribute colon rejection (document.go). html/tree.go:36-69 pre-splits colon-bearing tag names before CreateElementNS, and html/ never calls Document.CreateAttribute. Element.SetAttribute/SetBooleanAttribute perform their own inline colon checks (element.go) and are documented in their own bullet above, which makes no never-fires-on-parse claim. -->
-- DTD content-model builder API — `Document.CreateElementContent(name, etype) → (*ElementContent, error)` builds a leaf (`ElementContentElement`/`ElementContentPCDATA`); `Document.CreateElementContentSeq(c1, c2, occur)` / `Document.CreateElementContentChoice(c1, c2, occur)` build validated sequence (,) / choice (|) interior nodes (both children must be non-nil and structurally complete); `ElementContent.SetOccurrence(occur) → (*ElementContent, error)` sets the once/?/*/+ indicator. `DTD.AddElementDecl(name, typ, content)` rejects a structurally-incomplete model (`validateElementContentModel`) before storing, so serialization can never nil-deref. `DTD.RemoveElement(name, prefix) → *ElementDecl` unlinks the decl from the child list (not just the lookup table) and returns it (`document.go` / `dtd_elem.go` / `dtd.go` / `valid.go`)
-- DTD declaration builders — the `DTD.Add*` family builds a declaration from public parameters, registers it in the lookup table, AND links it into the DTD child list so it serializes: `AddEntity(name, typ, publicID, systemID, content) → (*Entity, error)`, `AddNotation(name, publicID, systemID) → (*Notation, error)`, `AddElementDecl(name, typ, content) → (*ElementDecl, error)`, and `AddAttributeDecl(elem, name, atype, def, defvalue, enumValues Enumeration) → (*AttributeDecl, error)` — the latter builds an `<!ATTLIST>` declaration. Like its siblings it validates only the enum parameters (`atype` a defined `enum.Attr*` value, `def` a defined `enum.AttrDefault*` kind — else `ErrInvalidArgument`) and rejects a duplicate (`ErrDuplicateDeclaration`); it splits `name` into prefix+local on the first colon as `AddElementDecl` does and clones `enumValues` before storing (a later caller mutation cannot corrupt the stored decl). It TRUSTS the caller for well-formed names, default values, and namespace/URI syntax — it does NOT validate them against the parser's Name/URI grammar, character ranges, or cross-declaration validity constraints (those are enforced by `ValidateDTD`), matching how `AddNotation`/`AddEntity`/`AddElementDecl` trust the caller. `AddNotation` is caller-trusting too, with one narrow exception: it rejects a colon in the notation name (`ErrInvalidArgument`), because a notation name is an XML NCName and the parser rejects a colon-bearing `<!NOTATION>` name, so a colon would produce un-reparseable output. The attribute table is keyed by an `attrDeclKey{local, prefix, elem}` struct (not a `local:prefix:elem` string, which would collide distinct triples — mirrors the parser's `specialAttrKey`). The low-level `registerAttribute` (no child-list link) is unexported; callers use `AddAttributeDecl` (`dtd.go`). `registerAttribute` also maintains two registration-order sequences — the per-element index `attrsByElem map[string][]*AttributeDecl` and the subset-wide `attrDecls []*AttributeDecl` — so `AttributesForElement(elem)` is an index lookup rather than a scan of every declaration in the subset, and every declaration-order-sensitive consumer reads a sequence instead of the `attributes` map
-- `node.DeclareNamespace(prefix, uri) → error` / `node.AddNamespaceDecl(*Namespace) → error` (promoted to `*Element` etc.) — do NOT themselves add a second declaration for a prefix in `nsDefs` and never change the node's active namespace/expanded name. `DeclareNamespace` allocates a fresh `*Namespace`; `AddNamespaceDecl` attaches the caller's existing one WITHOUT allocating (a built tree can reuse one `Namespace` as both a declaration and an element's active namespace) and returns `ErrNilNode` for a nil ns. On an ELEMENT node, a prefix in use by the element's own name or a NON-empty-prefix attribute at a URI DIFFERENT from the requested URI is a genuine conflict (checked first, whether or not an nsDefs entry exists — this covers the fresh-append path where the active ns/attr set the prefix but no nsDefs entry does): the tree is left unchanged and both `DeclareNamespace` and `AddNamespaceDecl` return the same `%w`-wrapped `ErrInvalidOperation` (matchable with `errors.Is`). The conflict check is element-scoped: on a non-element node (Text, Comment, CDATASection, …) `n.ns` is never serialized, so there is no conflict and the dedup step below still runs (the node never rejects; `AddNamespaceDecl` installs on case 1/3 and keeps the existing slot on a same-URI no-op). An empty-prefix attribute is NOT counted (it never uses the default namespace and the serializer skips it), so a default-prefix rebind is not blocked by one. Otherwise same-prefix+same-URI is a no-op and a different-URI redeclare COLLAPSES the slot in place, replacing it per method: `DeclareNamespace` installs a FRESH `*Namespace`, `AddNamespaceDecl` installs the CALLER's object; both leave the prior slot object unmutated, so an aliasing `n.ns`/`attr.ns` or a caller-retained handle is unaffected. These methods do NOT reconcile a conflict introduced AFTER declaration by `SetActiveNamespace`/`SetNamespace` (which set the active namespace independently); keeping at most one `xmlns:prefix` per element across ALL mutators is a serializer-level concern, outside their scope. The writer enforces it: `dropConflictingActiveNS` drops any `nsDefs` declaration for the active namespace's prefix at a different URI (generalizing the `xmlns=""` default-namespace precedent; the active binding qualifies the element name, so it wins) and `reconcileNamespaces` keeps a per-element `emitted` prefix set so no prefix is declared twice on one start tag — the first occupant (declarations, then the name, before attributes) wins. No-op for parsed documents. Residual limitation: a NAME needing prefix `p` at URI Y while an ATTRIBUTE needs `p` at URI X is unsatisfiable with one prefix; the writer lets the name win, mis-binding the attribute; it synthesizes no fresh prefix. A caller that rebinds an in-use prefix must clear the use itself — reassign the active namespace (`SetActiveNamespace`/`SetNamespace`) and any prefixed attribute; `RemoveNamespaceByPrefix` alone drops only the nsDefs entry, not the `n.ns`/attribute use, so a rebind still rejects while that use remains. Caller owns any ns passed to `AddNamespaceDecl` and must not share it across independently-mutated nodes
-- `UnlinkNode(n MutableNode)` — detaches `n` from its parent/sibling chain; a nil or typed-nil `n` is a no-op. `node.Replace(...Node) → error` (guarded) rejects an EMPTY replacement set with `ErrInvalidOperation` (matching `Document.Replace`; use `UnlinkNode` to delete), a nil/typed-nil operand with `ErrNilNode`, and a cyclic insertion with `ErrCyclicNode`. The guarded mutation ops (`AddChild`/`AddSibling`/`Replace`) return `ErrCyclicNode` (wrapped via `%w`) when the insertion would create a cycle (into itself, a descendant, or replacing with an ancestor), and `ErrInvalidOperation` for a structural rejection (a non-attribute sibling/replacement of an attribute, duplicate replacement operands). `Parser.ParseInNodeContext` returns `ErrNilNode` for a nil/typed-nil context node
+- `CopyDoc(src) → (*Document, error)` / `CopyDTDInfo(src, dst) → error` / `CopyExtSubset(src, dst)` —
+  document-level deep copy: `CopyDoc` is a COMPLETE independent copy — the whole tree, BOTH DTD subsets, and
+  the document-level state a caller relies on (version/encoding/standalone, URL, property flags, SkipIDs, and
+  the interned ID table rebuilt against the copy's own elements; no mutable map or DTD is aliased);
+  `CopyDTDInfo` copies the INTERNAL subset's metadata + entities/elements/attributes/notations into `dst` and
+  RETURNS an error (notably when `dst` already has an internal subset); `CopyExtSubset` gives `dst` its own
+  independent deep copy of the source's EXTERNAL DTD subset (`copy.go` / `copy_dtd.go` / `dtd.go`)
+- No-preflight child linkage and raw single-pointer linkage are package-private: `appendFastChild(parent
+  MutableNode, child Node) → error` (`tree_fastpath.go`) links `child` into `parent`'s child slice bypassing
+  the per-node cycle/duplicate-attribute preflight that `AddChild` runs, and `unsafeSetNextSibling(n, next
+  Node)` / `unsafeSetParent(n, parent Node)` (`node.go`) set ONLY the named pointer with no cycle detection,
+  auto-unlinking, or reciprocal back-pointer maintenance. They are deliberately NOT on the `MutableNode`
+  interface (which exposes only guarded mutation:
+  `AddChild`/`AddSibling`/`Replace`/`AppendText`/`SetLine`/`SetOwnerDocument`/`SetTreeDoc`), so ordinary tree
+  mutation cannot reach them by accident, and there is no public entry point to any of them. Sibling packages
+  in this module reach them through the `internal/nodelink` hooks (`AppendFastChild` for `xslt3`'s strip-space
+  copier; `CorruptSelfNextSibling` and `CorruptTypedNilNextSibling` for the `xsd`/`xmldsig1` corrupt-tree
+  cycle-guard fixtures only); the external `helium_test` package reaches them through the `*ForTesting`
+  wrappers in `export_test.go`. There is no `prev`-pointer setter
+- `Document.SetDocumentElement(root MutableNode) → error` — sets/replaces the document element; `root` must be
+  an element (non-element kind → `ErrInvalidOperation`, nil/typed-nil root or nil receiver → `ErrNilNode`),
+  leaving the document untouched on rejection
+- Element/attribute node builders — `Document.CreateElement(name) → (*Element, error)` and
+  `Document.CreateAttribute(name, value, ns) → (*Attribute, error)` REJECT a colon in `name` (error message
+  points the caller at the namespaced form); `name` is not otherwise checked against the XML Name/NCName
+  grammar. This is a deliberate namespace-aware divergence from libxml2's `xmlNewNode`/`xmlNewProp`, which do
+  no validation — a colon in the single name field yields an unbound prefix that serializes as
+  namespace-ill-formed XML. Supply a namespaced element through `Document.CreateElementNS(localname, ns) →
+  (*Element, error)` (rejects a colon in `localname`, then sets `ns` as the element's active namespace via
+  `SetNamespace`, so `Name()` renders `prefix:localname`); it is the element analogue of the `SetAttribute` /
+  `SetAttributeNS` pairing. A nil receiver allocates a standalone (heap, non-slab) element for either. All
+  in-tree parser/build/copy call sites feed a pre-split local name (the parser splits the QName and sets the
+  namespace via `SetActiveNamespace`), so the rejection never fires on a well-formed parse (`document.go`)
+  <!-- A review finding claimed html/tree.go now routes raw colon-bearing HTML attributes into
+  SetAttribute/SetBooleanAttribute, contradicting the never-fires claim above. It does not: "the rejection" in
+  this bullet is the Document.CreateElement/CreateElementNS/CreateAttribute colon rejection (document.go).
+  html/tree.go:36-69 pre-splits colon-bearing tag names before CreateElementNS, and html/ never calls
+  Document.CreateAttribute. Element.SetAttribute/SetBooleanAttribute perform their own inline colon checks
+  (element.go) and are documented in their own bullet above, which makes no never-fires-on-parse claim. -->
+- DTD content-model builder API — `Document.CreateElementContent(name, etype) → (*ElementContent, error)`
+  builds a leaf (`ElementContentElement`/`ElementContentPCDATA`); `Document.CreateElementContentSeq(c1, c2,
+  occur)` / `Document.CreateElementContentChoice(c1, c2, occur)` build validated sequence (,) / choice (|)
+  interior nodes (both children must be non-nil and structurally complete);
+  `ElementContent.SetOccurrence(occur) → (*ElementContent, error)` sets the once/?/*/+ indicator.
+  `DTD.AddElementDecl(name, typ, content)` rejects a structurally-incomplete model
+  (`validateElementContentModel`) before storing, so serialization can never nil-deref.
+  `DTD.RemoveElement(name, prefix) → *ElementDecl` unlinks the decl from the child list (not just the lookup
+  table) and returns it (`document.go` / `dtd_elem.go` / `dtd.go` / `valid.go`)
+- DTD declaration builders — the `DTD.Add*` family builds a declaration from public parameters, registers it
+  in the lookup table, AND links it into the DTD child list so it serializes: `AddEntity(name, typ, publicID,
+  systemID, content) → (*Entity, error)`, `AddNotation(name, publicID, systemID) → (*Notation, error)`,
+  `AddElementDecl(name, typ, content) → (*ElementDecl, error)`, and `AddAttributeDecl(elem, name, atype, def,
+  defvalue, enumValues Enumeration) → (*AttributeDecl, error)` — the latter builds an `<!ATTLIST>`
+  declaration. Like its siblings it validates only the enum parameters (`atype` a defined `enum.Attr*` value,
+  `def` a defined `enum.AttrDefault*` kind — else `ErrInvalidArgument`) and rejects a duplicate
+  (`ErrDuplicateDeclaration`); it splits `name` into prefix+local on the first colon as `AddElementDecl` does
+  and clones `enumValues` before storing (a later caller mutation cannot corrupt the stored decl). It TRUSTS
+  the caller for well-formed names, default values, and namespace/URI syntax — it does NOT validate them
+  against the parser's Name/URI grammar, character ranges, or cross-declaration validity constraints (those
+  are enforced by `ValidateDTD`), matching how `AddNotation`/`AddEntity`/`AddElementDecl` trust the caller.
+  `AddNotation` is caller-trusting too, with one narrow exception: it rejects a colon in the notation name
+  (`ErrInvalidArgument`), because a notation name is an XML NCName and the parser rejects a colon-bearing
+  `<!NOTATION>` name, so a colon would produce un-reparseable output. The attribute table is keyed by an
+  `attrDeclKey{local, prefix, elem}` struct (not a `local:prefix:elem` string, which would collide distinct
+  triples — mirrors the parser's `specialAttrKey`). The low-level `registerAttribute` (no child-list link) is
+  unexported; callers use `AddAttributeDecl` (`dtd.go`). `registerAttribute` also maintains two
+  registration-order sequences — the per-element index `attrsByElem map[string][]*AttributeDecl` and the
+  subset-wide `attrDecls []*AttributeDecl` — so `AttributesForElement(elem)` is an index lookup rather than a
+  scan of every declaration in the subset, and every declaration-order-sensitive consumer reads a sequence
+  instead of the `attributes` map
+- `node.DeclareNamespace(prefix, uri) → error` / `node.AddNamespaceDecl(*Namespace) → error` (promoted to
+  `*Element` etc.) — do NOT themselves add a second declaration for a prefix in `nsDefs` and never change the
+  node's active namespace/expanded name. `DeclareNamespace` allocates a fresh `*Namespace`; `AddNamespaceDecl`
+  attaches the caller's existing one WITHOUT allocating (a built tree can reuse one `Namespace` as both a
+  declaration and an element's active namespace) and returns `ErrNilNode` for a nil ns. On an ELEMENT node, a
+  prefix in use by the element's own name or a NON-empty-prefix attribute at a URI DIFFERENT from the
+  requested URI is a genuine conflict (checked first, whether or not an nsDefs entry exists — this covers the
+  fresh-append path where the active ns/attr set the prefix but no nsDefs entry does): the tree is left
+  unchanged and both `DeclareNamespace` and `AddNamespaceDecl` return the same `%w`-wrapped
+  `ErrInvalidOperation` (matchable with `errors.Is`). The conflict check is element-scoped: on a non-element
+  node (Text, Comment, CDATASection, …) `n.ns` is never serialized, so there is no conflict and the dedup step
+  below still runs (the node never rejects; `AddNamespaceDecl` installs on case 1/3 and keeps the existing
+  slot on a same-URI no-op). An empty-prefix attribute is NOT counted (it never uses the default namespace and
+  the serializer skips it), so a default-prefix rebind is not blocked by one. Otherwise same-prefix+same-URI
+  is a no-op and a different-URI redeclare COLLAPSES the slot in place, replacing it per method:
+  `DeclareNamespace` installs a FRESH `*Namespace`, `AddNamespaceDecl` installs the CALLER's object; both
+  leave the prior slot object unmutated, so an aliasing `n.ns`/`attr.ns` or a caller-retained handle is
+  unaffected. These methods do NOT reconcile a conflict introduced AFTER declaration by
+  `SetActiveNamespace`/`SetNamespace` (which set the active namespace independently); keeping at most one
+  `xmlns:prefix` per element across ALL mutators is a serializer-level concern, outside their scope. The
+  writer enforces it: `dropConflictingActiveNS` drops any `nsDefs` declaration for the active namespace's
+  prefix at a different URI (generalizing the `xmlns=""` default-namespace precedent; the active binding
+  qualifies the element name, so it wins) and `reconcileNamespaces` keeps a per-element `emitted` prefix set
+  so no prefix is declared twice on one start tag — the first occupant (declarations, then the name, before
+  attributes) wins. No-op for parsed documents. Residual limitation: a NAME needing prefix `p` at URI Y while
+  an ATTRIBUTE needs `p` at URI X is unsatisfiable with one prefix; the writer lets the name win, mis-binding
+  the attribute; it synthesizes no fresh prefix. A caller that rebinds an in-use prefix must clear the use
+  itself — reassign the active namespace (`SetActiveNamespace`/`SetNamespace`) and any prefixed attribute;
+  `RemoveNamespaceByPrefix` alone drops only the nsDefs entry, not the `n.ns`/attribute use, so a rebind still
+  rejects while that use remains. Caller owns any ns passed to `AddNamespaceDecl` and must not share it across
+  independently-mutated nodes
+- `UnlinkNode(n MutableNode)` — detaches `n` from its parent/sibling chain; a nil or typed-nil `n` is a no-op.
+  `node.Replace(...Node) → error` (guarded) rejects an EMPTY replacement set with `ErrInvalidOperation`
+  (matching `Document.Replace`; use `UnlinkNode` to delete), a nil/typed-nil operand with `ErrNilNode`, and a
+  cyclic insertion with `ErrCyclicNode`. The guarded mutation ops (`AddChild`/`AddSibling`/`Replace`) return
+  `ErrCyclicNode` (wrapped via `%w`) when the insertion would create a cycle (into itself, a descendant, or
+  replacing with an ancestor), and `ErrInvalidOperation` for a structural rejection (a non-attribute
+  sibling/replacement of an attribute, duplicate replacement operands). `Parser.ParseInNodeContext` returns
+  `ErrNilNode` for a nil/typed-nil context node
 - `NodeGetBase(doc, node)` — effective xml:base URI
-- `BuildURI(reference, base)` — resolve a relative reference against a base; a byte-faithful port of libxml2 `xmlBuildURI(URI, base)`, so its argument order is `(reference, base)` (reference FIRST), the reverse of `url.URL.ResolveReference`/RFC 3986. c14n and all in-tree callers depend on this order. `node_base.go`
+- `BuildURI(reference, base)` — resolve a relative reference against a base; a byte-faithful port of libxml2
+  `xmlBuildURI(URI, base)`, so its argument order is `(reference, base)` (reference FIRST), the reverse of
+  `url.URL.ResolveReference`/RFC 3986. c14n and all in-tree callers depend on this order. `node_base.go`
 - `ResolveURI(base, ref) → (string, error)` — conventionally-ordered `(base, reference)` wrapper over `BuildURI`; returns an error when the reference cannot be resolved. Use this in new code instead of `BuildURI`'s reversed order. `node_base.go`
-- Files: `parser.go` (API), `parserctx.go` (context/state), `parser_document.go`, `parser_element.go`, `parser_whitespace.go`, `parser_xml_decl.go`, `parser_encoding.go`, `parser_decl.go`, `parser_content.go`, `parser_dtd_subset.go`, `parser_dtd_element.go`, `parser_dtd_attr.go`, `parser_entity_decl.go`, `parser_entity_ref.go`, `parser_state_gen.go`, `document.go`, `element.go`, `attribute.go`, `node.go`, `node_leaf.go`, `node_namespace.go`, `node_base.go`, `tree_builder.go`, `tree_namespaces.go`, `tree_fastpath.go`, `writer.go`, `writer_escape.go`, `writer_dtd.go`, `writer_xhtml.go`, `copy.go`, `copy_deep.go`, `copy_dtd.go`, `dtd.go`, `dtd_attr.go`, `dtd_elem.go`, `iter.go`, `errorhandler.go`, `resolver.go`, `doc.go`
+- Files: `parser.go` (API), `parserctx.go` (context/state), `parser_document.go`, `parser_element.go`,
+  `parser_whitespace.go`, `parser_xml_decl.go`, `parser_encoding.go`, `parser_decl.go`, `parser_content.go`,
+  `parser_dtd_subset.go`, `parser_dtd_element.go`, `parser_dtd_attr.go`, `parser_entity_decl.go`,
+  `parser_entity_ref.go`, `parser_state_gen.go`, `document.go`, `element.go`, `attribute.go`, `node.go`,
+  `node_leaf.go`, `node_namespace.go`, `node_base.go`, `tree_builder.go`, `tree_namespaces.go`,
+  `tree_fastpath.go`, `writer.go`, `writer_escape.go`, `writer_dtd.go`, `writer_xhtml.go`, `copy.go`,
+  `copy_deep.go`, `copy_dtd.go`, `dtd.go`, `dtd_attr.go`, `dtd_elem.go`, `iter.go`, `errorhandler.go`,
+  `resolver.go`, `doc.go`
 
 ## c14n/
 
@@ -83,7 +446,10 @@ W3C Canonical XML. 3 modes: C14N10, ExclusiveC14N10, C14N11.
 - Canonicalizer methods: Comments(), NodeSet([]Node), InclusiveNamespaces([]string), StrictXMLAttributes()
 - Terminal: **Canonicalize(*Document, io.Writer) → error**, **CanonicalizeTo(*Document) → ([]byte, error)**
 - C14N 1.1 xml:base is the lexical join (W3C §2.4 / libxml2 xmlC14NFixupBaseAttr) of in-document xml:base values — no external base URI. See `xmlbase.go` (joinURIReference).
-- StrictXMLAttributes() opts into W3C-strict node-set xml:base/lang/space handling; default matches libxml2 (a rendered element's own excluded xml:* attribute is still emitted — XMLDSig digest interop). Strict mode is also fail-closed on xml:base: a degenerate/un-canonicalizable value (malformed URI, empty-authority "//"/"///"/"urn://") errors out of Canonicalize, where default emits best-effort bytes.
+- StrictXMLAttributes() opts into W3C-strict node-set xml:base/lang/space handling; default matches libxml2 (a
+  rendered element's own excluded xml:* attribute is still emitted — XMLDSig digest interop). Strict mode is
+  also fail-closed on xml:base: a degenerate/un-canonicalizable value (malformed URI, empty-authority
+  "//"/"///"/"urn://") errors out of Canonicalize, where default emits best-effort bytes.
 - Files: `c14n.go` (API), `canonicalizer.go` (engine), `xmlbase.go` (xml:base join), `nsstack.go`, `sort.go`, `escape.go`
 - Imports: helium
 
@@ -118,20 +484,76 @@ XPath 3.1 expression parsing and evaluation.
   - `Compile(string) → (*Expression, error)` / `MustCompile(string) → *Expression` / `CompileExpr(Expr) → (*Expression, error)` — terminal methods
 - **NewEvaluator(EvaluatorOption) → Evaluator** — create evaluator from a flags bitmask (`DefaultEvaluatorOptions` = clone-on-write; `EvalBorrowing` = setters borrow caller-owned maps/slices without cloning)
   - `Evaluate(ctx, *Expression, Node) → (*Result, error)` — terminal method (`ctx` is cancellation only; config comes from the setters below)
-- **Expression.Validate(map[string]string) → error** — static namespace-prefix validation; **Expression.EvaluateReuse(ctx, *EvalState, Node) → (Result, error)** — low-allocation evaluation; **Expression.DumpVM(io.Writer) → error** — compiled VM instruction dump
-- **Evaluator fluent setters** (each returns an updated copy; maps/slices cloned unless `EvalBorrowing`): `Namespaces(map[string]string)`, `Variables(map[string]Sequence)`, `Functions(byLocal map[string]Function, byQName map[QualifiedName]Function)`, `VariableResolver(VariableResolver)`, `FunctionResolver(FunctionResolver)`, `OpLimit(int)`, `CurrentTime(time.Time)`, `ImplicitTimezone(*time.Location)`, `DefaultLanguage(string)`, `DefaultCollation(string)`, `DefaultDecimalFormat(DecimalFormat)`, `NamedDecimalFormats(map[QualifiedName]DecimalFormat)`, `BaseURI(string)`, `URIResolver(URIResolver)`, `CollectionResolver(CollectionResolver)`, `HTTPClient(*http.Client)`, `Position(int)`, `Size(int)`, `ContextItem(Item)`, `TypeAnnotations(map[helium.Node]string)`, `PreservedIDAnnotations(map[helium.Node]string)`, `IDNodes(map[helium.Node]struct{})` (PSVI is-id node set from `xsd.Validator.IDNodes`; a node here is treated as is-id by `fn:id`/`fn:element-with-id` in addition to those whose type annotation is a subtype of xs:ID — covers a singleton list of xs:ID and a union selecting an xs:ID-derived member), `SchemaDeclarations(SchemaDeclarations)`, `StrictPrefixes()`, `QNameValueNoDefaultNamespace()`, `AllowXML11Chars()`, `DocOrderCache(*DocOrderCache)`, `TraceWriter(io.Writer)`, `Parser(helium.Parser)` (XML parser used by `fn:parse-xml`/`fn:parse-xml-fragment`/`fn:doc`; supplies parse policy — limits, FS, XXE/network; unset → default `helium.NewParser()`)
+- **Expression.Validate(map[string]string) → error** — static namespace-prefix validation;
+  **Expression.EvaluateReuse(ctx, *EvalState, Node) → (Result, error)** — low-allocation evaluation;
+  **Expression.DumpVM(io.Writer) → error** — compiled VM instruction dump
+- **Evaluator fluent setters** (each returns an updated copy; maps/slices cloned unless `EvalBorrowing`):
+  `Namespaces(map[string]string)`, `Variables(map[string]Sequence)`, `Functions(byLocal map[string]Function,
+  byQName map[QualifiedName]Function)`, `VariableResolver(VariableResolver)`,
+  `FunctionResolver(FunctionResolver)`, `OpLimit(int)`, `CurrentTime(time.Time)`,
+  `ImplicitTimezone(*time.Location)`, `DefaultLanguage(string)`, `DefaultCollation(string)`,
+  `DefaultDecimalFormat(DecimalFormat)`, `NamedDecimalFormats(map[QualifiedName]DecimalFormat)`,
+  `BaseURI(string)`, `URIResolver(URIResolver)`, `CollectionResolver(CollectionResolver)`,
+  `HTTPClient(*http.Client)`, `Position(int)`, `Size(int)`, `ContextItem(Item)`,
+  `TypeAnnotations(map[helium.Node]string)`, `PreservedIDAnnotations(map[helium.Node]string)`,
+  `IDNodes(map[helium.Node]struct{})` (PSVI is-id node set from `xsd.Validator.IDNodes`; a node here is
+  treated as is-id by `fn:id`/`fn:element-with-id` in addition to those whose type annotation is a subtype of
+  xs:ID — covers a singleton list of xs:ID and a union selecting an xs:ID-derived member),
+  `SchemaDeclarations(SchemaDeclarations)`, `StrictPrefixes()`, `QNameValueNoDefaultNamespace()`,
+  `AllowXML11Chars()`, `DocOrderCache(*DocOrderCache)`, `TraceWriter(io.Writer)`, `Parser(helium.Parser)` (XML
+  parser used by `fn:parse-xml`/`fn:parse-xml-fragment`/`fn:doc`; supplies parse policy — limits, FS,
+  XXE/network; unset → default `helium.NewParser()`)
 - `Result` — wraps `Sequence`; methods: `Nodes()`, `IsBoolean()`, `IsNumber()`, `IsString()`, `IsAtomic()`, `Atomics()`, `Sequence()`, `StringValue()`, `Copy()`
-- **Reuse:** `Evaluator.NewEvalState(Node) → *EvalState` builds reusable state; `Expression.EvaluateReuse` runs against it. The returned `Result` is valid only until the next `EvaluateReuse` on the same `EvalState` (backing storage is overwritten) — use `Result.Copy()` to retain it. `EvalState` has `SetContextItem`/`SetPosition`/`SetSize` and is NOT concurrency-safe
-- **Evaluator.MaxResourceBytes(int64) → Evaluator** — cap bytes read from a single external resource by fn:unparsed-text(-lines/-available), fn:doc, fn:doc-available, fn:json-doc (0 = default cap, negative = unbounded); over-cap reads in fn:unparsed-text/fn:unparsed-text-lines fail FOUT1170 (fn:unparsed-text-available returns false), while fn:doc/fn:json-doc retrieval failures (incl. over-cap) surface as FODC0002 and fn:doc-available returns false
-- **PredeclaredNamespace(prefix string) → (string, bool)** / **PredeclaredNamespaces() → map[string]string** — XPath 3.0 predeclared static-context prefix bindings (`fn`, `math`, `map`, `array`, `err`, `xs`). `PredeclaredNamespaces` returns a fresh copy of all bindings. Callers must let explicit in-scope namespace declarations override these fallbacks (used by xslt3 to keep compile-time and runtime pattern prefix resolution symmetric)
-- **CompileRegex(pattern, flags string) → (*Regex, error)** — compile an XPath/XML Schema regex (flags `i`/`m`/`s`/`x`/`q`) for reuse by other packages (e.g. xslt3's `xsl:analyze-string`). `*Regex` methods: `MatchString(s) → (bool, error)`; `FindAllSubmatchIndex(s, n) → ([][]int, error)` (all matches, each a flat `(start,end)` index pair per group; `n<0` = unlimited); `EachSubmatchIndex(s, limit int, fn func([]int) bool) → error` — **streams** matches one at a time, calling `fn` per match (slice valid only during the call — copy to retain; unmatched group = `-1,-1`), stopping early when `fn` returns false. The streaming engines never accumulate, so live memory stays bounded regardless of match count and a caller can enforce a match-count budget (or honor a cancelled context) DURING enumeration. Leading-context patterns (e.g. multi-line `^`) can't stream on RE2, so they are matched in one bounded `FindAllStringSubmatchIndex` pass on Go `regexp` (staying linear — no backtracking-ReDoS regression for RE2-compatible patterns like `^(a+)+b`); `limit` (N+1 for a budget of N; `<=0` = uncapped) bounds that pass's allocation to the budget, never to the input match count
+- **Reuse:** `Evaluator.NewEvalState(Node) → *EvalState` builds reusable state; `Expression.EvaluateReuse`
+  runs against it. The returned `Result` is valid only until the next `EvaluateReuse` on the same `EvalState`
+  (backing storage is overwritten) — use `Result.Copy()` to retain it. `EvalState` has
+  `SetContextItem`/`SetPosition`/`SetSize` and is NOT concurrency-safe
+- **Evaluator.MaxResourceBytes(int64) → Evaluator** — cap bytes read from a single external resource by
+  fn:unparsed-text(-lines/-available), fn:doc, fn:doc-available, fn:json-doc (0 = default cap, negative =
+  unbounded); over-cap reads in fn:unparsed-text/fn:unparsed-text-lines fail FOUT1170
+  (fn:unparsed-text-available returns false), while fn:doc/fn:json-doc retrieval failures (incl. over-cap)
+  surface as FODC0002 and fn:doc-available returns false
+- **PredeclaredNamespace(prefix string) → (string, bool)** / **PredeclaredNamespaces() → map[string]string** —
+  XPath 3.0 predeclared static-context prefix bindings (`fn`, `math`, `map`, `array`, `err`, `xs`).
+  `PredeclaredNamespaces` returns a fresh copy of all bindings. Callers must let explicit in-scope namespace
+  declarations override these fallbacks (used by xslt3 to keep compile-time and runtime pattern prefix
+  resolution symmetric)
+- **CompileRegex(pattern, flags string) → (*Regex, error)** — compile an XPath/XML Schema regex (flags
+  `i`/`m`/`s`/`x`/`q`) for reuse by other packages (e.g. xslt3's `xsl:analyze-string`). `*Regex` methods:
+  `MatchString(s) → (bool, error)`; `FindAllSubmatchIndex(s, n) → ([][]int, error)` (all matches, each a flat
+  `(start,end)` index pair per group; `n<0` = unlimited); `EachSubmatchIndex(s, limit int, fn func([]int)
+  bool) → error` — **streams** matches one at a time, calling `fn` per match (slice valid only during the call
+  — copy to retain; unmatched group = `-1,-1`), stopping early when `fn` returns false. The streaming engines
+  never accumulate, so live memory stays bounded regardless of match count and a caller can enforce a
+  match-count budget (or honor a cancelled context) DURING enumeration. Leading-context patterns (e.g.
+  multi-line `^`) can't stream on RE2, so they are matched in one bounded `FindAllStringSubmatchIndex` pass on
+  Go `regexp` (staying linear — no backtracking-ReDoS regression for RE2-compatible patterns like `^(a+)+b`);
+  `limit` (N+1 for a budget of N; `<=0` = uncapped) bounds that pass's allocation to the budget, never to the
+  input match count
 - XPath 3.1 features: FLWOR, quantified, if-then-else, try-catch, maps, arrays, inline functions, HOFs, arrow operator, simple map, string concat, value/general/node comparisons
 - Built-in functions: 100+ across fn:, math:, map:, array: namespaces
 - Type system: Sequence ([]Item), AtomicValue, NodeItem, MapItem, ArrayItem, FunctionItem
 - Structured errors: XPathError with W3C error codes (XPTY0004, FOER0000, etc.)
 - Limits: recursion 5000, node-set 10M, configurable op limit
-- Runtime: `Compile()` first tries a direct fast path for simple path-like expressions and simple predicate comparisons, otherwise lowers AST to a VM instruction graph while collecting the prefix-validation plan, keeping trivial leaves inline in parent payloads and reusing parsed slices on the owned compile path; `Evaluate()` executes compiled refs by opcode and reuses shared eval helpers for semantics; AST/streamability access reparses from `Expression.source` on demand
-- Files: `xpath3.go` (API), `parser.go`, `lexer.go`, `expr.go`, `token.go`, `consts.go`, `eval.go`, `eval_path.go`, `eval_operators.go`, `eval_arithmetic.go`, `eval_control.go`, `eval_types.go`, `eval_funcall.go`, `eval_reuse.go`, `evaluator.go`, `vm.go`, `vm_dump.go`, `compile_direct.go`, `compare.go`, `cast.go`, `cast_numeric.go`, `cast_string.go`, `cast_datetime.go`, `types.go`, `float_value.go`, `sequence.go`, `context.go`, `variables.go`, `collation.go`, `regex.go`, `regex_cache.go`, `static_check.go`, `streamability.go`, `node_identity.go`, `uri_resolution.go`, `doc.go`, `errors.go`, `arithmetic_datetime.go`, `parse_ietf_date.go`, `format_datetime.go`, `format_integer.go`, `format_number.go`, `function_library.go`, `function_signatures.go`, `functions.go` (registry + boolean/not/true/false + fn:error/fn:trace), `functions_node.go`, `functions_string.go`, `functions_numeric.go`, `functions_aggregate.go`, `functions_sequence.go`, `functions_datetime.go`, `functions_uri.go`, `functions_qname.go`, `functions_hof.go`, `functions_map.go`, `functions_array.go`, `functions_math.go`, `functions_misc.go`, `functions_json.go`, `functions_json_xml.go`, `functions_serialize.go`, `functions_constructors.go` (XSD typed constructors, incl. xs:error), `functions_unparsed_text.go`
+- Runtime: `Compile()` first tries a direct fast path for simple path-like expressions and simple predicate
+  comparisons, otherwise lowers AST to a VM instruction graph while collecting the prefix-validation plan,
+  keeping trivial leaves inline in parent payloads and reusing parsed slices on the owned compile path;
+  `Evaluate()` executes compiled refs by opcode and reuses shared eval helpers for semantics;
+  AST/streamability access reparses from `Expression.source` on demand
+- Files: `xpath3.go` (API), `parser.go`, `lexer.go`, `expr.go`, `token.go`, `consts.go`, `eval.go`,
+  `eval_path.go`, `eval_operators.go`, `eval_arithmetic.go`, `eval_control.go`, `eval_types.go`,
+  `eval_funcall.go`, `eval_reuse.go`, `evaluator.go`, `vm.go`, `vm_dump.go`, `compile_direct.go`,
+  `compare.go`, `cast.go`, `cast_numeric.go`, `cast_string.go`, `cast_datetime.go`, `types.go`,
+  `float_value.go`, `sequence.go`, `context.go`, `variables.go`, `collation.go`, `regex.go`, `regex_cache.go`,
+  `static_check.go`, `streamability.go`, `node_identity.go`, `uri_resolution.go`, `doc.go`, `errors.go`,
+  `arithmetic_datetime.go`, `parse_ietf_date.go`, `format_datetime.go`, `format_integer.go`,
+  `format_number.go`, `function_library.go`, `function_signatures.go`, `functions.go` (registry +
+  boolean/not/true/false + fn:error/fn:trace), `functions_node.go`, `functions_string.go`,
+  `functions_numeric.go`, `functions_aggregate.go`, `functions_sequence.go`, `functions_datetime.go`,
+  `functions_uri.go`, `functions_qname.go`, `functions_hof.go`, `functions_map.go`, `functions_array.go`,
+  `functions_math.go`, `functions_misc.go`, `functions_json.go`, `functions_json_xml.go`,
+  `functions_serialize.go`, `functions_constructors.go` (XSD typed constructors, incl. xs:error),
+  `functions_unparsed_text.go`
 - Imports: helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence
 
 ## xslt3/
@@ -140,28 +562,204 @@ XSLT 3.0 stylesheet compilation + transformation on helium DOM with `xpath3` eva
 
 - **CompileStylesheet(ctx, *Document) → (*Stylesheet, error)** — convenience compile wrapper
 - **NewCompiler() → Compiler** — builder for stylesheet compilation
-- **Compiler.BaseURI(string) → Compiler** / **Compiler.URIResolver(URIResolver) → Compiler** / **Compiler.PackageResolver(PackageResolver) → Compiler** — compile-time resource/package resolution. Secure by default: `Compiler.URIResolver` is the opt-in for ALL compile-time stylesheet loading — `xsl:import`, `xsl:include`, output-format parameter documents (`xsl:output @parameter-document`), compile-time `fn:transform` `stylesheet-location` (e.g. static-variable evaluation), and compile-time `doc()`/`doc-available()` inside `use-when` (resolved against the module's effective static base, i.e. the module URI with its root `xml:base` folded in — including for an external `xsl:import`/`xsl:include` module's root `use-when`). With no `URIResolver` configured there is no implicit `os.ReadFile`; each of those loads errors out (`xsl:import`/`xsl:include` → "no URIResolver configured"; parameter docs → XTSE0090; `fn:transform` → FOXT0003; use-when `doc-available()` → false). Runtime `fn:transform stylesheet-location` likewise requires the compile-time `URIResolver` carried on the stylesheet.
-- **Compiler.StaticParameters(*Parameters) → Compiler** / **Compiler.SetStaticParameter(string, Sequence) → Compiler** / **Compiler.ClearStaticParameters() → Compiler** / **Compiler.ImportSchemas(...*xsd.Schema) → Compiler** — compile-time static params + schema imports
+- **Compiler.BaseURI(string) → Compiler** / **Compiler.URIResolver(URIResolver) → Compiler** /
+  **Compiler.PackageResolver(PackageResolver) → Compiler** — compile-time resource/package resolution. Secure
+  by default: `Compiler.URIResolver` is the opt-in for ALL compile-time stylesheet loading — `xsl:import`,
+  `xsl:include`, output-format parameter documents (`xsl:output @parameter-document`), compile-time
+  `fn:transform` `stylesheet-location` (e.g. static-variable evaluation), and compile-time
+  `doc()`/`doc-available()` inside `use-when` (resolved against the module's effective static base, i.e. the
+  module URI with its root `xml:base` folded in — including for an external `xsl:import`/`xsl:include`
+  module's root `use-when`). With no `URIResolver` configured there is no implicit `os.ReadFile`; each of
+  those loads errors out (`xsl:import`/`xsl:include` → "no URIResolver configured"; parameter docs → XTSE0090;
+  `fn:transform` → FOXT0003; use-when `doc-available()` → false). Runtime `fn:transform stylesheet-location`
+  likewise requires the compile-time `URIResolver` carried on the stylesheet.
+- **Compiler.StaticParameters(*Parameters) → Compiler** / **Compiler.SetStaticParameter(string, Sequence) →
+  Compiler** / **Compiler.ClearStaticParameters() → Compiler** / **Compiler.ImportSchemas(...*xsd.Schema) →
+  Compiler** — compile-time static params + schema imports
 - **Compiler.MaxResourceBytes(int64) → Compiler** — set the per-resource read cap inherited by invocations (0 = [MaxResourceBytes] default, negative = unbounded, positive = that cap)
-- **Compiler.Parser(helium.Parser) → Compiler** / **Invocation.Parser(helium.Parser) → Invocation** — the parser governing parse policy (limits, FS, XXE/network) for stylesheet, schema, and runtime source/`fn:doc` parsing; **forwarded** into the `xsd.Compiler`s and `xpath3.Evaluator`s the engine builds internally. xslt3 still forces its functional needs (entity substitution; `fn:doc` default-DTD-attributes/base-uri handling). Unset → the hardened default; `Invocation.Parser` overrides the compiler's for that run
-- **Compiler.AllowExternalEntities(bool) → Compiler** — XXE policy for compile-time parses of external stylesheet modules (`xsl:import`/`xsl:include`/`xsl:use-package`, and compile-time `fn:transform` stylesheets). **Default false (XXE BLOCKED): external DTDs / external general entities are NOT loaded or substituted** (parser is `BlockXXE(true).LoadExternalDTD(false).AllowNetwork(false)`). Set true to restore the legacy permissive behavior (resolver-mediated external entity loading via `LoadExternalDTD(true).SubstituteEntities(true)`, subject to `MaxResourceBytes`). The compiled value is carried on the `Stylesheet` and inherited by `fn:transform` nested compiles and (unless overridden) by runtime invocations. Serialization parameter documents and imported XSD schemas are always parsed XXE-blocked.
+- **Compiler.Parser(helium.Parser) → Compiler** / **Invocation.Parser(helium.Parser) → Invocation** — the
+  parser governing parse policy (limits, FS, XXE/network) for stylesheet, schema, and runtime source/`fn:doc`
+  parsing; **forwarded** into the `xsd.Compiler`s and `xpath3.Evaluator`s the engine builds internally. xslt3
+  still forces its functional needs (entity substitution; `fn:doc` default-DTD-attributes/base-uri handling).
+  Unset → the hardened default; `Invocation.Parser` overrides the compiler's for that run
+- **Compiler.AllowExternalEntities(bool) → Compiler** — XXE policy for compile-time parses of external
+  stylesheet modules (`xsl:import`/`xsl:include`/`xsl:use-package`, and compile-time `fn:transform`
+  stylesheets). **Default false (XXE BLOCKED): external DTDs / external general entities are NOT loaded or
+  substituted** (parser is `BlockXXE(true).LoadExternalDTD(false).AllowNetwork(false)`). Set true to restore
+  the legacy permissive behavior (resolver-mediated external entity loading via
+  `LoadExternalDTD(true).SubstituteEntities(true)`, subject to `MaxResourceBytes`). The compiled value is
+  carried on the `Stylesheet` and inherited by `fn:transform` nested compiles and (unless overridden) by
+  runtime invocations. Serialization parameter documents and imported XSD schemas are always parsed
+  XXE-blocked.
 - **Compiler.Compile(ctx, *Document) → (*Stylesheet, error)** / **Compiler.MustCompile(ctx, *Document) → *Stylesheet** — terminal compile methods
-- **Transform(ctx, *Document, *Stylesheet) → (*Document, error)** / **TransformToWriter(ctx, *Document, *Stylesheet, io.Writer) → error** / **TransformString(ctx, *Document, *Stylesheet) → (string, error)** — convenience wrappers; nil `*Stylesheet` returns error here
+- **Transform(ctx, *Document, *Stylesheet) → (*Document, error)** / **TransformToWriter(ctx, *Document,
+  *Stylesheet, io.Writer) → error** / **TransformString(ctx, *Document, *Stylesheet) → (string, error)** —
+  convenience wrappers; nil `*Stylesheet` returns error here
 - **Stylesheet.Transform(*Document) → Invocation** / **Stylesheet.ApplyTemplates(*Document) → Invocation** / **Stylesheet.CallTemplate(string) → Invocation** / **Stylesheet.CallFunction(string, ...Sequence) → Invocation** — invocation entrypoints
-- **Invocation.SourceDocument(*Document) → Invocation** / **Mode(string)** / **Selection(Sequence)** *(ApplyTemplates only)* / **GlobalParameters(*Parameters)** / **TunnelParameters(*Parameters)** / **SetParameter(string, Sequence)** / **SetTunnelParameter(string, Sequence)** / **SetInitialTemplateParameter(string, Sequence)** / **SetInitialModeParameter(string, Sequence)** / **MessageHandler(MessageHandler)** / **ResultDocumentHandler(ResultDocumentHandler)** / **RawResultHandler(RawResultHandler)** / **PrimaryItemsHandler(PrimaryItemsHandler)** / **AnnotationHandler(AnnotationHandler)** / **CollectionResolver(xpath3.CollectionResolver)** / **URIResolver(xpath3.URIResolver)** / **HTTPClient(\*http.Client)** / **BaseOutputURI(string)** / **SourceSchemas(...*xsd.Schema)** / **OnMultipleMatch(OnMultipleMatchMode)** / **TraceWriter(io.Writer)** / **GlobalContextSelect(string)** / **MaxResourceBytes(int64)** / **AllowExternalEntities(bool)** — fluent runtime configuration. `GlobalContextSelect` sets an XPath expression (evaluated against the source document after whitespace stripping) that determines the global context item; if it evaluates to an empty sequence the global context item is absent and global variables referencing `.` raise XPDY0002. `AllowExternalEntities` sets the XXE policy for runtime parses of external documents (`fn:doc`/`document()`, `xsl:source-document`, `xsl:merge`, and `fn:transform` stylesheet sources). **Default false (XXE BLOCKED): external DTDs / external general entities are NOT loaded or substituted**; when left unset it inherits the value compiled into the stylesheet (`Compiler.AllowExternalEntities`); set true to restore the legacy permissive behavior for trusted documents. `MaxResourceBytes` caps bytes read from a single runtime external resource: 0 inherits the Compiler/stylesheet cap (then the [MaxResourceBytes] default), negative disables the bound, positive sets that cap. The cap applies to all runtime reads, but the over-cap error differs by layer: XSLT's own loader (`fn:doc`/`document()`, `xsl:source-document`, `xsl:merge`, runtime `xsl:result-document` parameter documents, `xsi:schemaLocation` source schemas, `fn:transform` stylesheet/package sources) fails with [ErrResourceTooLarge], whereas the XPath built-ins `fn:unparsed-text`/`fn:unparsed-text-lines` surface FOUT1170 (`fn:unparsed-text-available` returns false) and `fn:json-doc` surfaces FODC0002 — they honor the cap but do NOT carry the `ErrResourceTooLarge` sentinel. `URIResolver` and `HTTPClient` are the opt-in for runtime resource retrieval — `fn:doc`/`fn:unparsed-text`, plus `xsl:source-document`, `xsl:merge`, and `fn:stream-available`; without them those instructions error (`FODC0002`) or report unavailable per the default-deny model (no implicit `os.ReadFile`).
+- **Invocation.SourceDocument(*Document) → Invocation** / **Mode(string)** / **Selection(Sequence)**
+  *(ApplyTemplates only)* / **GlobalParameters(*Parameters)** / **TunnelParameters(*Parameters)** /
+  **SetParameter(string, Sequence)** / **SetTunnelParameter(string, Sequence)** /
+  **SetInitialTemplateParameter(string, Sequence)** / **SetInitialModeParameter(string, Sequence)** /
+  **MessageHandler(MessageHandler)** / **ResultDocumentHandler(ResultDocumentHandler)** /
+  **RawResultHandler(RawResultHandler)** / **PrimaryItemsHandler(PrimaryItemsHandler)** /
+  **AnnotationHandler(AnnotationHandler)** / **CollectionResolver(xpath3.CollectionResolver)** /
+  **URIResolver(xpath3.URIResolver)** / **HTTPClient(\*http.Client)** / **BaseOutputURI(string)** /
+  **SourceSchemas(...*xsd.Schema)** / **OnMultipleMatch(OnMultipleMatchMode)** / **TraceWriter(io.Writer)** /
+  **GlobalContextSelect(string)** / **MaxResourceBytes(int64)** / **AllowExternalEntities(bool)** — fluent
+  runtime configuration. `GlobalContextSelect` sets an XPath expression (evaluated against the source document
+  after whitespace stripping) that determines the global context item; if it evaluates to an empty sequence
+  the global context item is absent and global variables referencing `.` raise XPDY0002.
+  `AllowExternalEntities` sets the XXE policy for runtime parses of external documents (`fn:doc`/`document()`,
+  `xsl:source-document`, `xsl:merge`, and `fn:transform` stylesheet sources). **Default false (XXE BLOCKED):
+  external DTDs / external general entities are NOT loaded or substituted**; when left unset it inherits the
+  value compiled into the stylesheet (`Compiler.AllowExternalEntities`); set true to restore the legacy
+  permissive behavior for trusted documents. `MaxResourceBytes` caps bytes read from a single runtime external
+  resource: 0 inherits the Compiler/stylesheet cap (then the [MaxResourceBytes] default), negative disables
+  the bound, positive sets that cap. The cap applies to all runtime reads, but the over-cap error differs by
+  layer: XSLT's own loader (`fn:doc`/`document()`, `xsl:source-document`, `xsl:merge`, runtime
+  `xsl:result-document` parameter documents, `xsi:schemaLocation` source schemas, `fn:transform`
+  stylesheet/package sources) fails with [ErrResourceTooLarge], whereas the XPath built-ins
+  `fn:unparsed-text`/`fn:unparsed-text-lines` surface FOUT1170 (`fn:unparsed-text-available` returns false)
+  and `fn:json-doc` surfaces FODC0002 — they honor the cap but do NOT carry the `ErrResourceTooLarge`
+  sentinel. `URIResolver` and `HTTPClient` are the opt-in for runtime resource retrieval —
+  `fn:doc`/`fn:unparsed-text`, plus `xsl:source-document`, `xsl:merge`, and `fn:stream-available`; without
+  them those instructions error (`FODC0002`) or report unavailable per the default-deny model (no implicit
+  `os.ReadFile`).
 - **Invocation.Do(ctx) → (*Document, error)** / **Invocation.Serialize(ctx) → (string, error)** / **Invocation.WriteTo(ctx, io.Writer) → error** / **Invocation.ResolvedOutputDef() → *OutputDef** — terminal execution + resolved primary output metadata
 - **NewParameters() → *Parameters** — mutable XSLT parameter carrier keyed by expanded name
-- **TransformFunction(...TransformOption) → xpath3.Function** — standalone `fn:transform()` for registering on a bare `xpath3.Evaluator` (`Evaluator.Functions(nil, {fn:transform: ...})`), for callers driving xpath3 directly with no outer running stylesheet (e.g. the QT3 harness). Shares its implementation with the in-stylesheet `fn:transform` (`ec.fnTransform` is a thin wrapper over the same `transformFnConfig.run`). Deps the in-stylesheet path inherits from its execution context are supplied explicitly via `TransformOption`: `WithTransformURIResolver(xpath3.URIResolver)` (stylesheet-location reads, nested-compile module loading, and inner `fn:doc`), `WithTransformPackageResolver`, `WithTransformHTTPClient`, `WithTransformBaseURI`, `WithTransformMaxResourceBytes`, `WithTransformAllowExternalEntities`, `WithTransformParser`, `WithTransformImportSchemas`. Handles the `stylesheet-location`, `stylesheet-node`, `stylesheet-text` (inline source), and `package-name` stylesheet-source options. A `stylesheet-node` that is an element node which is not its owner document's document element (a simplified/literal-result stylesheet supplied as a fragment child, or an element nested in a larger tree) is compiled from that element as the stylesheet root: `stylesheetNodeCompileDocument` deep-copies the element into a fresh document so the element itself is the document element. The whole owning document is not compiled, since its document element would be a different node. The `stylesheet-base-uri` map option sets the base URI for resolving relative `xsl:include`/`xsl:import` inside a `stylesheet-text`/`stylesheet-node` (a relative value is itself resolved against the call's static base URI, `WithTransformBaseURI`); it overrides `WithTransformBaseURI` for `stylesheet-text` and the node's own document base URI (`NodeGetBase`) for `stylesheet-node`. Absent the option, `stylesheet-text` falls back to `WithTransformBaseURI` and `stylesheet-node` to the node's document base URI, so a relative include with no usable base fails (XTSE0165). `initial-template` is resolved preserving its namespace (a QName value becomes Clark `{uri}local`), so a namespaced named template resolves. `run` validates the option map before doing work (`validateTransformOptions`, F&O 3.1 §14.8.3): exactly one of `stylesheet-location`/`stylesheet-node`/`stylesheet-text`/`package-name`, at most one of `initial-template`/`initial-mode`/`initial-function`, `source-node` and `initial-match-selection` mutually exclusive, `delivery-format` ∈ {document, serialized, raw}, `xslt-version` numeric, and each param map (`stylesheet-params`/`static-params`/`template-params`/`tunnel-params`) a map keyed by xs:QName — a structural/enum/exclusivity violation is FOXT0002, a mistyped option value is XPTY0004. `requested-properties` is checked against helium's advertised capabilities (`transformCapabilities`): `is-schema-aware`, `supports-serialization`, `supports-backwards-compatibility`, `supports-namespace-axis`, `supports-dynamic-evaluation`, `supports-higher-order-functions` are true and `supports-streaming` is false (DOM-materialization, not streaming); a recognized XSLT-namespace property requested with an unsatisfiable value raises FOXT0006. When `delivery-format` is `serialized`, the `serialization-params` map overrides the principal result's `OutputDef` (`applySerializationParams`: method, indent, omit-xml-declaration, byte-order-mark, undeclare-prefixes, encoding, version, standalone, media-type, doctype-public/system, item-separator). The QName-valued `cdata-section-elements` and `suppress-indentation` params (sequences of xs:QName, whose {uri}local Clark names are extracted via `mergeSerializationQNames`) and the map-valued `use-character-maps` param (a `map(xs:string, xs:string)` merged via `applyUseCharacterMapsParam`) accumulate onto the stylesheet's own `xsl:output` values: the two element-name sets are unioned, and character-map entries are merged with the serialization-params value winning per character. A recognized param present with an empty-sequence value resets it to the serialization default (`resetSerializationParam`). Two bases are kept SEPARATE (F&O 3.1 §14.8). (1) The PRINCIPAL result-map key: a relative `base-output-uri` is resolved ONCE against the fn:transform call's static base URI (`cfg.baseURI` — `ec.effectiveStaticBaseURI()` in-stylesheet, i.e. the call-site base honoring an `xml:base` on the calling template/element, not the bare module URI; or `WithTransformBaseURI` standalone) via `canonicalResultURIKey`; the result map keys the principal by that resolved value when supplied, else by the literal `"output"`. (2) The base for RESOLVING secondary result-document output URIs (`cfg.outputBaseURI`, seeded into `ec.currentOutputURI`): the resolved `base-output-uri` when supplied, else the call's effective static base URI — so secondary result-map keys are absolute whenever ANY base exists, even when `base-output-uri` is omitted. Only when there is genuinely no base at all (no `base-output-uri` AND no static base — e.g. a standalone call with no `WithTransformBaseURI`) does a secondary key remain best-effort relative; the spec cannot require an absolute URI when no base is available. When `base-output-uri` is absent the principal output has no declared URI (no `canonicalPrimaryURI` XTDE1490 reservation). the principal entry is emitted only when the transformation actually wrote principal content, so a stylesheet producing only secondary `xsl:result-document`s has no principal entry (W3C bug 30209, `documentHasChildren`). Each secondary result document is keyed by its fully-resolved absolute output URI. Internally the `ec.resultDocuments`/`resultDocItems`/`resultDocOutputDefs` stores, the XTDE1490 duplicate-detection set (`usedResultURIs`), and `Document.URL` all key on the SAME resolved canonical URI (`dupKey == ec.currentOutputURI`), so a nested `xsl:result-document` resolves against its enclosing document's dynamic output URI (not the top-level base) and two nested documents writing the same relative href under different enclosing URIs never overwrite one another; the `resultDocCollector` reads `Document.URL` to key the result map, so those distinct absolute URIs both survive. The raw href as written is preserved separately (`ec.resultDocHrefs`) solely for the public `ResultDocumentHandler`, which receives it unchanged. `serialized` delivery returns `SerializeResult` output unchanged; direct XML serialization omits helium.Writer's per-document-child terminators and preserves top-level text newlines as result content unless serializer indentation intentionally discards whitespace-only text when indentation is enabled and the result has an element child, while stream paths leave every final byte untouched. A `source-node` that is not a document node is itself the initial match selection (the template matches that element), while the source tree's document root supplies the default global context item. The `global-context-item` option (required type `item()`) determines the context item seen by global variables/parameters independently of the initial match selection: a present-but-empty or multi-item value is `XPTY0004` (`validateTransformGlobalContextItem`); an explicit item (node or atomic/map/array/function) overrides the source-node default and is what gets type-checked against `xsl:global-context-item/@as` (`XTTE0590`) — a non-node item is exposed via `ec.contextItem` scoped to global evaluation only and never leaks into template execution. When the stylesheet declares `xsl:global-context-item use="absent"` the global context item is absent regardless of any supplied option (a global `.` raises `XPDY0002`) — this affects ONLY the global context item (`ec.globalContextAbsent`), NOT the source-node/initial match selection, so a supplied source-node still drives apply-templates normally (no spurious `XTDE0040`); when neither a source-node/initial-match-selection nor an explicit item is supplied the global context item is likewise absent (`cfg.globalContextAbsent` → `XPDY0002` on `.`, and `XTDE3086` if `use="required"`), even though a synthetic empty document is still substituted as the navigable source tree for an initial-template/-function entry. A `post-process` function item (`function(xs:string, item()*) as item()*`) is invoked once per delivered result — the principal `output` entry and each secondary result — with `(result-URI, result-value)` (the principal gets `base-output-uri`, each secondary its href key); its return value replaces the entry's value in the result map, across all three delivery formats (document node, serialized string, raw items).
+- **TransformFunction(...TransformOption) → xpath3.Function** — standalone `fn:transform()` for registering on
+  a bare `xpath3.Evaluator` (`Evaluator.Functions(nil, {fn:transform: ...})`), for callers driving xpath3
+  directly with no outer running stylesheet (e.g. the QT3 harness). Shares its implementation with the
+  in-stylesheet `fn:transform` (`ec.fnTransform` is a thin wrapper over the same `transformFnConfig.run`).
+  Deps the in-stylesheet path inherits from its execution context are supplied explicitly via
+  `TransformOption`: `WithTransformURIResolver(xpath3.URIResolver)` (stylesheet-location reads, nested-compile
+  module loading, and inner `fn:doc`), `WithTransformPackageResolver`, `WithTransformHTTPClient`,
+  `WithTransformBaseURI`, `WithTransformMaxResourceBytes`, `WithTransformAllowExternalEntities`,
+  `WithTransformParser`, `WithTransformImportSchemas`. Handles the `stylesheet-location`, `stylesheet-node`,
+  `stylesheet-text` (inline source), and `package-name` stylesheet-source options. A `stylesheet-node` that is
+  an element node which is not its owner document's document element (a simplified/literal-result stylesheet
+  supplied as a fragment child, or an element nested in a larger tree) is compiled from that element as the
+  stylesheet root: `stylesheetNodeCompileDocument` deep-copies the element into a fresh document so the
+  element itself is the document element. The whole owning document is not compiled, since its document
+  element would be a different node. The `stylesheet-base-uri` map option sets the base URI for resolving
+  relative `xsl:include`/`xsl:import` inside a `stylesheet-text`/`stylesheet-node` (a relative value is itself
+  resolved against the call's static base URI, `WithTransformBaseURI`); it overrides `WithTransformBaseURI`
+  for `stylesheet-text` and the node's own document base URI (`NodeGetBase`) for `stylesheet-node`. Absent the
+  option, `stylesheet-text` falls back to `WithTransformBaseURI` and `stylesheet-node` to the node's document
+  base URI, so a relative include with no usable base fails (XTSE0165). `initial-template` is resolved
+  preserving its namespace (a QName value becomes Clark `{uri}local`), so a namespaced named template
+  resolves. `run` validates the option map before doing work (`validateTransformOptions`, F&O 3.1 §14.8.3):
+  exactly one of `stylesheet-location`/`stylesheet-node`/`stylesheet-text`/`package-name`, at most one of
+  `initial-template`/`initial-mode`/`initial-function`, `source-node` and `initial-match-selection` mutually
+  exclusive, `delivery-format` ∈ {document, serialized, raw}, `xslt-version` numeric, and each param map
+  (`stylesheet-params`/`static-params`/`template-params`/`tunnel-params`) a map keyed by xs:QName — a
+  structural/enum/exclusivity violation is FOXT0002, a mistyped option value is XPTY0004.
+  `requested-properties` is checked against helium's advertised capabilities (`transformCapabilities`):
+  `is-schema-aware`, `supports-serialization`, `supports-backwards-compatibility`, `supports-namespace-axis`,
+  `supports-dynamic-evaluation`, `supports-higher-order-functions` are true and `supports-streaming` is false
+  (DOM-materialization, not streaming); a recognized XSLT-namespace property requested with an unsatisfiable
+  value raises FOXT0006. When `delivery-format` is `serialized`, the `serialization-params` map overrides the
+  principal result's `OutputDef` (`applySerializationParams`: method, indent, omit-xml-declaration,
+  byte-order-mark, undeclare-prefixes, encoding, version, standalone, media-type, doctype-public/system,
+  item-separator). The QName-valued `cdata-section-elements` and `suppress-indentation` params (sequences of
+  xs:QName, whose {uri}local Clark names are extracted via `mergeSerializationQNames`) and the map-valued
+  `use-character-maps` param (a `map(xs:string, xs:string)` merged via `applyUseCharacterMapsParam`)
+  accumulate onto the stylesheet's own `xsl:output` values: the two element-name sets are unioned, and
+  character-map entries are merged with the serialization-params value winning per character. A recognized
+  param present with an empty-sequence value resets it to the serialization default
+  (`resetSerializationParam`). Two bases are kept SEPARATE (F&O 3.1 §14.8). (1) The PRINCIPAL result-map key:
+  a relative `base-output-uri` is resolved ONCE against the fn:transform call's static base URI (`cfg.baseURI`
+  — `ec.effectiveStaticBaseURI()` in-stylesheet, i.e. the call-site base honoring an `xml:base` on the calling
+  template/element, not the bare module URI; or `WithTransformBaseURI` standalone) via
+  `canonicalResultURIKey`; the result map keys the principal by that resolved value when supplied, else by the
+  literal `"output"`. (2) The base for RESOLVING secondary result-document output URIs (`cfg.outputBaseURI`,
+  seeded into `ec.currentOutputURI`): the resolved `base-output-uri` when supplied, else the call's effective
+  static base URI — so secondary result-map keys are absolute whenever ANY base exists, even when
+  `base-output-uri` is omitted. Only when there is genuinely no base at all (no `base-output-uri` AND no
+  static base — e.g. a standalone call with no `WithTransformBaseURI`) does a secondary key remain best-effort
+  relative; the spec cannot require an absolute URI when no base is available. When `base-output-uri` is
+  absent the principal output has no declared URI (no `canonicalPrimaryURI` XTDE1490 reservation). the
+  principal entry is emitted only when the transformation actually wrote principal content, so a stylesheet
+  producing only secondary `xsl:result-document`s has no principal entry (W3C bug 30209,
+  `documentHasChildren`). Each secondary result document is keyed by its fully-resolved absolute output URI.
+  Internally the `ec.resultDocuments`/`resultDocItems`/`resultDocOutputDefs` stores, the XTDE1490
+  duplicate-detection set (`usedResultURIs`), and `Document.URL` all key on the SAME resolved canonical URI
+  (`dupKey == ec.currentOutputURI`), so a nested `xsl:result-document` resolves against its enclosing
+  document's dynamic output URI (not the top-level base) and two nested documents writing the same relative
+  href under different enclosing URIs never overwrite one another; the `resultDocCollector` reads
+  `Document.URL` to key the result map, so those distinct absolute URIs both survive. The raw href as written
+  is preserved separately (`ec.resultDocHrefs`) solely for the public `ResultDocumentHandler`, which receives
+  it unchanged. `serialized` delivery returns `SerializeResult` output unchanged; direct XML serialization
+  omits helium.Writer's per-document-child terminators and preserves top-level text newlines as result content
+  unless serializer indentation intentionally discards whitespace-only text when indentation is enabled and
+  the result has an element child, while stream paths leave every final byte untouched. A `source-node` that
+  is not a document node is itself the initial match selection (the template matches that element), while the
+  source tree's document root supplies the default global context item. The `global-context-item` option
+  (required type `item()`) determines the context item seen by global variables/parameters independently of
+  the initial match selection: a present-but-empty or multi-item value is `XPTY0004`
+  (`validateTransformGlobalContextItem`); an explicit item (node or atomic/map/array/function) overrides the
+  source-node default and is what gets type-checked against `xsl:global-context-item/@as` (`XTTE0590`) — a
+  non-node item is exposed via `ec.contextItem` scoped to global evaluation only and never leaks into template
+  execution. When the stylesheet declares `xsl:global-context-item use="absent"` the global context item is
+  absent regardless of any supplied option (a global `.` raises `XPDY0002`) — this affects ONLY the global
+  context item (`ec.globalContextAbsent`), NOT the source-node/initial match selection, so a supplied
+  source-node still drives apply-templates normally (no spurious `XTDE0040`); when neither a
+  source-node/initial-match-selection nor an explicit item is supplied the global context item is likewise
+  absent (`cfg.globalContextAbsent` → `XPDY0002` on `.`, and `XTDE3086` if `use="required"`), even though a
+  synthetic empty document is still substituted as the navigable source tree for an initial-template/-function
+  entry. A `post-process` function item (`function(xs:string, item()*) as item()*`) is invoked once per
+  delivered result — the principal `output` entry and each secondary result — with `(result-URI,
+  result-value)` (the principal gets `base-output-uri`, each secondary its href key); its return value
+  replaces the entry's value in the result map, across all three delivery formats (document node, serialized
+  string, raw items).
 - `fn:transform` serialized delivery serializes every emitted principal and secondary result. Any result serialization failure raises `FOXT0003`.
 - Key types: `Stylesheet`, `Compiler`, `Invocation`, `Parameters`, `OutputDef`, `URIResolver`, `PackageResolver`, `MessageHandler`, `ResultDocumentHandler`, `RawResultHandler`, `PrimaryItemsHandler`, `AnnotationHandler`, `TransformOption`
-- Resource limits: `MaxResourceBytes` (const, 10 MiB default per-resource read cap) + `ErrResourceTooLarge` (error returned when an external resource exceeds the cap); enforced against actual bytes read, configurable per Compiler/Invocation. The same cap doubles as the xsl:analyze-string match-count ceiling: matches are streamed one at a time (via `xpath3.Regex.EachSubmatchIndex`) and the running count is checked during enumeration, so an empty-matching regex over a large input is rejected with `ErrResourceTooLarge` without allocating memory proportional to the match count
-- Supports: `xsl:template`, `xsl:apply-templates`, `xsl:call-template`, `xsl:param`/`xsl:variable`, `xsl:include`/`xsl:import`, `xsl:sort`, `xsl:number`, `xsl:message`, `xsl:key`, `xsl:output`, `xsl:import-schema`, `xsl:function`, literal result elements, AVTs, `xsl:attribute-set`, `xsl:map`/`xsl:map-entry`, `xsl:source-document`, `xsl:iterate`, `xsl:fork`, `xsl:accumulator`, `xsl:merge`, `xsl:where-populated`, `xsl:try`/`xsl:catch`, `xsl:for-each-group`, `xsl:result-document`, `xsl:next-match`, `xsl:apply-imports`
-- Schema awareness: `xsl:import-schema` compiles XSD schemas, `type=` on `xsl:element`/`xsl:attribute` annotates result nodes, `validation=` on `xsl:copy`/`xsl:copy-of`, `default-validation` stylesheet attribute, `type-available()` function, runtime source validation via `Invocation.SourceSchemas(...)`, annotation callbacks via `AnnotationHandler`
-- Streaming: `xsl:source-document` (DOM-materialization), `xsl:iterate`/`xsl:break`/`xsl:next-iteration`/`xsl:on-completion`, `xsl:fork`, `xsl:accumulator`/`xsl:accumulator-rule`, `xsl:merge`/`xsl:merge-source`/`xsl:merge-key`/`xsl:merge-action`; streamability analysis (XTSE3430) post-compilation pass
-- Runtime helpers: `current()`, `document()`, `key()`, `generate-id()`, `system-property()`, `unparsed-entity-uri()`, `unparsed-entity-public-id()`, `type-available()`, `snapshot()`, `copy-of()`, `accumulator-before()`/`accumulator-after()`, `current-merge-group()`/`current-merge-key()`, `transform()`
+- Resource limits: `MaxResourceBytes` (const, 10 MiB default per-resource read cap) + `ErrResourceTooLarge`
+  (error returned when an external resource exceeds the cap); enforced against actual bytes read, configurable
+  per Compiler/Invocation. The same cap doubles as the xsl:analyze-string match-count ceiling: matches are
+  streamed one at a time (via `xpath3.Regex.EachSubmatchIndex`) and the running count is checked during
+  enumeration, so an empty-matching regex over a large input is rejected with `ErrResourceTooLarge` without
+  allocating memory proportional to the match count
+- Supports: `xsl:template`, `xsl:apply-templates`, `xsl:call-template`, `xsl:param`/`xsl:variable`,
+  `xsl:include`/`xsl:import`, `xsl:sort`, `xsl:number`, `xsl:message`, `xsl:key`, `xsl:output`,
+  `xsl:import-schema`, `xsl:function`, literal result elements, AVTs, `xsl:attribute-set`,
+  `xsl:map`/`xsl:map-entry`, `xsl:source-document`, `xsl:iterate`, `xsl:fork`, `xsl:accumulator`, `xsl:merge`,
+  `xsl:where-populated`, `xsl:try`/`xsl:catch`, `xsl:for-each-group`, `xsl:result-document`, `xsl:next-match`,
+  `xsl:apply-imports`
+- Schema awareness: `xsl:import-schema` compiles XSD schemas, `type=` on `xsl:element`/`xsl:attribute`
+  annotates result nodes, `validation=` on `xsl:copy`/`xsl:copy-of`, `default-validation` stylesheet
+  attribute, `type-available()` function, runtime source validation via `Invocation.SourceSchemas(...)`,
+  annotation callbacks via `AnnotationHandler`
+- Streaming: `xsl:source-document` (DOM-materialization),
+  `xsl:iterate`/`xsl:break`/`xsl:next-iteration`/`xsl:on-completion`, `xsl:fork`,
+  `xsl:accumulator`/`xsl:accumulator-rule`, `xsl:merge`/`xsl:merge-source`/`xsl:merge-key`/`xsl:merge-action`;
+  streamability analysis (XTSE3430) post-compilation pass
+- Runtime helpers: `current()`, `document()`, `key()`, `generate-id()`, `system-property()`,
+  `unparsed-entity-uri()`, `unparsed-entity-public-id()`, `type-available()`, `snapshot()`, `copy-of()`,
+  `accumulator-before()`/`accumulator-after()`, `current-merge-group()`/`current-merge-key()`, `transform()`
 - Output methods: `xml`, `html`, `xhtml`, `text`, `json`, `adaptive`
-- Adaptive serialization delegates a singleton element/document item to the XML method. Every XSLT path that delegates a document node to `helium.Writer` uses exact-document mode, so writer-added child terminators never enter serialized output. Comment and processing-instruction items, including top-level primary and secondary `xsl:comment` and `xsl:processing-instruction` output, use the XML writer without a declaration, preserving markup and target-version character validation; character maps and normalization do not change their data. A top-level adaptive markup sequence keeps its item separators outside the DOM while it remains markup-only, so standalone serialization stays declaration-free and applies character maps and normalization to separator character data. If a later non-markup item requires XML fallback, every deferred separator is restored at its original boundary. A quoted string-like atomic delegates character-data processing to the Text method before adaptive quoting, including normalization and character maps.
-- Files: `xslt3.go` (package doc + convenience wrappers), `doc.go`, `compile.go` (compiler builder + orchestration), `compile_*.go` (imports/packages/schema/templates/functions/modes/formats/patterns/streaming/instruction compilation), `execute*.go` (runtime), `functions*.go` (built-ins + `fn:transform` bridge), `stylesheet.go`, `invocation.go`, `instruction.go`, `parameters.go`, `options.go`, `dispatch_index.go` (per-mode template dispatch index: buckets templates by node kind/expanded name so `findFirstMatch`/`hasConflictingMatch` skip templates their pattern's terminal step provably cannot match), `output*.go` (`output.go`, `output_xml.go`, `output_html.go`, `output_json.go`, `output_adaptive.go`, `output_charmap.go`), `sort.go`, `types.go`, `avt.go`, `keys.go`, `qname_resolve.go`, `number_words.go`, `source_schema.go`, `schema_constructors.go`, `schema_context.go`, `schema_resolver_fs.go`, `package_*.go`, `streamability*.go`, `errors.go`, `resource_limit.go` (per-resource read cap + `MaxResourceBytes`/`ErrResourceTooLarge`); the XSLT element registry lives in `xslt3/internal/elements` (`elements.go`, `data.go`, see below)
+- Adaptive serialization delegates a singleton element/document item to the XML method. Every XSLT path that
+  delegates a document node to `helium.Writer` uses exact-document mode, so writer-added child terminators
+  never enter serialized output. Comment and processing-instruction items, including top-level primary and
+  secondary `xsl:comment` and `xsl:processing-instruction` output, use the XML writer without a declaration,
+  preserving markup and target-version character validation; character maps and normalization do not change
+  their data. A top-level adaptive markup sequence keeps its item separators outside the DOM while it remains
+  markup-only, so standalone serialization stays declaration-free and applies character maps and normalization
+  to separator character data. If a later non-markup item requires XML fallback, every deferred separator is
+  restored at its original boundary. A quoted string-like atomic delegates character-data processing to the
+  Text method before adaptive quoting, including normalization and character maps.
+- Files: `xslt3.go` (package doc + convenience wrappers), `doc.go`, `compile.go` (compiler builder +
+  orchestration), `compile_*.go`
+  (imports/packages/schema/templates/functions/modes/formats/patterns/streaming/instruction compilation),
+  `execute*.go` (runtime), `functions*.go` (built-ins + `fn:transform` bridge), `stylesheet.go`,
+  `invocation.go`, `instruction.go`, `parameters.go`, `options.go`, `dispatch_index.go` (per-mode template
+  dispatch index: buckets templates by node kind/expanded name so `findFirstMatch`/`hasConflictingMatch` skip
+  templates their pattern's terminal step provably cannot match), `output*.go` (`output.go`, `output_xml.go`,
+  `output_html.go`, `output_json.go`, `output_adaptive.go`, `output_charmap.go`), `sort.go`, `types.go`,
+  `avt.go`, `keys.go`, `qname_resolve.go`, `number_words.go`, `source_schema.go`, `schema_constructors.go`,
+  `schema_context.go`, `schema_resolver_fs.go`, `package_*.go`, `streamability*.go`, `errors.go`,
+  `resource_limit.go` (per-resource read cap + `MaxResourceBytes`/`ErrResourceTooLarge`); the XSLT element
+  registry lives in `xslt3/internal/elements` (`elements.go`, `data.go`, see below)
 - Imports: helium, xpath3, xsd, html, internal/lexicon, internal/nodelink, internal/sequence, internal/writerctl, xslt3/internal/elements
 - Tests: hand-written unit tests only. The W3C XSLT 3.0 conformance suite lives in the sibling `helium-w3c-tests` module (fetches upstream, depends on this module via a replace directive)
 
@@ -184,28 +782,96 @@ XSLT element registry: metadata for all ~80 recognized XSLT 3.0 elements.
 
 ## xsd/
 
-XML Schema (XSD) compilation and validation. Defaults to XSD 1.0; XSD 1.1 is opt-in via `Compiler.Version(xsd.Version11)` (or a `vc:minVersion="1.1"` hint on the schema root). See the "XSD — Version Toggle" section in CLAUDE.md for what is implemented in 1.1.
+XML Schema (XSD) compilation and validation. Defaults to XSD 1.0; XSD 1.1 is opt-in via
+`Compiler.Version(xsd.Version11)` (or a `vc:minVersion="1.1"` hint on the schema root). See the "XSD — Version
+Toggle" section in CLAUDE.md for what is implemented in 1.1.
 
 - **NewCompiler() → Compiler** — create fluent builder for schema compilation
   - `Label(name)`, `BaseDir(dir)`, `FS(fs.FS)`, `ErrorHandler(h)`, `Version(Version)` — builder methods (clone-on-write). `Version(Version10|Version11)` selects the XSD spec version (default `Version10`)
-  - `Compiler.Parser(helium.Parser)` — sets the parser used to parse the schema document and all nested `xs:include`/`xs:import`/`xs:redefine` targets; supplies parse policy (limits, FS, XXE/network). Distinct from `FS`, which *fetches* schema bytes; the injected parser governs *parse policy* of those bytes. Unset → default schema parser (`helium.NewParser().SubstituteEntities(true)`) so entity references in schema attribute values are expanded; an explicit parser is used exactly as supplied.
-  - `Compiler.FS(fs.FS)` — sets the `fs.FS` used to load schemas referenced by `xs:include`, `xs:import`, and `xs:redefine`. **Secure by default** (mirrors `helium.NewParser`): the default (and what a nil value restores) is a deny-all FS (`internal/iofs.DenyAll`, opens nothing), so an untrusted schema cannot disclose local files or exhaust resources via a hostile `schemaLocation`. Opt into host access with `helium.PermissiveFS()` (any `os.Open` path) or a confined FS. Each nested schema is read through a fixed `maxNestedSchemaSize` byte cap (10 MiB) regardless of FS, so an endless source (e.g. `schemaLocation` → `/dev/zero`) cannot exhaust memory; an over-cap read is fatal (`errSchemaTooLarge`, see `IsFatalSchemaLoad`). Schema-location resolution is URI-aware: when `BaseDir` is a URI (e.g. `https://…` or `file:///…`) a relative include is resolved with RFC 3986 semantics and an absolute-URI include is passed through unchanged, so the name handed to the FS is the canonical nested-schema URI; when `BaseDir` is a local path, names use `filepath.Join` and may be absolute / OS-style (rejected by `fs.ValidPath` FSes like `os.DirFS`/`fstest.MapFS`)
+  - `Compiler.Parser(helium.Parser)` — sets the parser used to parse the schema document and all nested
+    `xs:include`/`xs:import`/`xs:redefine` targets; supplies parse policy (limits, FS, XXE/network). Distinct
+    from `FS`, which *fetches* schema bytes; the injected parser governs *parse policy* of those bytes. Unset
+    → default schema parser (`helium.NewParser().SubstituteEntities(true)`) so entity references in schema
+    attribute values are expanded; an explicit parser is used exactly as supplied.
+  - `Compiler.FS(fs.FS)` — sets the `fs.FS` used to load schemas referenced by `xs:include`, `xs:import`, and
+    `xs:redefine`. **Secure by default** (mirrors `helium.NewParser`): the default (and what a nil value
+    restores) is a deny-all FS (`internal/iofs.DenyAll`, opens nothing), so an untrusted schema cannot
+    disclose local files or exhaust resources via a hostile `schemaLocation`. Opt into host access with
+    `helium.PermissiveFS()` (any `os.Open` path) or a confined FS. Each nested schema is read through a fixed
+    `maxNestedSchemaSize` byte cap (10 MiB) regardless of FS, so an endless source (e.g. `schemaLocation` →
+    `/dev/zero`) cannot exhaust memory; an over-cap read is fatal (`errSchemaTooLarge`, see
+    `IsFatalSchemaLoad`). Schema-location resolution is URI-aware: when `BaseDir` is a URI (e.g. `https://…`
+    or `file:///…`) a relative include is resolved with RFC 3986 semantics and an absolute-URI include is
+    passed through unchanged, so the name handed to the FS is the canonical nested-schema URI; when `BaseDir`
+    is a local path, names use `filepath.Join` and may be absolute / OS-style (rejected by `fs.ValidPath` FSes
+    like `os.DirFS`/`fstest.MapFS`)
   - `Compile(ctx, *Document) → (*Schema, error)` / `CompileFile(ctx, path) → (*Schema, error)` — terminal methods; return `(nil, ErrCompilationFailed)` on fatal schema diagnostics
 - **NewValidator(schema) → Validator** — create fluent builder for validation
-  - `Label(name)`, `ErrorHandler(h)`, `Annotations(*TypeAnnotations)`, `NilledElements(*NilledElements)`, `IDNodes(*IDNodes)` — builder methods. `IDNodes` collects the PSVI is-id nodes (XDM 3.1): every attribute/element whose actual validated content is a single xs:ID-derived value — an atomic xs:ID, a SINGLETON list of xs:ID, or a union that SELECTS an xs:ID-derived member. A multi-item list or a non-ID union member is not is-id. Version-independent and runs regardless of `SkipDatatypeIntegrityChecks` (it observes a per-node property, it does not enforce document ID uniqueness). Feeds `xpath3.Evaluator.IDNodes` for `fn:id`/`fn:element-with-id`
+  - `Label(name)`, `ErrorHandler(h)`, `Annotations(*TypeAnnotations)`, `NilledElements(*NilledElements)`,
+    `IDNodes(*IDNodes)` — builder methods. `IDNodes` collects the PSVI is-id nodes (XDM 3.1): every
+    attribute/element whose actual validated content is a single xs:ID-derived value — an atomic xs:ID, a
+    SINGLETON list of xs:ID, or a union that SELECTS an xs:ID-derived member. A multi-item list or a non-ID
+    union member is not is-id. Version-independent and runs regardless of `SkipDatatypeIntegrityChecks` (it
+    observes a per-node property, it does not enforce document ID uniqueness). Feeds
+    `xpath3.Evaluator.IDNodes` for `fn:id`/`fn:element-with-id`
   - `Validate(ctx, *Document) → error` — terminal method
 - **(*TypeDef).Validate(ctx, value, nsMap) → error** — validate a lexical value against a simple type; nsMap (prefix→URI) may be nil
 - **(*TypeDef).ValidateElement(ctx, elem, schema) → error** — validate an element's content against a type
 - `Schema.LookupElement(local, ns)`, `Schema.LookupType(local, ns)`, `Schema.NamedTypes()`, `Schema.TargetNamespace()`
-- **Schema.Declarations() → xpath3.SchemaDeclarations** — an `xpath3.SchemaDeclarations` view over the compiled schema for schema-aware XPath (schema-element/attribute node tests, schema-aware cast/castable, instance-of/subtype tests, substitution-group membership, typed-value atomization of PSVI-annotated nodes). Pair with `xpath3.Evaluator.SchemaDeclarations(...)` and `TypeAnnotations(...)` (fed by `Validator.Annotations`). Borrows the schema read-only; safe to share across concurrent evaluations. Backed by the `schemaDecls` adapter in `schema_decls.go` — the same one used internally for xs:assert evaluation, and the single canonical implementation xslt3's multi-schema `schemaRegistry` (`xslt3/schema_context.go`) delegates its per-schema `SchemaDeclarations` lookups to. The one method xslt3 does NOT delegate is `IsSubtypeOf`: XSLT SequenceType matching treats a simpleContent COMPLEX type as a subtype of its simple content base (so it matches `element(*, T)`), whereas this adapter deliberately excludes a complex type from its simple ancestry (so `instance of element(*, xs:string)` is false for an xs:assert node)
-- **ResolveSchemaURI(ref, base) → (string, error)** / **URIScheme(s) → string** — the single canonical schema-location URI-resolution helper and scheme-detector, shared with `xslt3` so the two layers cannot drift (URI-aware: absolute-URI pass-through, RFC 3986 with `OmitHost` preservation for URI bases, `filepath.Join` + `..`-escape guard for local bases)
-- **FatalSchemaLoader** interface (`FatalSchemaLoad() bool`) — a `Compiler.FS` may return an `Open` error whose chain carries a value satisfying this interface to force an `xs:import` load failure to be FATAL instead of the usual warn-and-continue ("Skipping the import."). `xslt3`'s `schemaResolverFS` uses it so an over-cap nested-import read (`ErrResourceTooLarge`) is not silently skipped; the wrapped chain is preserved so callers can still `errors.Is`/`errors.As` the cause
-- **IsFatalSchemaLoad(err) → bool** — the SINGLE source of truth for "is this a fatal schema-load condition that must abort compilation, as opposed to warn-and-continue or falling back to a pre-compiled schema". Returns true (via `errors.Is`/`errors.As`) for a schema-location `..`-escape, an `xs:import` depth overflow, an `xs:include`/`xs:redefine` depth overflow (`errIncludeDepthExceeded` — otherwise an over-deep include chain inside an IMPORTED schema would be demoted to a warning and silently ignored by `loadImport`), an over-cap nested-schema read (`errSchemaTooLarge`), and any error satisfying `FatalSchemaLoader`. The two xsd import warn-or-continue sites and `xslt3`'s `xsl:import-schema` fallback guard both route through it (xslt3's `isFatalSchemaLoadError` delegates to it, adding the xslt3-package `ErrResourceTooLarge` sentinel), so the classification cannot drift between the layers. The path-escape / depth sentinels stay unexported; this helper is the public surface
-- Supports: complex/simple types, sequences, choices, all, groups, attribute groups, substitution groups, import/include/redefine/override, IDC (xs:unique/key/keyref), XSD 1.1 assertions/assertion facets, conditional type assignment, open content, schema default attributes, wildcard algebra, relaxed xs:all, and relaxed wildcard/UPA behavior
-- `ElementDecl.SubstitutionGroup` = first substitution-group head QName for compatibility; `ElementDecl.SubstitutionGroups` = all head QNames. XSD 1.1 `@substitutionGroup` may be XSD-whitespace-separated QName list; XSD 1.0 preserves single-QName behavior. `Schema.SubstGroupMembers(head)` returns the eligible transitive member set after substitution block and derivation filtering.
-- `ErrValidationFailed` — sentinel error returned by `Validate()` when the document is invalid; individual errors delivered via `ErrorHandler`. `Validate()` also returns `ErrNilSchema` (no compiled schema) and `ErrNilDocument` (nil document); a nil `ctx` is normalized to `context.Background()`
+- **Schema.Declarations() → xpath3.SchemaDeclarations** — an `xpath3.SchemaDeclarations` view over the
+  compiled schema for schema-aware XPath (schema-element/attribute node tests, schema-aware cast/castable,
+  instance-of/subtype tests, substitution-group membership, typed-value atomization of PSVI-annotated nodes).
+  Pair with `xpath3.Evaluator.SchemaDeclarations(...)` and `TypeAnnotations(...)` (fed by
+  `Validator.Annotations`). Borrows the schema read-only; safe to share across concurrent evaluations. Backed
+  by the `schemaDecls` adapter in `schema_decls.go` — the same one used internally for xs:assert evaluation,
+  and the single canonical implementation xslt3's multi-schema `schemaRegistry` (`xslt3/schema_context.go`)
+  delegates its per-schema `SchemaDeclarations` lookups to. The one method xslt3 does NOT delegate is
+  `IsSubtypeOf`: XSLT SequenceType matching treats a simpleContent COMPLEX type as a subtype of its simple
+  content base (so it matches `element(*, T)`), whereas this adapter deliberately excludes a complex type from
+  its simple ancestry (so `instance of element(*, xs:string)` is false for an xs:assert node)
+- **ResolveSchemaURI(ref, base) → (string, error)** / **URIScheme(s) → string** — the single canonical
+  schema-location URI-resolution helper and scheme-detector, shared with `xslt3` so the two layers cannot
+  drift (URI-aware: absolute-URI pass-through, RFC 3986 with `OmitHost` preservation for URI bases,
+  `filepath.Join` + `..`-escape guard for local bases)
+- **FatalSchemaLoader** interface (`FatalSchemaLoad() bool`) — a `Compiler.FS` may return an `Open` error
+  whose chain carries a value satisfying this interface to force an `xs:import` load failure to be FATAL
+  instead of the usual warn-and-continue ("Skipping the import."). `xslt3`'s `schemaResolverFS` uses it so an
+  over-cap nested-import read (`ErrResourceTooLarge`) is not silently skipped; the wrapped chain is preserved
+  so callers can still `errors.Is`/`errors.As` the cause
+- **IsFatalSchemaLoad(err) → bool** — the SINGLE source of truth for "is this a fatal schema-load condition
+  that must abort compilation, as opposed to warn-and-continue or falling back to a pre-compiled schema".
+  Returns true (via `errors.Is`/`errors.As`) for a schema-location `..`-escape, an `xs:import` depth overflow,
+  an `xs:include`/`xs:redefine` depth overflow (`errIncludeDepthExceeded` — otherwise an over-deep include
+  chain inside an IMPORTED schema would be demoted to a warning and silently ignored by `loadImport`), an
+  over-cap nested-schema read (`errSchemaTooLarge`), and any error satisfying `FatalSchemaLoader`. The two xsd
+  import warn-or-continue sites and `xslt3`'s `xsl:import-schema` fallback guard both route through it
+  (xslt3's `isFatalSchemaLoadError` delegates to it, adding the xslt3-package `ErrResourceTooLarge` sentinel),
+  so the classification cannot drift between the layers. The path-escape / depth sentinels stay unexported;
+  this helper is the public surface
+- Supports: complex/simple types, sequences, choices, all, groups, attribute groups, substitution groups,
+  import/include/redefine/override, IDC (xs:unique/key/keyref), XSD 1.1 assertions/assertion facets,
+  conditional type assignment, open content, schema default attributes, wildcard algebra, relaxed xs:all, and
+  relaxed wildcard/UPA behavior
+- `ElementDecl.SubstitutionGroup` = first substitution-group head QName for compatibility;
+  `ElementDecl.SubstitutionGroups` = all head QNames. XSD 1.1 `@substitutionGroup` may be
+  XSD-whitespace-separated QName list; XSD 1.0 preserves single-QName behavior.
+  `Schema.SubstGroupMembers(head)` returns the eligible transitive member set after substitution block and
+  derivation filtering.
+- `ErrValidationFailed` — sentinel error returned by `Validate()` when the document is invalid; individual
+  errors delivered via `ErrorHandler`. `Validate()` also returns `ErrNilSchema` (no compiled schema) and
+  `ErrNilDocument` (nil document); a nil `ctx` is normalized to `context.Background()`
 - `ErrCompilationFailed` — sentinel error returned by `Compile()`/`CompileFile()` when the schema has one or more fatal errors; the returned schema is nil and individual diagnostics are delivered via `ErrorHandler`
-- Files: `xsd.go` (API), `doc.go`, `schema.go` (data model), `constants.go`, `compile.go` + `compile_imports.go` (compile orchestration/imports), `resolve_uri.go` (shared schema-location URI resolver `ResolveSchemaURI`/`URIScheme`), `read_types.go` + `read_particles.go` + `read_elements.go` (schema readers), `link_refs.go` + `restriction_particle.go` + `all_subsumption.go` + `substitution_group.go` + `wildcard_algebra.go` + `check_*.go` (`check_element_consistent.go`, `check_elements.go`, `check_facets.go`, `check_upa.go`; reference resolution + constraints), `validate.go` + `validate_elem.go` + `validate_idc.go` + `validate_id.go` (validation flow/content/IDC/ID), `simplevalue_core.go` + `simplevalue_facets.go` (simple-value engine), `assert.go` + `assertion_facet.go` (XSD 1.1 assertions), `alternative.go` (conditional type assignment), `conditional_inclusion.go` (XSD 1.1 conditional inclusion), `opencontent.go` (open content), `override.go` (xs:override), `inherited_attrs.go` (XSD 1.1 inherited attributes), `schema_decls.go` (schema-aware XPath adapter), `errors.go`
+- Files: `xsd.go` (API), `doc.go`, `schema.go` (data model), `constants.go`, `compile.go` +
+  `compile_imports.go` (compile orchestration/imports), `resolve_uri.go` (shared schema-location URI resolver
+  `ResolveSchemaURI`/`URIScheme`), `read_types.go` + `read_particles.go` + `read_elements.go` (schema
+  readers), `link_refs.go` + `restriction_particle.go` + `all_subsumption.go` + `substitution_group.go` +
+  `wildcard_algebra.go` + `check_*.go` (`check_element_consistent.go`, `check_elements.go`, `check_facets.go`,
+  `check_upa.go`; reference resolution + constraints), `validate.go` + `validate_elem.go` + `validate_idc.go`
+  + `validate_id.go` (validation flow/content/IDC/ID), `simplevalue_core.go` + `simplevalue_facets.go`
+  (simple-value engine), `assert.go` + `assertion_facet.go` (XSD 1.1 assertions), `alternative.go`
+  (conditional type assignment), `conditional_inclusion.go` (XSD 1.1 conditional inclusion), `opencontent.go`
+  (open content), `override.go` (xs:override), `inherited_attrs.go` (XSD 1.1 inherited attributes),
+  `schema_decls.go` (schema-aware XPath adapter), `errors.go`
 - Imports: helium, xpath1/, xpath3/ (XSD 1.1 assertions + conditional type assignment), internal/lexicon
 - Status: see `.claude/docs/libxml2-parity.md` for libxml2 golden counts and W3C XSD 1.1 conformance run policy; do not cache branch-specific counts here
 
@@ -217,8 +883,19 @@ RELAX NG schema compilation and validation.
   - `Label(name)`, `BaseDir(dir)`, `FS(fs.FS)`, `MaxResourceBytes(int)`, `ErrorHandler(h)` — builder methods (clone-on-write)
   - `Compiler.BaseDir(dir)` — base directory for resolving relative paths in `include` and `externalRef` during compilation
   - `Compiler.Parser(helium.Parser)` — sets the parser used to parse the grammar and its `include`/`externalRef` targets; supplies parse policy (limits, FS, XXE/network), distinct from the fetch `FS`. Unset → default `helium.NewParser()`.
-  - `Compiler.FS(fs.FS)` — sets the `fs.FS` used to load schemas referenced by `include` and `externalRef`. **Secure by default**: the default (and what a nil value restores) is a deny-all FS (`internal/iofs.DenyAll`, opens nothing), mirroring `helium.NewParser`, so an untrusted schema cannot read host files via `include`/`externalRef`. Pass `helium.PermissiveFS()` (any `os.Open` path) or a confined FS to opt into loading. Resolution (`resolveHref` in `parse.go`) honors an absolute href as-is first; otherwise it resolves against ancestor `xml:base` via `BuildURI`; only when neither applies does it fall back to `filepath.Join(BaseDir, href)`, and finally to the bare href. The resolved name may thus be absolute / OS-style; FS implementations enforcing `fs.ValidPath` (`os.DirFS`, `fstest.MapFS`) reject them, so a sandboxing FS must accept OS-style names
-  - `Compiler.MaxResourceBytes(int)` — per-resource byte cap on each `include`/`externalRef` target read (`readResource` in `parse.go`, via `internal/iolimit`). Default 10 MiB (`defaultMaxResourceBytes`); `<= 0` restores the default. An over-cap resource fails to load with an "exceeds the maximum resource size" compile error, and is never read in full
+  - `Compiler.FS(fs.FS)` — sets the `fs.FS` used to load schemas referenced by `include` and `externalRef`.
+    **Secure by default**: the default (and what a nil value restores) is a deny-all FS
+    (`internal/iofs.DenyAll`, opens nothing), mirroring `helium.NewParser`, so an untrusted schema cannot read
+    host files via `include`/`externalRef`. Pass `helium.PermissiveFS()` (any `os.Open` path) or a confined FS
+    to opt into loading. Resolution (`resolveHref` in `parse.go`) honors an absolute href as-is first;
+    otherwise it resolves against ancestor `xml:base` via `BuildURI`; only when neither applies does it fall
+    back to `filepath.Join(BaseDir, href)`, and finally to the bare href. The resolved name may thus be
+    absolute / OS-style; FS implementations enforcing `fs.ValidPath` (`os.DirFS`, `fstest.MapFS`) reject them,
+    so a sandboxing FS must accept OS-style names
+  - `Compiler.MaxResourceBytes(int)` — per-resource byte cap on each `include`/`externalRef` target read
+    (`readResource` in `parse.go`, via `internal/iolimit`). Default 10 MiB (`defaultMaxResourceBytes`); `<= 0`
+    restores the default. An over-cap resource fails to load with an "exceeds the maximum resource size"
+    compile error, and is never read in full
   - `Compile(ctx, *Document) → (*Grammar, error)` / `CompileFile(ctx, path) → (*Grammar, error)` — terminal methods
 - **NewValidator(grammar) → Validator** — create fluent builder for validation
   - `Filename(name)`, `ErrorHandler(h)` — builder methods
@@ -237,15 +914,47 @@ RELAX NG schema compilation and validation.
 HTML 4.01 parser producing helium DOM or SAX events.
 
 - **NewParser() → Parser** — create fluent parser builder
-- Parser methods: `SuppressImplied(bool)`, `StripBlanks(bool)`, `SuppressErrors(bool)`, `SuppressWarnings(bool)`, `Strict(bool)`, `MaxContentSize(int)` (approximate soft per-chunk cap for normal data-state text and raw-text/RCDATA/plaintext — chunks target this size but an indivisible token, e.g. a whole UTF-8 rune or resolved char-ref, is never split, so a chunk may slightly exceed it; HARD cap for comment/bogus-comment/PI — over-cap fails the parse with `ErrContentSizeExceeded` since those are indivisible nodes; normal data-state and RCDATA char-ref resolution share the same cap-aware path (`parseCharRefBounded`) — it uses a FIXED `maxEntityNameLen` (~32 byte) lookahead independent of the cap, so a SHORT resolvable named reference (known entity or legacy prefix) whose run fits the cap is never rejected for being a small name (`&amp;` resolves under `MaxContentSize(2)`); ANY UNRESOLVED named-reference literal (whether short, semicolon-terminated, or unbounded) fails with `ErrContentSizeExceeded` once the bytes it would emit (`&` + name + optional `;`) exceed the cap; a SATURATED ambiguous legacy-prefix run (`&amp` + a tail that overflows the 32-byte lookahead) is consumed into a cap-bounded spool and HARD-FAILS with `ErrContentSizeExceeded` if it exceeds the cap before its end is reached, emitting nothing — only a within-cap saturated run legacy-resolves; a normal data-state run's LEADING whitespace prefix is deferred (buffer `pendingWS`) until its first non-whitespace byte fixes both whitespace-significance (`StripBlanks`) and implied-`<body>` insertion — so `<html> a` keeps the space and `a` in one run under `<body>`, and `<p> &amp;</p>`/`<p> < b</p>` keep the leading space; that deferred prefix is bounded by the cap and HARD-FAILS with `ErrContentSizeExceeded` (regardless of `StripBlanks`) if it reaches the cap before any non-whitespace byte appears; indivisible STRUCTURAL token scans — tag name, end-tag name, attribute name, PUBLIC/SYSTEM DOCTYPE literal, intra-tag whitespace run (`scanTokenLimit`) — are also HARD-capped with `ErrContentSizeExceeded`, but against a separate cap FLOORED at the 16 MiB default (so small `MaxContentSize` never rejects ordinary names like `script`) that grows only when `MaxContentSize` exceeds the floor; `parseDoctype` checks `fatalErr` after EACH scanner so an over-cap run on a streaming reader fails promptly without a further blocking read; default 16 MiB)
+- Parser methods: `SuppressImplied(bool)`, `StripBlanks(bool)`, `SuppressErrors(bool)`,
+  `SuppressWarnings(bool)`, `Strict(bool)`, `MaxContentSize(int)` (approximate soft per-chunk cap for normal
+  data-state text and raw-text/RCDATA/plaintext — chunks target this size but an indivisible token, e.g. a
+  whole UTF-8 rune or resolved char-ref, is never split, so a chunk may slightly exceed it; HARD cap for
+  comment/bogus-comment/PI — over-cap fails the parse with `ErrContentSizeExceeded` since those are
+  indivisible nodes; normal data-state and RCDATA char-ref resolution share the same cap-aware path
+  (`parseCharRefBounded`) — it uses a FIXED `maxEntityNameLen` (~32 byte) lookahead independent of the cap, so
+  a SHORT resolvable named reference (known entity or legacy prefix) whose run fits the cap is never rejected
+  for being a small name (`&amp;` resolves under `MaxContentSize(2)`); ANY UNRESOLVED named-reference literal
+  (whether short, semicolon-terminated, or unbounded) fails with `ErrContentSizeExceeded` once the bytes it
+  would emit (`&` + name + optional `;`) exceed the cap; a SATURATED ambiguous legacy-prefix run (`&amp` + a
+  tail that overflows the 32-byte lookahead) is consumed into a cap-bounded spool and HARD-FAILS with
+  `ErrContentSizeExceeded` if it exceeds the cap before its end is reached, emitting nothing — only a
+  within-cap saturated run legacy-resolves; a normal data-state run's LEADING whitespace prefix is deferred
+  (buffer `pendingWS`) until its first non-whitespace byte fixes both whitespace-significance (`StripBlanks`)
+  and implied-`<body>` insertion — so `<html> a` keeps the space and `a` in one run under `<body>`, and `<p>
+  &amp;</p>`/`<p> < b</p>` keep the leading space; that deferred prefix is bounded by the cap and HARD-FAILS
+  with `ErrContentSizeExceeded` (regardless of `StripBlanks`) if it reaches the cap before any non-whitespace
+  byte appears; indivisible STRUCTURAL token scans — tag name, end-tag name, attribute name, PUBLIC/SYSTEM
+  DOCTYPE literal, intra-tag whitespace run (`scanTokenLimit`) — are also HARD-capped with
+  `ErrContentSizeExceeded`, but against a separate cap FLOORED at the 16 MiB default (so small
+  `MaxContentSize` never rejects ordinary names like `script`) that grows only when `MaxContentSize` exceeds
+  the floor; `parseDoctype` checks `fatalErr` after EACH scanner so an over-cap run on a streaming reader
+  fails promptly without a further blocking read; default 16 MiB)
 - Terminal: **Parse(ctx, []byte)**, **ParseReader(ctx, io.Reader)**, **ParseFile(ctx, path)**, **ParseWithSAX(ctx, []byte, SAXHandler)**, **NewPushParser(ctx)**, **NewSAXPushParser(ctx, SAXHandler)**
 - **NewWriter() → Writer** — create fluent writer builder
-- Writer methods: `DefaultDTD(bool)`, `Format(bool)`, `PreserveCase(bool)`, `EscapeURIAttributes(bool)`, `EscapeControlChars(bool)`, `NullNamespaceHTMLOnly(bool)` (HTML 4.01 rule: a void element only in the null namespace is minimized; a namespaced one gets an explicit end tag), `CharacterMap(map[rune]string)` (substitute a mapped rune with its raw replacement in text/attribute content — Serialization 3.1 §7 character maps for the html output method; nil/empty is byte-identical)
+- Writer methods: `DefaultDTD(bool)`, `Format(bool)`, `PreserveCase(bool)`, `EscapeURIAttributes(bool)`,
+  `EscapeControlChars(bool)`, `NullNamespaceHTMLOnly(bool)` (HTML 4.01 rule: a void element only in the null
+  namespace is minimized; a namespaced one gets an explicit end tag), `CharacterMap(map[rune]string)`
+  (substitute a mapped rune with its raw replacement in text/attribute content — Serialization 3.1 §7
+  character maps for the html output method; nil/empty is byte-identical)
 - Terminal: **WriteTo(io.Writer, Node)**
 - **Write(io.Writer, Node) → error** — serialize with default settings
 - **WriteString(Node) → (string, error)** — serialize to string with default settings
 - Auto-closing, void elements, implicit html/head/body insertion
-- Encoding: prescan charset=utf-8 → U+FFFD for invalid bytes; otherwise Latin-1/Win-1252→UTF-8. `ParseReader`/push path: an UNDECLARED stream that keeps proving valid UTF-8 is deferred (buffered) until a non-UTF-8 byte flips the whole prefix to Windows-1252; that undecided prefix is BOUNDED at the configured `MaxContentSize` (16 MiB default), capped chunk-independently — valid UTF-8 ending at/below the cap is accepted (one-byte EOF probe), but the cap filling with more bytes still to come fails closed with `ErrContentSizeExceeded` (`encoding_reader.go`)
+- Encoding: prescan charset=utf-8 → U+FFFD for invalid bytes; otherwise Latin-1/Win-1252→UTF-8.
+  `ParseReader`/push path: an UNDECLARED stream that keeps proving valid UTF-8 is deferred (buffered) until a
+  non-UTF-8 byte flips the whole prefix to Windows-1252; that undecided prefix is BOUNDED at the configured
+  `MaxContentSize` (16 MiB default), capped chunk-independently — valid UTF-8 ending at/below the cap is
+  accepted (one-byte EOF probe), but the cap filling with more bytes still to come fails closed with
+  `ErrContentSizeExceeded` (`encoding_reader.go`)
 - Entity resolution: 2125 WHATWG + 106 legacy HTML4; legacy entities work without `;`
 - Files: `html.go` (API), `parser.go`, `entities.go`, `elements.go`, `dump.go` (serializer), `tree.go` (DOM builder), `sax.go`
 - Imports: helium, sax/
@@ -256,13 +965,32 @@ XInclude 1.0 processing with recursive inclusion and fallback.
 
 - **NewProcessor() → Processor** — create fluent builder
 - Processor methods: `NoXIncludeMarkers()`, `NoBaseFixup()`, `Resolver(Resolver)`, `BaseURI(string)`, `MaxIncludeSize(int)`, `MaxIncludeDepth(int)`, `ErrorHandler(helium.ErrorHandler)`, `Parser(helium.Parser)`
-- `Processor.Parser(helium.Parser)` — supplies the **resource limits** (depth/name-length/amplification/content-model-depth) used to parse included documents. XInclude still forces its own loading policy: external-DTD loading is on and the filesystem is confined to the `Resolver`'s sandbox (the injected parser's FS is NOT used for included docs — the `Resolver` is the security boundary). Unset → default `helium.NewParser()` base.
+- `Processor.Parser(helium.Parser)` — supplies the **resource limits**
+  (depth/name-length/amplification/content-model-depth) used to parse included documents. XInclude still
+  forces its own loading policy: external-DTD loading is on and the filesystem is confined to the `Resolver`'s
+  sandbox (the injected parser's FS is NOT used for included docs — the `Resolver` is the security boundary).
+  Unset → default `helium.NewParser()` base.
 - Terminal: **Process(ctx, *Document) → (int, error)**, **ProcessTree(ctx, Node) → (int, error)**
 - `Resolver` interface — custom resource loader; receives the href already resolved against the effective base (base arg is informational only — do NOT re-resolve, or the base directory is double-applied)
-- **Secure by default**: an unset `Resolver` denies all filesystem access (`NewFSResolver(iofs.DenyAll{})`), mirroring `helium.NewParser()`'s deny-all FS — untrusted input cannot disclose local files via `<xi:include>`. Opt in with `Resolver(NewFSResolver(fsys))` (confined `fs.FS`, e.g. `os.Root.FS`) or `Resolver(NewFSResolver(helium.PermissiveFS()))` for historical os.Open passthrough. NOTE: `NewFSResolver(nil)` is still permissive — only the processor's *unset* default is deny-all
+- **Secure by default**: an unset `Resolver` denies all filesystem access (`NewFSResolver(iofs.DenyAll{})`),
+  mirroring `helium.NewParser()`'s deny-all FS — untrusted input cannot disclose local files via
+  `<xi:include>`. Opt in with `Resolver(NewFSResolver(fsys))` (confined `fs.FS`, e.g. `os.Root.FS`) or
+  `Resolver(NewFSResolver(helium.PermissiveFS()))` for historical os.Open passthrough. NOTE:
+  `NewFSResolver(nil)` is still permissive — only the processor's *unset* default is deny-all
 - `Processor.MaxIncludeSize(int)` — per-include byte cap; unset or ≤ 0 uses the default 10 MiB (unexported `defaultMaxIncludeSize`); over-cap reads fail with `ErrIncludeTooLarge`
-- **Aggregate cap (internal, no public knob)**: across the whole expansion the cumulative materialized bytes are bounded at `maxIncludeAggregateMultiplier` (100) × the effective per-include cap (1 GiB by default; proportional, so lowering `MaxIncludeSize` lowers it), and the total spliced-resource count at `maxTotalIncludes` (65536). Counted per occurrence — repeated cache hits included — so many distinct sub-cap includes or one cached resource reused many times both trip it. An xpointer include charges the estimated footprint of each deep-copied selected subtree (`subtreeCopyCost`: `copiedNodeOverhead` per node + leaf content length, measured on the source before copying) against the same aggregate, so a small source whose xpointer selects many overlapping/nested nodes (O(n²) copies) is bounded instead of OOMing — the bytes READ from the source alone would not catch it. Over-aggregate fails with the same `ErrIncludeTooLarge` sentinel as the per-include cap. Guards amplification the per-include cap alone misses
-- `Processor.MaxIncludeDepth(int)` — xi:include nesting-depth cap; unset or ≤ 0 uses the default 40 (unexported `defaultMaxIncludeDepth`); over-cap fails with "maximum include depth exceeded". Bounds nesting only — cyclic includes are caught separately by circular detection
+- **Aggregate cap (internal, no public knob)**: across the whole expansion the cumulative materialized bytes
+  are bounded at `maxIncludeAggregateMultiplier` (100) × the effective per-include cap (1 GiB by default;
+  proportional, so lowering `MaxIncludeSize` lowers it), and the total spliced-resource count at
+  `maxTotalIncludes` (65536). Counted per occurrence — repeated cache hits included — so many distinct sub-cap
+  includes or one cached resource reused many times both trip it. An xpointer include charges the estimated
+  footprint of each deep-copied selected subtree (`subtreeCopyCost`: `copiedNodeOverhead` per node + leaf
+  content length, measured on the source before copying) against the same aggregate, so a small source whose
+  xpointer selects many overlapping/nested nodes (O(n²) copies) is bounded instead of OOMing — the bytes READ
+  from the source alone would not catch it. Over-aggregate fails with the same `ErrIncludeTooLarge` sentinel
+  as the per-include cap. Guards amplification the per-include cap alone misses
+- `Processor.MaxIncludeDepth(int)` — xi:include nesting-depth cap; unset or ≤ 0 uses the default 40
+  (unexported `defaultMaxIncludeDepth`); over-cap fails with "maximum include depth exceeded". Bounds nesting
+  only — cyclic includes are caught separately by circular detection
 - Default `NewFSResolver` converts absolute `file:` hrefs to OS paths via `internal/iofs.FileURIToPath` (non-local hosts rejected)
 - Max URI 2000 chars, circular detection, doc/text caching
 - Files: `xinclude.go`
@@ -285,16 +1013,27 @@ XPointer expression evaluation with scheme cascading.
 
 Schematron schema compilation and validation.
 
-- **Compiler** (fluent, clone-on-write): `NewCompiler()` → `.Label(s)` / `.ErrorHandler(h)` / `.Parser(helium.Parser)` / `.QueryBinding(b)` / `.DefaultQueryBinding(b)` → `.Compile(ctx, doc)` or `.CompileFile(ctx, path)`. `Parser` sets the parser used by `CompileFile` (parse policy: limits, FS, XXE/network); unset → default `helium.NewParser()`. `QueryBinding` forces the query language binding and ignores the schema's `queryBinding` attribute; `DefaultQueryBinding` only chooses the fallback for a schema that names none
+- **Compiler** (fluent, clone-on-write): `NewCompiler()` → `.Label(s)` / `.ErrorHandler(h)` /
+  `.Parser(helium.Parser)` / `.QueryBinding(b)` / `.DefaultQueryBinding(b)` → `.Compile(ctx, doc)` or
+  `.CompileFile(ctx, path)`. `Parser` sets the parser used by `CompileFile` (parse policy: limits, FS,
+  XXE/network); unset → default `helium.NewParser()`. `QueryBinding` forces the query language binding and
+  ignores the schema's `queryBinding` attribute; `DefaultQueryBinding` only chooses the fallback for a schema
+  that names none
 - **Validator** (fluent, clone-on-write): `NewValidator(schema)` → `.Label(s)` / `.Quiet()` / `.ErrorHandler(h)` → `.Validate(ctx, doc)`
 - `ErrValidationFailed` — sentinel returned by `Validator.Validate` on validation failure; individual `*ValidationError` delivered to ErrorHandler
 - `ErrNoSchema` — sentinel returned by `Validator.Validate` when the Validator has no compiled schema
 - `ErrCompileFailed` — sentinel returned by `Compiler.Compile`/`CompileFile` when compilation fails
 - `ErrUnsupportedQueryBinding` — sentinel returned by `ParseQueryBinding` and by `Compiler.Compile`/`CompileFile` for a query language binding this package does not implement
-- **QueryBinding** — `QueryBindingUnspecified` / `QueryBindingXPath1` (`xslt`, absent attribute) / `QueryBindingXPath3` (`xslt3`, `xpath3`); `ParseQueryBinding(s)` maps an attribute value (trimmed, case-insensitive), `Schema.QueryBinding()` reports the resolved binding. Every other value is refused, including the unimplemented 2.0 bindings and the names the standard reserves without defining (`xpath`, `xquery`, `stx`, `exslt`)
+- **QueryBinding** — `QueryBindingUnspecified` / `QueryBindingXPath1` (`xslt`, absent attribute) /
+  `QueryBindingXPath3` (`xslt3`, `xpath3`); `ParseQueryBinding(s)` maps an attribute value (trimmed,
+  case-insensitive), `Schema.QueryBinding()` reports the resolved binding. Every other value is refused,
+  including the unimplemented 2.0 bindings and the names the standard reserves without defining (`xpath`,
+  `xquery`, `stx`, `exslt`)
 - Supports: schema, pattern, rule, assert, report, let, name, value-of
 - Variable bindings via `<let>` and `<param>`
-- Files: `schematron.go` (API + config), `schema.go` (data model), `parse.go` (compilation), `validate.go` (validation), `errors.go` (error types + formatting), `querybinding.go` (binding resolution), `engine.go` (engine/runner/value seam), `engine_xpath1.go` + `engine_xpath3.go` (per-binding engines)
+- Files: `schematron.go` (API + config), `schema.go` (data model), `parse.go` (compilation), `validate.go`
+  (validation), `errors.go` (error types + formatting), `querybinding.go` (binding resolution), `engine.go`
+  (engine/runner/value seam), `engine_xpath1.go` + `engine_xpath3.go` (per-binding engines)
 - Imports: helium, internal/xpath, xpath1/, xpath3/, internal/xpath1/number
 
 ## catalog/
@@ -307,7 +1046,12 @@ OASIS XML Catalog resolution for public/system IDs and URIs.
 - **Loader.MaxBytes(n) → Loader** — cap catalog file size; exceed → `ErrCatalogTooLarge` (default `MaxCatalogSize`, 10 MiB)
 - **Catalog.Resolve(ctx, pubID, sysID) → string** — resolve external identifier
 - **Catalog.ResolveURI(ctx, uri) → string** — resolve URI reference
-- **Catalog.ResolveResult(ctx, pubID, sysID) → (uri string, broke bool)** / **Catalog.ResolveURIResult(ctx, uri) → (resolved string, broke bool)** — like Resolve/ResolveURI but also report a catalog break (the OASIS/libxml2 "cut" signal: a matching delegate was consulted and every delegate target failed). An exhausted nextCatalog chain is NOT a break — it returns `broke==false`. `broke==true` means "no match, STOP searching"; `broke==false` with `""` means "no match, keep searching". Chain callers (CLI `catalogChain`) honor `broke` to stop falling through to later catalogs
+- **Catalog.ResolveResult(ctx, pubID, sysID) → (uri string, broke bool)** / **Catalog.ResolveURIResult(ctx,
+  uri) → (resolved string, broke bool)** — like Resolve/ResolveURI but also report a catalog break (the
+  OASIS/libxml2 "cut" signal: a matching delegate was consulted and every delegate target failed). An
+  exhausted nextCatalog chain is NOT a break — it returns `broke==false`. `broke==true` means "no match, STOP
+  searching"; `broke==false` with `""` means "no match, keep searching". Chain callers (CLI `catalogChain`)
+  honor `broke` to stop falling through to later catalogs
 - Const `MaxCatalogSize`; sentinel `ErrCatalogTooLarge`
 - Catalog chaining via nextCatalog; URN urn:publicid: support
 - Files: `catalog.go`, `load.go`
@@ -347,42 +1091,418 @@ Generic push parser infrastructure shared by both XML and HTML push parsers.
 
 XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
 
-- **NewSigner() → Signer** — create fluent builder for signing (clone-on-write value type). `Signer.Reference` deep-copies the `ReferenceConfig.Transforms` slice (and each transform's internal prefix slice) at ingress, and `clone` re-copies it, so a later mutation of the caller's `Transforms` slice cannot alter a configured Signer or race with signing. `ExcC14NTransform(prefixes...)` copies the prefix varargs and `Prefixes()` returns a copy, so a transform's prefix list is immutable to callers.
+- **NewSigner() → Signer** — create fluent builder for signing (clone-on-write value type). `Signer.Reference`
+  deep-copies the `ReferenceConfig.Transforms` slice (and each transform's internal prefix slice) at ingress,
+  and `clone` re-copies it, so a later mutation of the caller's `Transforms` slice cannot alter a configured
+  Signer or race with signing. `ExcC14NTransform(prefixes...)` copies the prefix varargs and `Prefixes()`
+  returns a copy, so a transform's prefix list is immutable to callers.
   - `SignatureAlgorithm(uri)`, `CanonicalizationMethod(uri)`, `Reference(ReferenceConfig)`, `KeyInfo(KeyInfoBuilder)`, `SignatureID(id)`, `AllowSHA1(bool)` — builder methods
-  - `SignEnveloped(ctx, doc, parent, key)`, `SignEnveloping(ctx, doc, content, key)`, `SignDetached(ctx, doc, key)` — terminal methods. Each honors `ctx` symmetrically with verification: an already-cancelled/expired context short-circuits at the top of the call (before the Signature skeleton is built, any caller content is moved into an `<Object>`, or any canonicalization/crypto runs), and the per-Reference loop re-checks `ctx.Err()` between references, returning the bare context error (an enveloped sign adds no Signature and an enveloping sign moves no content on the cancelled path)
-  - `SignEnveloping` wraps the content nodes in a `<ds:Object>`. A same-document reference (`URI="#id"`) pointing INTO the Signature's own Object content (e.g. a `<ds:Manifest>`/`<ds:SignatureProperties>` carrying an `Id`) resolves and is digested WITHOUT the Signature ever being inserted into the caller's document: reference resolution searches the document and the detached Signature subtree, an in-Object target is canonicalized on its own (the live Signature is moved into a throwaway document only for the c14n walk, rooted under a proxy element that reproduces the target's full inherited canonicalization context — the caller document element's in-scope namespace declarations AND its inherited xml:* attributes, copied per the C14N version to match exactly what helium's own canonicalizer inherits to a node-set apex (Canonical XML 1.0 inherits EVERY xml:* attribute including xml:id; Canonical XML 1.1 inherits only xml:lang/xml:space and lexically joins xml:base, xml:id NOT inherited) — so a reference into the Object verifies under inclusive Canonical XML 1.0 and 1.1 once the Signature is placed under the caller root; exclusive Canonical XML inherits neither namespaces nor xml:* and is unaffected; the proxy is never in the canonicalized node set, and the temporary move is always undone — on normal return, error, or a panic unwinding out of canonicalization), and a document target (`URI="#root"`, even the document element) is digested over its unchanged subtree — byte-identical to a signature with no such internal reference. An id that matches in BOTH the document and the Signature's own Object content is rejected as an ambiguous cross-tree collision (`ErrAmbiguousReference`).
-  - `SignEnveloping` content safety (`sign.go` `signEnveloping` + helpers `contentMovable`/`movedContent`/`restoreMovedContent`/`restoreOneContent`): every `content` entry must be a movable node (`helium.MutableNode`; an ordinary DOM element qualifies). A nil, typed-nil, or read-only entry (e.g. a `NamespaceNodeWrapper`) is rejected up front in a preflight with an indexed error `content[i] is nil or not movable (%T)` wrapping `ErrInvalidSignature`, before any node is moved — never silently dropped. Every content node's pre-move parent, both sibling anchors, and original OwnerDocument are snapshotted BEFORE any node is moved (moving one node changes the live sibling links of the others, so a per-node capture taken at move time would record a stale anchor); the nodes are then moved into the `<Object>` with a non-coalescing splice (`AddChild` for the first node into the empty Object, then `Replace(prev, node)` to place each subsequent node after the previous one) so two adjacent Text content entries are not merged into one node. A `defer` fires on the error/panic path only (a `success` flag skips it on the normal return) to restore every moved node to its exact original position (parent, siblings, order, and OwnerDocument), leaving the caller's DOM byte-identical to before the call. The restore inserts each node before its original next sibling when that sibling is movable (deferring until the anchor is back in place — a right-to-left order that always terminates), else inserts it after its original previous sibling; both are non-coalescing `Replace` splices, so a restored former-last-child Text node is not merged into its previous sibling and a node whose next sibling is read-only still lands in its exact slot. A node whose snapshotted parent is nil is returned to a detached state ONLY when it had no sibling anchors either; a parentless node that still had a saved prev/next sibling is spliced back onto that sibling chain, so a detached-but-sibling-linked chain is restored exactly. After the structural rollback, each moved subtree's original OwnerDocument is restored with `SetTreeDoc` — `canonicalizeDetachedSubtree` rewrites the moved subtree's owners to the signing document, so content that came from a different `helium.Document` is handed back pointing at its original owner (a no-op for content already in the signing document). On success the content stays in the Object (enveloping semantics). This mirrors `canonicalizeDetachedSubtree`'s restore-on-every-failure-exit discipline.
-  - Signing never mutates the caller's document (enveloping content moves excepted, and undone on failure per the bullet above). For a detached Signature (`SignDetached`/`SignEnveloping`, `sigElem.Parent()==nil`), `computeAndSetSignatureValue` (`sign.go`) canonicalizes `<ds:SignedInfo>` through the SAME throwaway-document proxy (`canonicalizeDetachedSubtree`, `transforms.go`) — the proxy reproduces the caller document element's in-scope namespaces + inherited xml:* per C14N version, so the SignedInfo digest is byte-identical to canonicalizing it while attached under `doc.DocumentElement()`, and the temporary move is undone on normal return, error, or panic. Enveloped signing (`SignEnveloped`) canonicalizes SignedInfo in place under the parent it was inserted into. **Placement caveat (inclusive C14N only):** because the proxy carries the SIGNING doc element's inherited context, a detached Signature whose SignedInfo CanonicalizationMethod (or an in-Object Reference) uses INCLUSIVE Canonical XML (`C14N10`/`C14N11`) must be placed by the caller directly under the document element (or an element with the same in-scope namespaces + inherited `xml:*`); placing it under an element that adds in-scope namespace declarations or `xml:*` attributes changes the inclusively-canonicalized bytes and verification fails. Exclusive C14N (the `NewSigner` default) inherits neither and is placement-independent. Documented on the `SignDetached`/`SignEnveloping` godoc + README.
-  - Returned-node lifetime: the detached `ds:Signature` from `SignDetached`/`SignEnveloping` is built from the passed-in `doc`'s slab storage (`buildSignatureSkeleton` uses `doc.CreateElement`), so it is owned by `doc` — but a successful sign leaves it safe to hold past `doc.Free()`. `computeAndSetSignatureValue` canonicalizes `<ds:SignedInfo>` by grafting the live Signature into a throwaway document (`canonicalizeDetachedSubtree`), a cross-document move whose `addChild` preflight runs `noteCrossDocumentEscape` and sets `doc.slabEscaped`. `slabEscaped` is never cleared, so `Document.Free` is already a no-op and never recycles the chunks backing the returned Signature. The Signature therefore stays valid after `doc.Free()` and the caller does NOT need to move it into a destination document first to keep it. The `SignDetached`/`SignEnveloping` godoc states this, and `sign_lifetime_test.go` proves the node survives `doc.Free()` plus slab-pool churn intact.
+  - `SignEnveloped(ctx, doc, parent, key)`, `SignEnveloping(ctx, doc, content, key)`, `SignDetached(ctx, doc,
+    key)` — terminal methods. Each honors `ctx` symmetrically with verification: an already-cancelled/expired
+    context short-circuits at the top of the call (before the Signature skeleton is built, any caller content
+    is moved into an `<Object>`, or any canonicalization/crypto runs), and the per-Reference loop re-checks
+    `ctx.Err()` between references, returning the bare context error (an enveloped sign adds no Signature and
+    an enveloping sign moves no content on the cancelled path)
+  - `SignEnveloping` wraps the content nodes in a `<ds:Object>`. A same-document reference (`URI="#id"`)
+    pointing INTO the Signature's own Object content (e.g. a `<ds:Manifest>`/`<ds:SignatureProperties>`
+    carrying an `Id`) resolves and is digested WITHOUT the Signature ever being inserted into the caller's
+    document: reference resolution searches the document and the detached Signature subtree, an in-Object
+    target is canonicalized on its own (the live Signature is moved into a throwaway document only for the
+    c14n walk, rooted under a proxy element that reproduces the target's full inherited canonicalization
+    context — the caller document element's in-scope namespace declarations AND its inherited xml:*
+    attributes, copied per the C14N version to match exactly what helium's own canonicalizer inherits to a
+    node-set apex (Canonical XML 1.0 inherits EVERY xml:* attribute including xml:id; Canonical XML 1.1
+    inherits only xml:lang/xml:space and lexically joins xml:base, xml:id NOT inherited) — so a reference into
+    the Object verifies under inclusive Canonical XML 1.0 and 1.1 once the Signature is placed under the
+    caller root; exclusive Canonical XML inherits neither namespaces nor xml:* and is unaffected; the proxy is
+    never in the canonicalized node set, and the temporary move is always undone — on normal return, error, or
+    a panic unwinding out of canonicalization), and a document target (`URI="#root"`, even the document
+    element) is digested over its unchanged subtree — byte-identical to a signature with no such internal
+    reference. An id that matches in BOTH the document and the Signature's own Object content is rejected as
+    an ambiguous cross-tree collision (`ErrAmbiguousReference`).
+  - `SignEnveloping` content safety (`sign.go` `signEnveloping` + helpers
+    `contentMovable`/`movedContent`/`restoreMovedContent`/`restoreOneContent`): every `content` entry must be
+    a movable node (`helium.MutableNode`; an ordinary DOM element qualifies). A nil, typed-nil, or read-only
+    entry (e.g. a `NamespaceNodeWrapper`) is rejected up front in a preflight with an indexed error
+    `content[i] is nil or not movable (%T)` wrapping `ErrInvalidSignature`, before any node is moved — never
+    silently dropped. Every content node's pre-move parent, both sibling anchors, and original OwnerDocument
+    are snapshotted BEFORE any node is moved (moving one node changes the live sibling links of the others, so
+    a per-node capture taken at move time would record a stale anchor); the nodes are then moved into the
+    `<Object>` with a non-coalescing splice (`AddChild` for the first node into the empty Object, then
+    `Replace(prev, node)` to place each subsequent node after the previous one) so two adjacent Text content
+    entries are not merged into one node. A `defer` fires on the error/panic path only (a `success` flag skips
+    it on the normal return) to restore every moved node to its exact original position (parent, siblings,
+    order, and OwnerDocument), leaving the caller's DOM byte-identical to before the call. The restore inserts
+    each node before its original next sibling when that sibling is movable (deferring until the anchor is
+    back in place — a right-to-left order that always terminates), else inserts it after its original previous
+    sibling; both are non-coalescing `Replace` splices, so a restored former-last-child Text node is not
+    merged into its previous sibling and a node whose next sibling is read-only still lands in its exact slot.
+    A node whose snapshotted parent is nil is returned to a detached state ONLY when it had no sibling anchors
+    either; a parentless node that still had a saved prev/next sibling is spliced back onto that sibling
+    chain, so a detached-but-sibling-linked chain is restored exactly. After the structural rollback, each
+    moved subtree's original OwnerDocument is restored with `SetTreeDoc` — `canonicalizeDetachedSubtree`
+    rewrites the moved subtree's owners to the signing document, so content that came from a different
+    `helium.Document` is handed back pointing at its original owner (a no-op for content already in the
+    signing document). On success the content stays in the Object (enveloping semantics). This mirrors
+    `canonicalizeDetachedSubtree`'s restore-on-every-failure-exit discipline.
+  - Signing never mutates the caller's document (enveloping content moves excepted, and undone on failure per
+    the bullet above). For a detached Signature (`SignDetached`/`SignEnveloping`, `sigElem.Parent()==nil`),
+    `computeAndSetSignatureValue` (`sign.go`) canonicalizes `<ds:SignedInfo>` through the SAME
+    throwaway-document proxy (`canonicalizeDetachedSubtree`, `transforms.go`) — the proxy reproduces the
+    caller document element's in-scope namespaces + inherited xml:* per C14N version, so the SignedInfo digest
+    is byte-identical to canonicalizing it while attached under `doc.DocumentElement()`, and the temporary
+    move is undone on normal return, error, or panic. Enveloped signing (`SignEnveloped`) canonicalizes
+    SignedInfo in place under the parent it was inserted into. **Placement caveat (inclusive C14N only):**
+    because the proxy carries the SIGNING doc element's inherited context, a detached Signature whose
+    SignedInfo CanonicalizationMethod (or an in-Object Reference) uses INCLUSIVE Canonical XML
+    (`C14N10`/`C14N11`) must be placed by the caller directly under the document element (or an element with
+    the same in-scope namespaces + inherited `xml:*`); placing it under an element that adds in-scope
+    namespace declarations or `xml:*` attributes changes the inclusively-canonicalized bytes and verification
+    fails. Exclusive C14N (the `NewSigner` default) inherits neither and is placement-independent. Documented
+    on the `SignDetached`/`SignEnveloping` godoc + README.
+  - Returned-node lifetime: the detached `ds:Signature` from `SignDetached`/`SignEnveloping` is built from the
+    passed-in `doc`'s slab storage (`buildSignatureSkeleton` uses `doc.CreateElement`), so it is owned by
+    `doc` — but a successful sign leaves it safe to hold past `doc.Free()`. `computeAndSetSignatureValue`
+    canonicalizes `<ds:SignedInfo>` by grafting the live Signature into a throwaway document
+    (`canonicalizeDetachedSubtree`), a cross-document move whose `addChild` preflight runs
+    `noteCrossDocumentEscape` and sets `doc.slabEscaped`. `slabEscaped` is never cleared, so `Document.Free`
+    is already a no-op and never recycles the chunks backing the returned Signature. The Signature therefore
+    stays valid after `doc.Free()` and the caller does NOT need to move it into a destination document first
+    to keep it. The `SignDetached`/`SignEnveloping` godoc states this, and `sign_lifetime_test.go` proves the
+    node survives `doc.Free()` plus slab-pool churn intact.
 - **NewVerifier(KeySource) → Verifier** — create fluent builder for verification (clone-on-write value type)
   - `AllowSHA1(bool)`, `AllowXPointer(bool)`, `LenientKeyInfo(bool)`, `ReferenceResolver(r)`, `ReferenceParser(p)`, `ValidateManifests(bool)`, `XSLTTransformer(t)`, `MaxReferences(n)`, `MaxKeyInfoEntries(n)`, `MaxDecodedBytes(n)` — builder methods
-  - **Parse-time resource caps** (`xmldsig1.go` `verifierConfig` + `verify.go` `verifyBudget`): bound the decode/parse work an unsigned, attacker-controlled Signature can force BEFORE the SignatureValue is checked (many/large `DigestValue`/`SignatureValue`/`X509Certificate` base64 decodes, one `x509.ParseCertificate` per embedded cert). `MaxReferences` (default 1024) caps `ds:Reference` count, `MaxKeyInfoEntries` (default 256) caps `KeyInfo` children + `X509Data` children, `MaxDecodedBytes` (default 10 MiB) caps the running certificate/signature octet total. Exceeding any → `ErrResourceLimitExceeded` (before digesting/crypto). Per builder, `n==0` selects the default and `n<0` disables the cap. The `verifyBudget` also polls `ctx.Err()` inside the KeyInfo/Reference parse loops (not just at their boundaries), so a cancelled ctx/passed deadline stops the parse promptly. `MaxDecodedBytes` has **five** charge sites, four of them DOM-decoded (`verify.go` SignatureValue + DigestValue, `keyinfo.go` X509Certificate, `retrieval_method.go:374` same-document rawX509Certificate) and one not (`retrieval_method.go:318` external rawX509Certificate octets). The DOM-decoded element is NOT necessarily inside `ds:Signature` — a same-document `ds:RetrievalMethod` URI resolves to any element in the document by ID, any local name, any namespace (`retrieval_method_internal_test.go` charges a `ds:SPKIData` this way). **The four DOM-decoded sites are charged BEFORE the value is materialized**, so for them the cap bounds what verification BUILDS, not merely what it keeps: each goes through `verify.go` `decodeBudgeted` → `xmlbase64.DecodeElement`, which walks the element's children once with an `xmlbase64.Counter`, charges `verifyBudget.consume` with the counted `DecodedLen()`, and only then walks them again to build the whitespace-stripped characters (`xmlbase64.AppendStripped`) and decode into a buffer sized at that same count. The lexical text is never joined into one string — xs:base64Binary permits XML whitespace between characters and a value may be spread over any number of text and CDATA children, so the lexical length is attacker-chosen and unrelated to the charge (the parser's per-run `MaxNodeContentSize` bounds one CDATA run, not their sum). `DecodeElement` reads text, CDATA, and entity-reference children and nothing else: a comment/PI contributes no character information item and is skipped, and any other child (an element among them) is refused with an error before the charge, because reading one would aggregate its whole subtree into a buffer no cap approved. An entity reference is read through its first child only — the declared `helium.Entity`, whose `Content()` is a leaf accessor returning the raw replacement literal with no expansion of a nested reference and no recursion — so it costs one copy of that literal, and a replacement that is not base64 (an unexpanded `&inner;`, markup) just fails the decode. Walking the `Entity`'s siblings instead would leave the value entirely: they are the DTD's remaining entity declarations. A CHILDLESS `EntityRef` contributes no characters and is NOT an error: an undeclared general entity is a validity error, not a well-formedness one, once the document has an external subset the parser did not read (or a parameter-entity reference) and is not `standalone="yes"`, so `parser_entity_ref.go` keeps the reference and links no declaration to it — ordinary output for a document any unauthenticated peer can send. `c14n` canonicalizes such a reference by walking the children it does not have, so reading it as nothing is what keeps the base64 reader and the canonicalizer agreeing about one document. An `EntityRef` whose first child is a NON-NIL node that is not an `Entity` is refused; the parser links a reference to its declared `Entity` or to nothing at all, so that shape is reachable only from a caller-built DOM, and refusing it is what holds the bound for one. Because the charge precedes the decode, a value that is both over cap and invalid base64 reports `ErrResourceLimitExceeded`, and the base64 error never surfaces. **The fifth site is the exception**: an external `ds:RetrievalMethod` is fetched by the configured `ReferenceResolver` under the resolver's OWN 64 MiB cap and run through its transforms, and only then charged — so those octets are charged AFTER materialization and are not base64-decoded bytes. The KeyInfo values outside the budget (KeyName, X509SKI, X509SubjectName/IssuerName, the base64 KeyValue families) are not charged at all. The XPath-transform expression is not charged against `MaxDecodedBytes` either; it has its own fixed `maxXPathFilterExpressionBytes` = 8 KiB length ceiling (`verify.go`, applied in `parseXPathTransform` → `ErrResourceLimitExceeded`), bounding the expression where it is read off the document because compiling one costs superlinearly in its LENGTH (a flat predicate chain allocates ~100x its own size) while xpath1's parse-depth bound constrains only nesting. The two compile-failure diagnostics quote at most `maxErrorExpressionBytes` = 128 bytes of the expression (`transforms.go` `truncatedExpression`), so an error string cannot be as large as the expression it names. The two KeyInfo values carried as DECIMAL TEXT, where the rest carry base64, are bounded by fixed digit ceilings instead of by the budget (`keyinfo.go`): `maxX509SerialNumberDigits` = 1024 for `ds:X509SerialNumber` and `maxRFC4050CoordinateDigits` = 1024 for EACH of the RFC 4050 `ECDSAKeyValue` `PublicKey` `X`/`Y` `Value` attributes. `big.Int.SetString` is QUADRATIC in the digit count (1 MiB of digits ≈ 1 s and 2.4 GB of scratch), and both sites are read before the SignatureValue check, so each value is refused with `ErrInvalidKeyInfo` **before** the conversion — a ceiling weighed after it would return the same error having already paid the whole cost, which `keyinfo_decimal_bound_internal_test.go` pins with a TotalAlloc bound on top of the same document written conforming. Both are fixed internal constants with NO builder knob and are deliberately NOT folded into `MaxDecodedBytes`: a byte budget generous enough for real key material still admits a minutes-long conversion, so that knob's value space is the wrong shape for a quadratic cost. Conforming input is nowhere near either ceiling (RFC 5280 §4.1.2.2 caps a serial at 20 octets = ≤49 decimal digits; a P-521 field element = ≤157). The 1.1 `ECKeyValue` `PublicKey` carries a fixed 133-octet cap of its own instead (see the `KeyInfoData` entry below).
-  - `Verify(ctx, doc)`, `VerifyElement(ctx, doc, sigElem)` — terminal methods. `VerifyElement` takes the target element straight from the caller (bypassing `findSignatureElements`), so it applies the same gate itself before any work: a nil `sigElem`, or one that is not local-name `Signature` in the core XML-Signature namespace (`isDSigCoreNS`), is rejected with `ErrInvalidSignature`, so it is never nil-dereferenced or parsed as a ds:Signature.
-  - **Reference static preflight** (`verify.go` `preflightVerifierReferences`): after the Signature is parsed and its weak-algorithm policy is checked, verification validates every parsed transform list and compiles/validates every XPath filter and enabled general XPointer expression before KeyInfo retrieval, key resolution, SignatureValue authentication, or the top-level Reference digest loop. Each parsed Reference caches its ordered transform steps plus any prepared general-XPointer evaluator for execution, so no Reference resolver or XSLT transformer runs when a later Reference has a static XPath failure. Per-reference errors keep their `VerificationError` index and URI. Opt-in Manifest inner references use a separate all-siblings preparation pass and remain advisory.
+  - **Parse-time resource caps** (`xmldsig1.go` `verifierConfig` + `verify.go` `verifyBudget`): bound the
+    decode/parse work an unsigned, attacker-controlled Signature can force BEFORE the SignatureValue is
+    checked (many/large `DigestValue`/`SignatureValue`/`X509Certificate` base64 decodes, one
+    `x509.ParseCertificate` per embedded cert). `MaxReferences` (default 1024) caps `ds:Reference` count,
+    `MaxKeyInfoEntries` (default 256) caps `KeyInfo` children + `X509Data` children, `MaxDecodedBytes`
+    (default 10 MiB) caps the running certificate/signature octet total. Exceeding any →
+    `ErrResourceLimitExceeded` (before digesting/crypto). Per builder, `n==0` selects the default and `n<0`
+    disables the cap. The `verifyBudget` also polls `ctx.Err()` inside the KeyInfo/Reference parse loops (not
+    just at their boundaries), so a cancelled ctx/passed deadline stops the parse promptly. `MaxDecodedBytes`
+    has **five** charge sites, four of them DOM-decoded (`verify.go` SignatureValue + DigestValue,
+    `keyinfo.go` X509Certificate, `retrieval_method.go:374` same-document rawX509Certificate) and one not
+    (`retrieval_method.go:318` external rawX509Certificate octets). The DOM-decoded element is NOT necessarily
+    inside `ds:Signature` — a same-document `ds:RetrievalMethod` URI resolves to any element in the document
+    by ID, any local name, any namespace (`retrieval_method_internal_test.go` charges a `ds:SPKIData` this
+    way). **The four DOM-decoded sites are charged BEFORE the value is materialized**, so for them the cap
+    bounds what verification BUILDS, not merely what it keeps: each goes through `verify.go` `decodeBudgeted`
+    → `xmlbase64.DecodeElement`, which walks the element's children once with an `xmlbase64.Counter`, charges
+    `verifyBudget.consume` with the counted `DecodedLen()`, and only then walks them again to build the
+    whitespace-stripped characters (`xmlbase64.AppendStripped`) and decode into a buffer sized at that same
+    count. The lexical text is never joined into one string — xs:base64Binary permits XML whitespace between
+    characters and a value may be spread over any number of text and CDATA children, so the lexical length is
+    attacker-chosen and unrelated to the charge (the parser's per-run `MaxNodeContentSize` bounds one CDATA
+    run, not their sum). `DecodeElement` reads text, CDATA, and entity-reference children and nothing else: a
+    comment/PI contributes no character information item and is skipped, and any other child (an element among
+    them) is refused with an error before the charge, because reading one would aggregate its whole subtree
+    into a buffer no cap approved. An entity reference is read through its first child only — the declared
+    `helium.Entity`, whose `Content()` is a leaf accessor returning the raw replacement literal with no
+    expansion of a nested reference and no recursion — so it costs one copy of that literal, and a replacement
+    that is not base64 (an unexpanded `&inner;`, markup) just fails the decode. Walking the `Entity`'s
+    siblings instead would leave the value entirely: they are the DTD's remaining entity declarations. A
+    CHILDLESS `EntityRef` contributes no characters and is NOT an error: an undeclared general entity is a
+    validity error, not a well-formedness one, once the document has an external subset the parser did not
+    read (or a parameter-entity reference) and is not `standalone="yes"`, so `parser_entity_ref.go` keeps the
+    reference and links no declaration to it — ordinary output for a document any unauthenticated peer can
+    send. `c14n` canonicalizes such a reference by walking the children it does not have, so reading it as
+    nothing is what keeps the base64 reader and the canonicalizer agreeing about one document. An `EntityRef`
+    whose first child is a NON-NIL node that is not an `Entity` is refused; the parser links a reference to
+    its declared `Entity` or to nothing at all, so that shape is reachable only from a caller-built DOM, and
+    refusing it is what holds the bound for one. Because the charge precedes the decode, a value that is both
+    over cap and invalid base64 reports `ErrResourceLimitExceeded`, and the base64 error never surfaces. **The
+    fifth site is the exception**: an external `ds:RetrievalMethod` is fetched by the configured
+    `ReferenceResolver` under the resolver's OWN 64 MiB cap and run through its transforms, and only then
+    charged — so those octets are charged AFTER materialization and are not base64-decoded bytes. The KeyInfo
+    values outside the budget (KeyName, X509SKI, X509SubjectName/IssuerName, the base64 KeyValue families) are
+    not charged at all. The XPath-transform expression is not charged against `MaxDecodedBytes` either; it has
+    its own fixed `maxXPathFilterExpressionBytes` = 8 KiB length ceiling (`verify.go`, applied in
+    `parseXPathTransform` → `ErrResourceLimitExceeded`), bounding the expression where it is read off the
+    document because compiling one costs superlinearly in its LENGTH (a flat predicate chain allocates ~100x
+    its own size) while xpath1's parse-depth bound constrains only nesting. The two compile-failure
+    diagnostics quote at most `maxErrorExpressionBytes` = 128 bytes of the expression (`transforms.go`
+    `truncatedExpression`), so an error string cannot be as large as the expression it names. The two KeyInfo
+    values carried as DECIMAL TEXT, where the rest carry base64, are bounded by fixed digit ceilings instead
+    of by the budget (`keyinfo.go`): `maxX509SerialNumberDigits` = 1024 for `ds:X509SerialNumber` and
+    `maxRFC4050CoordinateDigits` = 1024 for EACH of the RFC 4050 `ECDSAKeyValue` `PublicKey` `X`/`Y` `Value`
+    attributes. `big.Int.SetString` is QUADRATIC in the digit count (1 MiB of digits ≈ 1 s and 2.4 GB of
+    scratch), and both sites are read before the SignatureValue check, so each value is refused with
+    `ErrInvalidKeyInfo` **before** the conversion — a ceiling weighed after it would return the same error
+    having already paid the whole cost, which `keyinfo_decimal_bound_internal_test.go` pins with a TotalAlloc
+    bound on top of the same document written conforming. Both are fixed internal constants with NO builder
+    knob and are deliberately NOT folded into `MaxDecodedBytes`: a byte budget generous enough for real key
+    material still admits a minutes-long conversion, so that knob's value space is the wrong shape for a
+    quadratic cost. Conforming input is nowhere near either ceiling (RFC 5280 §4.1.2.2 caps a serial at 20
+    octets = ≤49 decimal digits; a P-521 field element = ≤157). The 1.1 `ECKeyValue` `PublicKey` carries a
+    fixed 133-octet cap of its own instead (see the `KeyInfoData` entry below).
+  - `Verify(ctx, doc)`, `VerifyElement(ctx, doc, sigElem)` — terminal methods. `VerifyElement` takes the
+    target element straight from the caller (bypassing `findSignatureElements`), so it applies the same gate
+    itself before any work: a nil `sigElem`, or one that is not local-name `Signature` in the core
+    XML-Signature namespace (`isDSigCoreNS`), is rejected with `ErrInvalidSignature`, so it is never
+    nil-dereferenced or parsed as a ds:Signature.
+  - **Reference static preflight** (`verify.go` `preflightVerifierReferences`): after the Signature is parsed
+    and its weak-algorithm policy is checked, verification validates every parsed transform list and
+    compiles/validates every XPath filter and enabled general XPointer expression before KeyInfo retrieval,
+    key resolution, SignatureValue authentication, or the top-level Reference digest loop. Each parsed
+    Reference caches its ordered transform steps plus any prepared general-XPointer evaluator for execution,
+    so no Reference resolver or XSLT transformer runs when a later Reference has a static XPath failure.
+    Per-reference errors keep their `VerificationError` index and URI. Opt-in Manifest inner references use a
+    separate all-siblings preparation pass and remain advisory.
 - **NewEnvelopedReference() → ReferenceConfig** — WHOLE-DOCUMENT enveloped defaults: empty URI (always resolves to the document element, regardless of the `SignEnveloped` parent) + enveloped-signature transform + ExcC14N + SHA-256
-- **NewEnvelopedReferenceByID(id) → ReferenceConfig** — element-scoped enveloped defaults: `URI="#id"` (covers only the element carrying that id) + enveloped-signature transform + ExcC14N + SHA-256. Correct for signing a specific nested element (e.g. a SAML Assertion by its ID); the id must be recognized as an ID attribute per the package's ID rules
-- Key sources: `StaticKey(key)`, `X509CertKeySource(cert)`, `KeyByNameSource(map[string]any)`, `X509CertPoolKeySource(certs...)`, `KeySourceFunc`. `X509CertKeySource(nil)` resolves to `ErrNoKeySource` at `ResolveKey` time (fails closed on a per-request registry miss), so it never panics on `cert.PublicKey`. `KeyByNameSource` maps a `ds:KeyName` to a key: it tries the KeyInfo's `KeyNames` in document order and returns the first present in the map, else `ErrNoKeySource` (a nil KeyInfo or no-match fails closed). `X509CertPoolKeySource` selects a cert from its set by matching the verification-side KeyInfo with selector strength applied across the WHOLE pool, strongest first — every cert is tried for an exact raw-DER `X509Certificates` match, then every cert for `X509SKIs` vs `cert.SubjectKeyId` (both exact/reliable), then `X509IssuerSerials` vs Issuer+Serial, then `X509SubjectNames` vs Subject (the last two best-effort `pkix.Name.String()` comparisons, NOT RFC 2253 canonical), returning the matched cert's `PublicKey` else `ErrNoKeySource`. Pool order only breaks ties within a selector class, so a strong match on a later cert is never masked by a weak match on an earlier one (four named predicates `certMatchesRawDER`/`certMatchesSKI`/`certMatchesIssuerSerial`/`certMatchesSubjectName`). Selecting a cert never establishes trust; the returned key is still subject to the caller's out-of-band trust decision.
-- Key info builders (signing side): `X509DataKeyInfo(certs...)`, `RSAKeyValueKeyInfo()`. `X509DataKeyInfo()` with zero certificates OR any nil certificate entry fails `BuildKeyInfo`/signing with `ErrInvalidKeyInfo` (empty → a schema-invalid empty `<X509Data>`; a nil entry → would panic on `cert.Raw`); the shared `validate()` check runs in `BuildKeyInfo` and in the `SignEnveloping` preflight, so both are rejected before any caller content is moved into the `<Object>`. `RSAKeyValueKeyInfo()` derives the `RSAKeyValue` from a concrete `*rsa.PrivateKey`/`*rsa.PublicKey` or, matching the signing path, from an opaque `crypto.Signer` whose `Public()` is an `*rsa.PublicKey` (HSM/KMS-backed); any other key or a signer whose public key is not `*rsa.PublicKey` → `ErrKeyMismatch`.
-- **`KeyInfoData` is UNTRUSTED**: it is parsed from the document's `ds:KeyInfo` and handed to `KeySource.ResolveKey` BEFORE the signature is verified, so every field (embedded `X509Certificate`s, `RSA`/`EC`/`DSAKeyValue`, issuer/serial + subject-name selectors) is attacker-controlled and NOT authenticated by the signature. A `KeySource` MUST match it against a trust store / pinned key / validated chain and return a pre-trusted key — NEVER blindly return an embedded cert's public key or a `KeyValue`. It is a *selector* into trusted material, not the key material. `StaticKey`/`X509CertKeySource` ignore `KeyInfoData` (safe default); a custom `KeySource` consulting it owns the trust decision. Documented on the `KeySource`/`KeyInfoData` godoc + README.
-- Parsed `KeyInfoData` (verification input, `keyinfo.go`, namespace-strict): `KeyNames` (`KeyName` opaque label strings, whitespace-trimmed), `X509Certificates` (`X509Certificate`), `X509SKIs` (`X509SKI` → raw DER SubjectKeyIdentifier octets, base64-decoded), `X509IssuerSerials` (`X509IssuerSerial` → `{IssuerName, SerialNumber *big.Int}`, extracted verbatim — no DName canonicalization/matching), `X509SubjectNames` (`X509SubjectName` DN strings), `RSAKeyValue`, `ECKeyValue`, `DSAKeyValue` (`{P,Q,G,Y *big.Int}`). `ECKeyValue` is populated from EITHER the XML-Signature 1.1 `ECKeyValue` (`xmldsig11#`; `NamedCurve@URI` + base64 EC point) OR the RFC 4050 legacy `ECDSAKeyValue` (`xmldsig-more#`; `DomainParameters/NamedCurve@URN` + `PublicKey/X`,`/Y` DECIMAL `Value` attributes, on-curve validated) — parse-only, RFC 4050 emission is not supported. A KeySource turns `ECKeyValue`/`DSAKeyValue`/`RSAKeyValue`/`X509*`/`KeyNames` into the actual verification key. Unknown curve / partial or malformed key material (including bad `X509SKI` base64) → `ErrInvalidKeyInfo` (before key resolution). The four base64 KeyInfo values — `X509SKI`, `RSAKeyValue`'s `Modulus`/`Exponent`, the 1.1 `ECKeyValue`'s `PublicKey`, and `DSAKeyValue`'s `P`/`Q`/`G`/`Y` — are read as CHARACTER DATA through `keyinfo.go` `decodeKeyInfoValue` → `xmlbase64.DecodeElement`, the same reader `DigestValue`/`SignatureValue`/`X509Certificate` use: text, CDATA and a one-hop entity reference are read, a comment or PI is skipped (neither contributes a character information item, so a commented value still decodes and an otherwise valid signature still verifies), and any other child is refused. None of the four is charged to the `verifyBudget`; the `ECKeyValue` `PublicKey` instead carries a fixed `keyinfo.go` `maxECPublicKeyBytes` = 133 decoded-octet cap, applied by its `DecodeElement` charge so an oversized point is refused before it is built. The curve set forces that cap, so it is arithmetic and not policy — a SEC1 uncompressed point is 65 octets on P-256, 97 on P-384, 133 on P-521 and `elliptic.Unmarshal` accepts nothing else — and it is the maximum across all three curves because `NamedCurve` may follow `PublicKey` in document order, so there may be no selected curve to size the value by (`ErrInvalidKeyInfo`).
-- `ds:RetrievalMethod` resolution (`retrieval_method.go`, `resolveRetrievalMethods` invoked from `verifySignature` after `parseKeyInfo`, before key resolution): a second, resolution-aware pass dereferences each core-namespace `RetrievalMethod` child of `KeyInfo` and appends retrieved certificates to `KeyInfoData.X509Certificates`. Before dereferencing any child, it parses + statically validates every direct pipeline and every reachable transform-free same-document RetrievalMethod chain, so resolver/XSLT callbacks run only after all reachable document-resident XPath expressions pass validation. Same-document targets use the XSW-hardened `resolveReference`; external URIs use the configured `ReferenceResolver` after base joining and size checks. An optional single core-namespace `ds:Transforms` is parsed through `parseRetrievalTransforms`/`parseTransformList` and executed by the shared `executeTransformPipeline`: same-document targets start as node-sets, external targets as octets, and repeated node-set/octet transitions are valid. `maxRetrievalTransformSteps` bounds the list before dereference or execution; over-cap → `ErrResourceLimitExceeded`. Enveloped transforms are always rejected for RetrievalMethod; unknown algorithms, invalid parameters, absent/typed-nil XSLT transformers, and a second `Transforms` fail closed. A transform-free same-document RetrievalMethod still interprets the resolved element directly, including recursive RetrievalMethod links. `TypeRawX509Certificate` → `x509.ParseCertificate`; `TypeX509Data` → locked-down reparse + `parseX509Data`; any other/absent Type → `ErrInvalidKeyInfo`. A resolved-but-invalid resource is `ErrInvalidKeyInfo`, while a resource that cannot be dereferenced is `ErrReferenceNotFound`. Recursive links use `maxRetrievalMethodDepth`=5 plus a visited-URI set. Retrieved material consumes the normal `verifyBudget`, and parsing never establishes trust. `Verifier.LenientKeyInfo(true)` skips only an unresolvable RetrievalMethod; resolved-but-invalid material remains fatal.
+- **NewEnvelopedReferenceByID(id) → ReferenceConfig** — element-scoped enveloped defaults: `URI="#id"` (covers
+  only the element carrying that id) + enveloped-signature transform + ExcC14N + SHA-256. Correct for signing
+  a specific nested element (e.g. a SAML Assertion by its ID); the id must be recognized as an ID attribute
+  per the package's ID rules
+- Key sources: `StaticKey(key)`, `X509CertKeySource(cert)`, `KeyByNameSource(map[string]any)`,
+  `X509CertPoolKeySource(certs...)`, `KeySourceFunc`. `X509CertKeySource(nil)` resolves to `ErrNoKeySource` at
+  `ResolveKey` time (fails closed on a per-request registry miss), so it never panics on `cert.PublicKey`.
+  `KeyByNameSource` maps a `ds:KeyName` to a key: it tries the KeyInfo's `KeyNames` in document order and
+  returns the first present in the map, else `ErrNoKeySource` (a nil KeyInfo or no-match fails closed).
+  `X509CertPoolKeySource` selects a cert from its set by matching the verification-side KeyInfo with selector
+  strength applied across the WHOLE pool, strongest first — every cert is tried for an exact raw-DER
+  `X509Certificates` match, then every cert for `X509SKIs` vs `cert.SubjectKeyId` (both exact/reliable), then
+  `X509IssuerSerials` vs Issuer+Serial, then `X509SubjectNames` vs Subject (the last two best-effort
+  `pkix.Name.String()` comparisons, NOT RFC 2253 canonical), returning the matched cert's `PublicKey` else
+  `ErrNoKeySource`. Pool order only breaks ties within a selector class, so a strong match on a later cert is
+  never masked by a weak match on an earlier one (four named predicates
+  `certMatchesRawDER`/`certMatchesSKI`/`certMatchesIssuerSerial`/`certMatchesSubjectName`). Selecting a cert
+  never establishes trust; the returned key is still subject to the caller's out-of-band trust decision.
+- Key info builders (signing side): `X509DataKeyInfo(certs...)`, `RSAKeyValueKeyInfo()`. `X509DataKeyInfo()`
+  with zero certificates OR any nil certificate entry fails `BuildKeyInfo`/signing with `ErrInvalidKeyInfo`
+  (empty → a schema-invalid empty `<X509Data>`; a nil entry → would panic on `cert.Raw`); the shared
+  `validate()` check runs in `BuildKeyInfo` and in the `SignEnveloping` preflight, so both are rejected before
+  any caller content is moved into the `<Object>`. `RSAKeyValueKeyInfo()` derives the `RSAKeyValue` from a
+  concrete `*rsa.PrivateKey`/`*rsa.PublicKey` or, matching the signing path, from an opaque `crypto.Signer`
+  whose `Public()` is an `*rsa.PublicKey` (HSM/KMS-backed); any other key or a signer whose public key is not
+  `*rsa.PublicKey` → `ErrKeyMismatch`.
+- **`KeyInfoData` is UNTRUSTED**: it is parsed from the document's `ds:KeyInfo` and handed to
+  `KeySource.ResolveKey` BEFORE the signature is verified, so every field (embedded `X509Certificate`s,
+  `RSA`/`EC`/`DSAKeyValue`, issuer/serial + subject-name selectors) is attacker-controlled and NOT
+  authenticated by the signature. A `KeySource` MUST match it against a trust store / pinned key / validated
+  chain and return a pre-trusted key — NEVER blindly return an embedded cert's public key or a `KeyValue`. It
+  is a *selector* into trusted material, not the key material. `StaticKey`/`X509CertKeySource` ignore
+  `KeyInfoData` (safe default); a custom `KeySource` consulting it owns the trust decision. Documented on the
+  `KeySource`/`KeyInfoData` godoc + README.
+- Parsed `KeyInfoData` (verification input, `keyinfo.go`, namespace-strict): `KeyNames` (`KeyName` opaque
+  label strings, whitespace-trimmed), `X509Certificates` (`X509Certificate`), `X509SKIs` (`X509SKI` → raw DER
+  SubjectKeyIdentifier octets, base64-decoded), `X509IssuerSerials` (`X509IssuerSerial` → `{IssuerName,
+  SerialNumber *big.Int}`, extracted verbatim — no DName canonicalization/matching), `X509SubjectNames`
+  (`X509SubjectName` DN strings), `RSAKeyValue`, `ECKeyValue`, `DSAKeyValue` (`{P,Q,G,Y *big.Int}`).
+  `ECKeyValue` is populated from EITHER the XML-Signature 1.1 `ECKeyValue` (`xmldsig11#`; `NamedCurve@URI` +
+  base64 EC point) OR the RFC 4050 legacy `ECDSAKeyValue` (`xmldsig-more#`; `DomainParameters/NamedCurve@URN`
+  + `PublicKey/X`,`/Y` DECIMAL `Value` attributes, on-curve validated) — parse-only, RFC 4050 emission is not
+  supported. A KeySource turns `ECKeyValue`/`DSAKeyValue`/`RSAKeyValue`/`X509*`/`KeyNames` into the actual
+  verification key. Unknown curve / partial or malformed key material (including bad `X509SKI` base64) →
+  `ErrInvalidKeyInfo` (before key resolution). The four base64 KeyInfo values — `X509SKI`, `RSAKeyValue`'s
+  `Modulus`/`Exponent`, the 1.1 `ECKeyValue`'s `PublicKey`, and `DSAKeyValue`'s `P`/`Q`/`G`/`Y` — are read as
+  CHARACTER DATA through `keyinfo.go` `decodeKeyInfoValue` → `xmlbase64.DecodeElement`, the same reader
+  `DigestValue`/`SignatureValue`/`X509Certificate` use: text, CDATA and a one-hop entity reference are read, a
+  comment or PI is skipped (neither contributes a character information item, so a commented value still
+  decodes and an otherwise valid signature still verifies), and any other child is refused. None of the four
+  is charged to the `verifyBudget`; the `ECKeyValue` `PublicKey` instead carries a fixed `keyinfo.go`
+  `maxECPublicKeyBytes` = 133 decoded-octet cap, applied by its `DecodeElement` charge so an oversized point
+  is refused before it is built. The curve set forces that cap, so it is arithmetic and not policy — a SEC1
+  uncompressed point is 65 octets on P-256, 97 on P-384, 133 on P-521 and `elliptic.Unmarshal` accepts nothing
+  else — and it is the maximum across all three curves because `NamedCurve` may follow `PublicKey` in document
+  order, so there may be no selected curve to size the value by (`ErrInvalidKeyInfo`).
+- `ds:RetrievalMethod` resolution (`retrieval_method.go`, `resolveRetrievalMethods` invoked from
+  `verifySignature` after `parseKeyInfo`, before key resolution): a second, resolution-aware pass dereferences
+  each core-namespace `RetrievalMethod` child of `KeyInfo` and appends retrieved certificates to
+  `KeyInfoData.X509Certificates`. Before dereferencing any child, it parses + statically validates every
+  direct pipeline and every reachable transform-free same-document RetrievalMethod chain, so resolver/XSLT
+  callbacks run only after all reachable document-resident XPath expressions pass validation. Same-document
+  targets use the XSW-hardened `resolveReference`; external URIs use the configured `ReferenceResolver` after
+  base joining and size checks. An optional single core-namespace `ds:Transforms` is parsed through
+  `parseRetrievalTransforms`/`parseTransformList` and executed by the shared `executeTransformPipeline`:
+  same-document targets start as node-sets, external targets as octets, and repeated node-set/octet
+  transitions are valid. `maxRetrievalTransformSteps` bounds the list before dereference or execution;
+  over-cap → `ErrResourceLimitExceeded`. Enveloped transforms are always rejected for RetrievalMethod; unknown
+  algorithms, invalid parameters, absent/typed-nil XSLT transformers, and a second `Transforms` fail closed. A
+  transform-free same-document RetrievalMethod still interprets the resolved element directly, including
+  recursive RetrievalMethod links. `TypeRawX509Certificate` → `x509.ParseCertificate`; `TypeX509Data` →
+  locked-down reparse + `parseX509Data`; any other/absent Type → `ErrInvalidKeyInfo`. A resolved-but-invalid
+  resource is `ErrInvalidKeyInfo`, while a resource that cannot be dereferenced is `ErrReferenceNotFound`.
+  Recursive links use `maxRetrievalMethodDepth`=5 plus a visited-URI set. Retrieved material consumes the
+  normal `verifyBudget`, and parsing never establishes trust. `Verifier.LenientKeyInfo(true)` skips only an
+  unresolvable RetrievalMethod; resolved-but-invalid material remains fatal.
 - Transforms: `Enveloped()`, `C14NTransform(uri)`, `ExcC14NTransform(prefixes...)`
-- **External-reference resolution (opt-in, `reference_resolver.go`)**: `ReferenceResolver.ResolveReference(ctx, uri)` supplies raw octets for a URI outside the four same-document forms. `Verifier.ReferenceResolver` / `Signer.ReferenceResolver` configure it; nil stays fail-closed with `ErrReferenceNotFound`. Verification validates the complete transform list against octet input BEFORE URI joining or resolver invocation, so an unknown algorithm, malformed XPath, or unavailable XSLT transformer cannot trigger external I/O. The URI is joined against `doc.URL()` through `helium.ResolveURI`, and every internal resolver call passes through `resolveReferenceOctets`, which enforces `maxReferenceBytes`=64 MiB. `externalReferenceDigestInput` starts the shared ordered executor with those octets. An empty transform list stays raw; a node-set-requiring step parses through `Verifier.ReferenceParser` / `Signer.ReferenceParser`, including after an intermediate Base64, C14N, or XSLT result. The default parser is locked down (`helium.NewParser()`: XXE blocked, no FS, no network). Enveloped transforms are invalid on external input. Sign and verify share the same executor and conversions; signing supports Base64 but rejects XPath/XSLT because it cannot emit their parameters. `VerifiedReference.External` marks resolver-satisfied references, and coverage helpers never attribute them to document elements. `FSReferenceResolver(fsys)` serves only contained slash paths, rejects schemes/fragments/escapes, performs no network access, and applies the 64 MiB cap; `LimitReferenceResolver` composes a lower per-resource cap around the built-in resolver or any custom resolver, applying the cap while the built-in FS resolver reads and checking arbitrary custom results after return. No HTTP resolver is shipped; a network implementation owns request, aggregate-byte, and availability policy.
-- **Manifest inner-reference validation (opt-in, `manifest.go`)**: a top-level `ds:Reference` whose `Type` is `TypeManifest` (`http://www.w3.org/2000/09/xmldsig#Manifest`) points at a `ds:Manifest` carrying its own `ds:Reference` list (XMLDSig core §5.1). The signature commits ONLY to the Manifest's own bytes — the top-level Manifest reference's digest over the `ds:Manifest` subtree is checked exactly like any other reference — so `Verify` never depends on the inner references. `Verifier.ValidateManifests(true)` opts in to walking them: after the top-level Manifest reference verifies, every direct core-namespace inner `ds:Reference` is parsed + statically prepared before any is executed. A preparation failure prevents every resolver/XSLT callback for that Manifest; the failing `ManifestReference` carries the error, and each otherwise prepared peer carries an advisory error wrapping the same cause. After a successful complete preparation pass, each inner Reference is resolved + transformed + digested through the SAME `canonicalizeReference`+`computeDigest`+`digestEqual` path (`validateManifestReference`), and the per-reference outcome is recorded in `VerifyResult.Manifests` (`[]ManifestResult{Reference *VerifiedReference, Element *helium.Element, References []ManifestReference}`; `ManifestReference{URI, DigestAlgorithm string, Element *helium.Element, Valid bool, Err error}`). Results are ADVISORY: a failed inner digest (`ErrDigestMismatch`), an unsupported inner transform (`ErrUnsupportedTransform`), or an unresolved external inner reference (`ErrReferenceNotFound`) is folded into that inner `ManifestReference`'s `Valid:false`/`Err` and NEVER fails `Verify`, and inner references never contribute to `Covers`/`SignedElement` — coverage is never attributed through a Manifest (preserving the XSW guarantee). Only ONE level is walked (a Manifest nested in a Manifest is digested but not recursively expanded), bounding the work; the walk re-checks `ctx.Err()` per inner reference. Default is FALSE → `VerifyResult.Manifests` is nil and no inner references are walked, byte-identical to before; it is opt-in because inner references may pull unsupported transforms or external URIs. `VerifiedReference.Type` (the top-level `Type` attribute, parsed by `parseReferenceElement`) is reported regardless of the toggle.
-- Same-document reference resolution (`referenceURIForm`/`resolveReference`, `transforms.go`) is fail-closed to four forms (XMLDSig core §4.3.3.2-3): `URI=""` and `#xpointer(/)` select the whole document; `#id` and `#xpointer(id('id'))` select the element with that id. The two `#xpointer` forms' node-sets INCLUDE comment nodes; the bare `""`/`#id` forms EXCLUDE them. Every other URI — an external reference, or any other `#xpointer(...)` scheme — is rejected with `ErrReferenceNotFound`. An attribute is recognized as an ID when it is DTD/schema-declared ID-typed (`enum.AttrID`), `xml:id`, or the `id` token in the casings `Id`/`ID`/`id`; this name set is FROZEN in `domutil.FindElementsByID` — distinct tokens (`wsu:Id`, SAML `AssertionID`) are not recognized by name; such documents must carry ID typing via schema. `>1` match (across the document and any enveloping Object content) → `ErrAmbiguousReference`.
-- **General XPointer resolution (opt-in, verify-only, `transforms.go`)**: `Verifier.AllowXPointer(true)` extends same-document resolution to an XPointer framework URI — zero+ `xmlns(prefix=uri)` scheme parts then one `xpointer(<expr>)` (`parseGeneralXPointer`, respecting balanced parens and `^(`/`^)`/`^^` circumflex escaping). Default OFF: a general XPointer stays fail-closed as an external reference, so the four-form default is byte-identical. When on, `prepareGeneralXPointer` statically validates the `xpointer()` XPath on the shared bounded evaluator with the document element's in-scope namespaces overlaid by the `xmlns()` overrides (`xpointerNamespaces`), so an unresolved variable/function/prefix fails as `ErrReferenceNotFound` before evaluation. `resolvePreparedGeneralXPointerTarget` then evaluates the expression and enforces a SINGLE element apex (`singleElementApex`, the XSW defense): empty → `ErrReferenceNotFound`, a multi-element or non-element node-set → `ErrAmbiguousReference`. An id() selector NEVER reaches xpath1's built-in id() (`Document.GetElementByID`, which resolves a duplicate id to the last-registered element — an XSW bypass): a whole-expression `id('X')` selector in any whitespace spelling (`id('X')`, `id ('X')`, `id( "X" )`; `parseXPointerIDSelector`) resolves through the duplicate-detecting `domutil.FindElementsByID` (`ErrAmbiguousReference` on a duplicate), and ANY other id() use — a wrapping paren, a predicate, a path step (`expressionReferencesID`) — is rejected fail-closed as `ErrReferenceNotFound` and never reaches the built-in. The selected element is fed into the existing subtree canonicalization path (comments included). `here()` is NOT registered for a URI-borne XPointer, so `xpointer(here())` fails closed with `ErrHereUnavailable` (preserved as a matchable sentinel through the general-XPointer error path).
-- Comment membership is a property of the reference FORM, not the c14n method: `effectiveC14NMethod` (`transforms.go`) downgrades a `#WithComments` canonicalization to its plain variant when the form excludes comments, so a bare `#id`/`""` reference never emits comments even under a `#WithComments` c14n, while the `#xpointer` forms carry them through. Sign and verify apply this identically so a roundtrip stays symmetric.
-- Reference transforms run in declared order through `executeTransformPipeline` (`transform_pipeline.go`) over a tagged `transformValue` (`nodeSetValue` or octets). Contracts: C14N requires node-set and returns octets; XPath/enveloped require and return node-set; Base64 and XSLT return octets, with XSLT requiring octets. The executor parses octets through the configured reference parser when a node-set is required and converts node-sets with inclusive C14N 1.0 when octets are required or at finalization. Repeated transitions and repeated C14N/XSLT/Base64 steps are valid. Base64 has the XMLDSig §6.6.2 exception: node-set input is derived from remaining text-node values instead of generic C14N. The initial same-document node-set stays lazy so bare C14N, enveloped+C14N, whole-document, subtree, and detached/enveloping paths retain their exact specialized canonicalizers. Materialization preserves owning-document, URI comment-membership, namespace-node, XPath, and `here()` semantics. Two node-set collectors exist (`transforms.go`) and the difference is load-bearing. `collectCanonicalizationNodes` builds the set that goes straight to c14n (`canonicalizeSubtree`, so SignedInfo, every unmaterialized Reference selection, the detached/enveloped paths, and the XSLT stylesheet serialization): it is mode-aware and LINEAR — an element carries the bindings it changes relative to its parent, plus the in-scope default namespace, plus (exclusive C14N only) its own prefix and its attributes' prefixes, while the subtree root carries the whole axis. Inclusive C14N compares a namespace node against the nearest rendered ANCESTOR'S SET, so an inherited binding must be absent there; exclusive C14N renders nothing for a visibly-utilized prefix missing from the element's own set, so those must stay — applying the inclusive rule to the exclusive path emits undeclared prefixes. `collectSubtreeNodes` keeps the COMPLETE in-scope namespace axis per element (quadratic) and is used only where an XPath filter transform may narrow the set: the filter is evaluated once per node, namespace nodes included, and may drop an interior element while keeping its descendants. Both walks poll `ctx`. `transforms_nodeset_internal_test.go` is the byte-equivalence gate: it canonicalizes the package fixtures, the W3C interop vectors, the c14n suite documents, and a seeded generated corpus both ways in all six methods with and without a PrefixList, and requires identical octets. `here()` is unavailable with `ErrHereUnavailable` for initial octets or after an octet boundary reparses into a different document; complete-list validation rejects that chain before resolver or transform callbacks run. Enveloped removal uses original node identity and is rejected on external/RetrievalMethod input or after an octet boundary. `validateTransformSteps` scans the complete list and statically validates every XPath expression before execution, so unknown algorithms, missing or malformed parameters, unavailable XSLT, unknown XPath functions, unbound XPath QName prefixes, unavailable `here()`, and invalid enveloped placement fail before an injected transform runs. XPath uses `newDSigXPathEvaluator` with namespaces, `hereFunction`, and `defaultXPathOpLimit`=100M. Base64 signing works through the exported `Transform` interface; XPath/XSLT signing stays rejected because `ReferenceConfig` cannot carry or emit their required child content. `ec:InclusiveNamespaces` is threaded through explicit exclusive-C14N steps; unknown C14N/SignatureMethod parameters fail closed.
-- Algorithms: RSA-SHA1/SHA224/SHA256/SHA384/SHA512, ECDSA-SHA1/SHA224/SHA256/SHA384/SHA512, HMAC-SHA1/SHA224/SHA256/SHA384/SHA512, Ed25519. ECDSA curves P-256/P-384/P-521 (P-521 via the `urn:oid:1.3.132.0.35` NamedCurve in ECKeyValue KeyInfo; signing/verifying is curve-agnostic via `curveKeySize`)
-- **DSA-SHA1 (`AlgDSASHA1`, `xmldsig#dsa-sha1`) is verify-only legacy interop** (`verifyDSA`, `algorithms.go`): SHA-1-weak (rejected on verify without `Verifier.AllowSHA1(true)`, exactly like rsa-sha1). Accepts a `*dsa.PublicKey` — from a parsed `DSAKeyValue` or an `x509`-parsed DSA certificate. `SignatureValue` is the XML-DSig fixed-width `r||s`, each half left-padded to Q's byte length; `verifyDSA` requires the total length to be EXACTLY `2*ceil(Q.BitLen()/8)` (a nil/zero Q or any other length → `ErrVerificationFailed`), closing a malleability gap where accepting any even length and splitting at the midpoint would silently reinterpret a mis-padded `r||s`. SIGNING DSA is NOT supported: `signBytes` rejects the DSA URI with a clear `ErrUnsupportedAlgorithm` ("DSA signing is not supported"), which names the missing feature outright. `crypto/dsa` is deprecated-but-standard; used verify-only.
-- Signing keys: a concrete `*rsa.PrivateKey`/`*ecdsa.PrivateKey`/`ed25519.PrivateKey`, any `crypto.Signer` whose `Public()` is one of those types (HSM/KMS/PKCS#11-backed), or `[]byte` for HMAC. `signRSA`/`signECDSA`/`signEd25519` (`algorithms.go`) take the concrete fast path and fall back to `crypto.Signer` (RSA: `Sign` with a `crypto.Hash` opts → identical PKCS1v15 bytes; ECDSA: DER `Sign` output run through `ecdsaDERToRaw`; Ed25519: `Sign` with `crypto.Hash(0)` over the raw message). A `crypto.Signer` whose public-key type does not match the algorithm → `ErrKeyMismatch`.
+- **External-reference resolution (opt-in, `reference_resolver.go`)**:
+  `ReferenceResolver.ResolveReference(ctx, uri)` supplies raw octets for a URI outside the four same-document
+  forms. `Verifier.ReferenceResolver` / `Signer.ReferenceResolver` configure it; nil stays fail-closed with
+  `ErrReferenceNotFound`. Verification validates the complete transform list against octet input BEFORE URI
+  joining or resolver invocation, so an unknown algorithm, malformed XPath, or unavailable XSLT transformer
+  cannot trigger external I/O. The URI is joined against `doc.URL()` through `helium.ResolveURI`, and every
+  internal resolver call passes through `resolveReferenceOctets`, which enforces `maxReferenceBytes`=64 MiB.
+  `externalReferenceDigestInput` starts the shared ordered executor with those octets. An empty transform list
+  stays raw; a node-set-requiring step parses through `Verifier.ReferenceParser` / `Signer.ReferenceParser`,
+  including after an intermediate Base64, C14N, or XSLT result. The default parser is locked down
+  (`helium.NewParser()`: XXE blocked, no FS, no network). Enveloped transforms are invalid on external input.
+  Sign and verify share the same executor and conversions; signing supports Base64 but rejects XPath/XSLT
+  because it cannot emit their parameters. `VerifiedReference.External` marks resolver-satisfied references,
+  and coverage helpers never attribute them to document elements. `FSReferenceResolver(fsys)` serves only
+  contained slash paths, rejects schemes/fragments/escapes, performs no network access, and applies the 64 MiB
+  cap; `LimitReferenceResolver` composes a lower per-resource cap around the built-in resolver or any custom
+  resolver, applying the cap while the built-in FS resolver reads and checking arbitrary custom results after
+  return. No HTTP resolver is shipped; a network implementation owns request, aggregate-byte, and availability
+  policy.
+- **Manifest inner-reference validation (opt-in, `manifest.go`)**: a top-level `ds:Reference` whose `Type` is
+  `TypeManifest` (`http://www.w3.org/2000/09/xmldsig#Manifest`) points at a `ds:Manifest` carrying its own
+  `ds:Reference` list (XMLDSig core §5.1). The signature commits ONLY to the Manifest's own bytes — the
+  top-level Manifest reference's digest over the `ds:Manifest` subtree is checked exactly like any other
+  reference — so `Verify` never depends on the inner references. `Verifier.ValidateManifests(true)` opts in to
+  walking them: after the top-level Manifest reference verifies, every direct core-namespace inner
+  `ds:Reference` is parsed + statically prepared before any is executed. A preparation failure prevents every
+  resolver/XSLT callback for that Manifest; the failing `ManifestReference` carries the error, and each
+  otherwise prepared peer carries an advisory error wrapping the same cause. After a successful complete
+  preparation pass, each inner Reference is resolved + transformed + digested through the SAME
+  `canonicalizeReference`+`computeDigest`+`digestEqual` path (`validateManifestReference`), and the
+  per-reference outcome is recorded in `VerifyResult.Manifests` (`[]ManifestResult{Reference
+  *VerifiedReference, Element *helium.Element, References []ManifestReference}`; `ManifestReference{URI,
+  DigestAlgorithm string, Element *helium.Element, Valid bool, Err error}`). Results are ADVISORY: a failed
+  inner digest (`ErrDigestMismatch`), an unsupported inner transform (`ErrUnsupportedTransform`), or an
+  unresolved external inner reference (`ErrReferenceNotFound`) is folded into that inner `ManifestReference`'s
+  `Valid:false`/`Err` and NEVER fails `Verify`, and inner references never contribute to
+  `Covers`/`SignedElement` — coverage is never attributed through a Manifest (preserving the XSW guarantee).
+  Only ONE level is walked (a Manifest nested in a Manifest is digested but not recursively expanded),
+  bounding the work; the walk re-checks `ctx.Err()` per inner reference. Default is FALSE →
+  `VerifyResult.Manifests` is nil and no inner references are walked, byte-identical to before; it is opt-in
+  because inner references may pull unsupported transforms or external URIs. `VerifiedReference.Type` (the
+  top-level `Type` attribute, parsed by `parseReferenceElement`) is reported regardless of the toggle.
+- Same-document reference resolution (`referenceURIForm`/`resolveReference`, `transforms.go`) is fail-closed
+  to four forms (XMLDSig core §4.3.3.2-3): `URI=""` and `#xpointer(/)` select the whole document; `#id` and
+  `#xpointer(id('id'))` select the element with that id. The two `#xpointer` forms' node-sets INCLUDE comment
+  nodes; the bare `""`/`#id` forms EXCLUDE them. Every other URI — an external reference, or any other
+  `#xpointer(...)` scheme — is rejected with `ErrReferenceNotFound`. An attribute is recognized as an ID when
+  it is DTD/schema-declared ID-typed (`enum.AttrID`), `xml:id`, or the `id` token in the casings
+  `Id`/`ID`/`id`; this name set is FROZEN in `domutil.FindElementsByID` — distinct tokens (`wsu:Id`, SAML
+  `AssertionID`) are not recognized by name; such documents must carry ID typing via schema. `>1` match
+  (across the document and any enveloping Object content) → `ErrAmbiguousReference`.
+- **General XPointer resolution (opt-in, verify-only, `transforms.go`)**: `Verifier.AllowXPointer(true)`
+  extends same-document resolution to an XPointer framework URI — zero+ `xmlns(prefix=uri)` scheme parts then
+  one `xpointer(<expr>)` (`parseGeneralXPointer`, respecting balanced parens and `^(`/`^)`/`^^` circumflex
+  escaping). Default OFF: a general XPointer stays fail-closed as an external reference, so the four-form
+  default is byte-identical. When on, `prepareGeneralXPointer` statically validates the `xpointer()` XPath on
+  the shared bounded evaluator with the document element's in-scope namespaces overlaid by the `xmlns()`
+  overrides (`xpointerNamespaces`), so an unresolved variable/function/prefix fails as `ErrReferenceNotFound`
+  before evaluation. `resolvePreparedGeneralXPointerTarget` then evaluates the expression and enforces a
+  SINGLE element apex (`singleElementApex`, the XSW defense): empty → `ErrReferenceNotFound`, a multi-element
+  or non-element node-set → `ErrAmbiguousReference`. An id() selector NEVER reaches xpath1's built-in id()
+  (`Document.GetElementByID`, which resolves a duplicate id to the last-registered element — an XSW bypass): a
+  whole-expression `id('X')` selector in any whitespace spelling (`id('X')`, `id ('X')`, `id( "X" )`;
+  `parseXPointerIDSelector`) resolves through the duplicate-detecting `domutil.FindElementsByID`
+  (`ErrAmbiguousReference` on a duplicate), and ANY other id() use — a wrapping paren, a predicate, a path
+  step (`expressionReferencesID`) — is rejected fail-closed as `ErrReferenceNotFound` and never reaches the
+  built-in. The selected element is fed into the existing subtree canonicalization path (comments included).
+  `here()` is NOT registered for a URI-borne XPointer, so `xpointer(here())` fails closed with
+  `ErrHereUnavailable` (preserved as a matchable sentinel through the general-XPointer error path).
+- Comment membership is a property of the reference FORM, not the c14n method: `effectiveC14NMethod`
+  (`transforms.go`) downgrades a `#WithComments` canonicalization to its plain variant when the form excludes
+  comments, so a bare `#id`/`""` reference never emits comments even under a `#WithComments` c14n, while the
+  `#xpointer` forms carry them through. Sign and verify apply this identically so a roundtrip stays symmetric.
+- Reference transforms run in declared order through `executeTransformPipeline` (`transform_pipeline.go`) over
+  a tagged `transformValue` (`nodeSetValue` or octets). Contracts: C14N requires node-set and returns octets;
+  XPath/enveloped require and return node-set; Base64 and XSLT return octets, with XSLT requiring octets. The
+  executor parses octets through the configured reference parser when a node-set is required and converts
+  node-sets with inclusive C14N 1.0 when octets are required or at finalization. Repeated transitions and
+  repeated C14N/XSLT/Base64 steps are valid. Base64 has the XMLDSig §6.6.2 exception: node-set input is
+  derived from remaining text-node values instead of generic C14N. The initial same-document node-set stays
+  lazy so bare C14N, enveloped+C14N, whole-document, subtree, and detached/enveloping paths retain their exact
+  specialized canonicalizers. Materialization preserves owning-document, URI comment-membership,
+  namespace-node, XPath, and `here()` semantics. Two node-set collectors exist (`transforms.go`) and the
+  difference is load-bearing. `collectCanonicalizationNodes` builds the set that goes straight to c14n
+  (`canonicalizeSubtree`, so SignedInfo, every unmaterialized Reference selection, the detached/enveloped
+  paths, and the XSLT stylesheet serialization): it is mode-aware and LINEAR — an element carries the bindings
+  it changes relative to its parent, plus the in-scope default namespace, plus (exclusive C14N only) its own
+  prefix and its attributes' prefixes, while the subtree root carries the whole axis. Inclusive C14N compares
+  a namespace node against the nearest rendered ANCESTOR'S SET, so an inherited binding must be absent there;
+  exclusive C14N renders nothing for a visibly-utilized prefix missing from the element's own set, so those
+  must stay — applying the inclusive rule to the exclusive path emits undeclared prefixes.
+  `collectSubtreeNodes` keeps the COMPLETE in-scope namespace axis per element (quadratic) and is used only
+  where an XPath filter transform may narrow the set: the filter is evaluated once per node, namespace nodes
+  included, and may drop an interior element while keeping its descendants. Both walks poll `ctx`.
+  `transforms_nodeset_internal_test.go` is the byte-equivalence gate: it canonicalizes the package fixtures,
+  the W3C interop vectors, the c14n suite documents, and a seeded generated corpus both ways in all six
+  methods with and without a PrefixList, and requires identical octets. `here()` is unavailable with
+  `ErrHereUnavailable` for initial octets or after an octet boundary reparses into a different document;
+  complete-list validation rejects that chain before resolver or transform callbacks run. Enveloped removal
+  uses original node identity and is rejected on external/RetrievalMethod input or after an octet boundary.
+  `validateTransformSteps` scans the complete list and statically validates every XPath expression before
+  execution, so unknown algorithms, missing or malformed parameters, unavailable XSLT, unknown XPath
+  functions, unbound XPath QName prefixes, unavailable `here()`, and invalid enveloped placement fail before
+  an injected transform runs. XPath uses `newDSigXPathEvaluator` with namespaces, `hereFunction`, and
+  `defaultXPathOpLimit`=100M. Base64 signing works through the exported `Transform` interface; XPath/XSLT
+  signing stays rejected because `ReferenceConfig` cannot carry or emit their required child content.
+  `ec:InclusiveNamespaces` is threaded through explicit exclusive-C14N steps; unknown C14N/SignatureMethod
+  parameters fail closed.
+- Algorithms: RSA-SHA1/SHA224/SHA256/SHA384/SHA512, ECDSA-SHA1/SHA224/SHA256/SHA384/SHA512,
+  HMAC-SHA1/SHA224/SHA256/SHA384/SHA512, Ed25519. ECDSA curves P-256/P-384/P-521 (P-521 via the
+  `urn:oid:1.3.132.0.35` NamedCurve in ECKeyValue KeyInfo; signing/verifying is curve-agnostic via
+  `curveKeySize`)
+- **DSA-SHA1 (`AlgDSASHA1`, `xmldsig#dsa-sha1`) is verify-only legacy interop** (`verifyDSA`,
+  `algorithms.go`): SHA-1-weak (rejected on verify without `Verifier.AllowSHA1(true)`, exactly like rsa-sha1).
+  Accepts a `*dsa.PublicKey` — from a parsed `DSAKeyValue` or an `x509`-parsed DSA certificate.
+  `SignatureValue` is the XML-DSig fixed-width `r||s`, each half left-padded to Q's byte length; `verifyDSA`
+  requires the total length to be EXACTLY `2*ceil(Q.BitLen()/8)` (a nil/zero Q or any other length →
+  `ErrVerificationFailed`), closing a malleability gap where accepting any even length and splitting at the
+  midpoint would silently reinterpret a mis-padded `r||s`. SIGNING DSA is NOT supported: `signBytes` rejects
+  the DSA URI with a clear `ErrUnsupportedAlgorithm` ("DSA signing is not supported"), which names the missing
+  feature outright. `crypto/dsa` is deprecated-but-standard; used verify-only.
+- Signing keys: a concrete `*rsa.PrivateKey`/`*ecdsa.PrivateKey`/`ed25519.PrivateKey`, any `crypto.Signer`
+  whose `Public()` is one of those types (HSM/KMS/PKCS#11-backed), or `[]byte` for HMAC.
+  `signRSA`/`signECDSA`/`signEd25519` (`algorithms.go`) take the concrete fast path and fall back to
+  `crypto.Signer` (RSA: `Sign` with a `crypto.Hash` opts → identical PKCS1v15 bytes; ECDSA: DER `Sign` output
+  run through `ecdsaDERToRaw`; Ed25519: `Sign` with `crypto.Hash(0)` over the raw message). A `crypto.Signer`
+  whose public-key type does not match the algorithm → `ErrKeyMismatch`.
 - Digests: SHA-1, SHA-224, SHA-256, SHA-384, SHA-512
 - **SHA-1 rejected by default** (rsa-sha1/ecdsa-sha1/hmac-sha1/sha1) on both sign and verify → `ErrWeakAlgorithm`; opt in with `Signer.AllowSHA1(true)` / `Verifier.AllowSHA1(true)` for legacy interop. SHA-224+ unaffected.
-- Errors: `ErrNoKeySource` sentinel — returned by verify when no usable KeySource is configured (nil cfg, untyped-nil, or typed-nil KeySource/func); `ErrWeakAlgorithm` — SHA-1 used without opt-in; `ErrReferenceNotFound` also covers a nil-resolver external reference and every `FSReferenceResolver` rejection short of the size cap (scheme URI, escaping path, leftover fragment, missing file); `ErrReferenceTooLarge` — an external reference resource exceeds the resolver's 64 MiB cap; `ErrResourceLimitExceeded` — a pre-SignatureValue resource cap described above is exceeded; `ErrHereUnavailable` — the XPath `here()` function invoked with no bearing node (signing path, URI-borne XPointer)
-- Per-reference failures are symmetric across sign and verify: signing wraps each failing Reference in `*ReferenceError{Op:"sign", Reference, URI, Err}` (`errors.go`, wrapped in the `processReference` loops of `signEnveloped`/`signEnveloping`/`signDetached` and in the pre-mutation `preflightSignerTransforms` transform-pipeline check), verification wraps each in `*VerificationError{Reference, URI, Err}` (`Reference == -1` marks a SignatureValue failure). Both `Unwrap()` to the cause, so a sentinel like `ErrReferenceNotFound`/`ErrUnsupportedTransform` stays `errors.Is`-matchable and the failing reference's index+URI is reachable via `errors.As`. The verify-side weak-digest preflight (`preflightParsedWeakAlgorithms`) also wraps a per-reference `ErrWeakAlgorithm` in `*VerificationError` carrying the failing reference's index+URI, symmetric with the sign-side preflight's `*ReferenceError`. A malformed ECDSA/DSA `SignatureValue` length on verify is classified as `ErrVerificationFailed` (not an untyped error), so `errors.Is(err, ErrVerificationFailed)` holds.
-- **XSLT transform (opt-in, verify-only, `xslt_transform.go`)**: `XSLTTransformer.TransformXSLT(ctx, stylesheet, input)` is the injected seam, configured through clone-on-write `Verifier.XSLTTransformer`. Nil and typed-nil values fail with `ErrUnsupportedTransform`. Each XSLT step receives the current pipeline octets, which may be raw resolver data or output from Base64, C14N, or an earlier XSLT; its output feeds the next step or digest, and one Reference may call the transformer multiple times. A later node-set step reparses the output through `ReferenceParser`. Both arguments are attacker-controlled, so the implementation owns compute, memory, output, URI, I/O, and XXE policy. Signing rejects XSLT because it cannot emit the stylesheet. Production `xmldsig1` does not import `xslt3`; the opt-in `xmldsig1/transform.XSLT` adapter does.
-- **`xmldsig1/transform` package** (`transform.XSLT`): a ready `XSLTTransformer` backed by `xslt3`, kept OUT of `xmldsig1` so the core keeps its minimal dependency set and its fail-closed default. It is the only member — every other transform (c14n/base64/XPath/enveloped) is native, so there is no `transform.C14N`; the package name names the domain (injected xmldsig1 transforms), not a family. The zero value `transform.XSLT{}` is usable, parses stylesheet+input with helium's locked-down parser (XXE/DTD/network blocked), relies on the caller's `ctx` deadline for a time bound, and returns complete output without an output-size cap or transform-step budget. Use it for interoperability testing or controlled profiles; a production boundary accepting attacker-controlled XSLT supplies a transformer with those limits. Passing it to `Verifier.XSLTTransformer` is the explicit point where the embedder accepts running attacker-controlled XSLT; helium never runs XSLT on its own. xslt3 disables helium.Writer's per-document-child terminators on the direct XML path; the adapter retains explicit top-level text content as result content, including non-indented newline cases and non-UTF-8 XML output, except when serializer indentation intentionally discards whitespace-only text because indentation is enabled and the result has an element child; it does not promise byte-for-byte preservation of serializer-added document-child terminators.
-- Files: `xmldsig1.go` (API), `constants.go`, `algorithms.go`, `weak_algorithm.go`, `sign.go`, `verify.go`, `transforms.go`, `transform_pipeline.go` (ordered Reference transform executor), `manifest.go` (opt-in Manifest inner-reference validation), `xslt_transform.go` (XSLT transform seam: `XSLTTransformer` + `parseXSLTTransform`), `reference_resolver.go` (external-reference resolver API + FSReferenceResolver), `keyinfo.go`, `retrieval_method.go` (ds:RetrievalMethod dereferencing), `errors.go`
+- Errors: `ErrNoKeySource` sentinel — returned by verify when no usable KeySource is configured (nil cfg,
+  untyped-nil, or typed-nil KeySource/func); `ErrWeakAlgorithm` — SHA-1 used without opt-in;
+  `ErrReferenceNotFound` also covers a nil-resolver external reference and every `FSReferenceResolver`
+  rejection short of the size cap (scheme URI, escaping path, leftover fragment, missing file);
+  `ErrReferenceTooLarge` — an external reference resource exceeds the resolver's 64 MiB cap;
+  `ErrResourceLimitExceeded` — a pre-SignatureValue resource cap described above is exceeded;
+  `ErrHereUnavailable` — the XPath `here()` function invoked with no bearing node (signing path, URI-borne
+  XPointer)
+- Per-reference failures are symmetric across sign and verify: signing wraps each failing Reference in
+  `*ReferenceError{Op:"sign", Reference, URI, Err}` (`errors.go`, wrapped in the `processReference` loops of
+  `signEnveloped`/`signEnveloping`/`signDetached` and in the pre-mutation `preflightSignerTransforms`
+  transform-pipeline check), verification wraps each in `*VerificationError{Reference, URI, Err}` (`Reference
+  == -1` marks a SignatureValue failure). Both `Unwrap()` to the cause, so a sentinel like
+  `ErrReferenceNotFound`/`ErrUnsupportedTransform` stays `errors.Is`-matchable and the failing reference's
+  index+URI is reachable via `errors.As`. The verify-side weak-digest preflight
+  (`preflightParsedWeakAlgorithms`) also wraps a per-reference `ErrWeakAlgorithm` in `*VerificationError`
+  carrying the failing reference's index+URI, symmetric with the sign-side preflight's `*ReferenceError`. A
+  malformed ECDSA/DSA `SignatureValue` length on verify is classified as `ErrVerificationFailed` (not an
+  untyped error), so `errors.Is(err, ErrVerificationFailed)` holds.
+- **XSLT transform (opt-in, verify-only, `xslt_transform.go`)**: `XSLTTransformer.TransformXSLT(ctx,
+  stylesheet, input)` is the injected seam, configured through clone-on-write `Verifier.XSLTTransformer`. Nil
+  and typed-nil values fail with `ErrUnsupportedTransform`. Each XSLT step receives the current pipeline
+  octets, which may be raw resolver data or output from Base64, C14N, or an earlier XSLT; its output feeds the
+  next step or digest, and one Reference may call the transformer multiple times. A later node-set step
+  reparses the output through `ReferenceParser`. Both arguments are attacker-controlled, so the implementation
+  owns compute, memory, output, URI, I/O, and XXE policy. Signing rejects XSLT because it cannot emit the
+  stylesheet. Production `xmldsig1` does not import `xslt3`; the opt-in `xmldsig1/transform.XSLT` adapter
+  does.
+- **`xmldsig1/transform` package** (`transform.XSLT`): a ready `XSLTTransformer` backed by `xslt3`, kept OUT
+  of `xmldsig1` so the core keeps its minimal dependency set and its fail-closed default. It is the only
+  member — every other transform (c14n/base64/XPath/enveloped) is native, so there is no `transform.C14N`; the
+  package name names the domain (injected xmldsig1 transforms), not a family. The zero value
+  `transform.XSLT{}` is usable, parses stylesheet+input with helium's locked-down parser (XXE/DTD/network
+  blocked), relies on the caller's `ctx` deadline for a time bound, and returns complete output without an
+  output-size cap or transform-step budget. Use it for interoperability testing or controlled profiles; a
+  production boundary accepting attacker-controlled XSLT supplies a transformer with those limits. Passing it
+  to `Verifier.XSLTTransformer` is the explicit point where the embedder accepts running attacker-controlled
+  XSLT; helium never runs XSLT on its own. xslt3 disables helium.Writer's per-document-child terminators on
+  the direct XML path; the adapter retains explicit top-level text content as result content, including
+  non-indented newline cases and non-UTF-8 XML output, except when serializer indentation intentionally
+  discards whitespace-only text because indentation is enabled and the result has an element child; it does
+  not promise byte-for-byte preservation of serializer-added document-child terminators.
+- Files: `xmldsig1.go` (API), `constants.go`, `algorithms.go`, `weak_algorithm.go`, `sign.go`, `verify.go`,
+  `transforms.go`, `transform_pipeline.go` (ordered Reference transform executor), `manifest.go` (opt-in
+  Manifest inner-reference validation), `xslt_transform.go` (XSLT transform seam: `XSLTTransformer` +
+  `parseXSLTTransform`), `reference_resolver.go` (external-reference resolver API + FSReferenceResolver),
+  `keyinfo.go`, `retrieval_method.go` (ds:RetrievalMethod dereferencing), `errors.go`
 - Imports: helium, c14n/, xpath1/ (XPath filter transform)
 
 ## xmlenc1/
@@ -390,52 +1510,536 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
 XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
 
 - **NewEncryptor() → Encryptor** — create fluent builder for encryption (clone-on-write value type)
-  - `BlockAlgorithm(uri)`, `AllowLegacyCBC(bool)`, `KeyTransportAlgorithm(uri)`, `RecipientPublicKey(key)`, `RecipientECPublicKey(key)`, `SessionKey(key)`, `KeyWrapAlgorithm(uri)`, `KeyEncryptionKey(kek)`, `OAEPDigest(uri)`, `OAEPMGF(uri)`, `OAEPParams(params)`, `KeyDerivationParams(params)` — builder methods. Every setter taking octets (`SessionKey`, `OAEPParams`, `KeyEncryptionKey`, and `KeyDerivationParams`' five OtherInfo fields) copies them at ingress, so a later mutation of the caller's array cannot alter a configured Encryptor
-  - `EncryptElement(ctx, elem)`, `EncryptContent(ctx, elem)`, `EncryptBytes(ctx, doc, plaintext)` — terminal methods; the last encrypts arbitrary octets, emits no `@Type` (xmlenc-core1 §3.1), and returns a **detached** element without touching the tree. Callers recover that payload with `DecryptBytes`, which returns opaque or application-defined plaintext octets without interpreting `@Type`. `Decrypt` parses only `TypeElement` and `TypeContent` and refuses every other `@Type` — absent, empty, or unrecognized — with `ErrOpaquePayload` (`opaqueTypeError`, `xmlenc1.go`), because `@Type` is outside the ciphertext and unauthenticated even under GCM: defaulting it to `TypeElement` would let a stripped attribute turn an opaque octet stream into parsed nodes a caller may graft into its tree (xmlenc-core1 §4.2, §3.1). The gate sits ahead of block-algorithm resolution, the CBC opt-in, and the `SessionKey` early return
+  - `BlockAlgorithm(uri)`, `AllowLegacyCBC(bool)`, `KeyTransportAlgorithm(uri)`, `RecipientPublicKey(key)`,
+    `RecipientECPublicKey(key)`, `SessionKey(key)`, `KeyWrapAlgorithm(uri)`, `KeyEncryptionKey(kek)`,
+    `OAEPDigest(uri)`, `OAEPMGF(uri)`, `OAEPParams(params)`, `KeyDerivationParams(params)` — builder methods.
+    Every setter taking octets (`SessionKey`, `OAEPParams`, `KeyEncryptionKey`, and `KeyDerivationParams`'
+    five OtherInfo fields) copies them at ingress, so a later mutation of the caller's array cannot alter a
+    configured Encryptor
+  - `EncryptElement(ctx, elem)`, `EncryptContent(ctx, elem)`, `EncryptBytes(ctx, doc, plaintext)` — terminal
+    methods; the last encrypts arbitrary octets, emits no `@Type` (xmlenc-core1 §3.1), and returns a
+    **detached** element without touching the tree. Callers recover that payload with `DecryptBytes`, which
+    returns opaque or application-defined plaintext octets without interpreting `@Type`. `Decrypt` parses only
+    `TypeElement` and `TypeContent` and refuses every other `@Type` — absent, empty, or unrecognized — with
+    `ErrOpaquePayload` (`opaqueTypeError`, `xmlenc1.go`), because `@Type` is outside the ciphertext and
+    unauthenticated even under GCM: defaulting it to `TypeElement` would let a stripped attribute turn an
+    opaque octet stream into parsed nodes a caller may graft into its tree (xmlenc-core1 §4.2, §3.1). The gate
+    sits ahead of block-algorithm resolution, the CBC opt-in, and the `SessionKey` early return
 - **NewDecryptor() → Decryptor** — create fluent builder for decryption
-  - `PrivateKey(key)`, `ECPrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)`, `BlockAlgorithm(uri)`, `AllowUnauthenticatedCBC(bool)`, `StrictPKCS7Padding(bool)`, `MaxEncryptedKeys(n)`, `MaxEncryptedKeyBytes(n)`, `MaxCipherValueBytes(n)`, `CipherReferenceResolver(r)` — builder methods
+  - `PrivateKey(key)`, `ECPrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)`, `BlockAlgorithm(uri)`,
+    `AllowUnauthenticatedCBC(bool)`, `StrictPKCS7Padding(bool)`, `MaxEncryptedKeys(n)`,
+    `MaxEncryptedKeyBytes(n)`, `MaxCipherValueBytes(n)`, `CipherReferenceResolver(r)` — builder methods
   - `Decrypt(ctx, elem)`, `DecryptBytes(ctx, elem)` — terminal methods; the latter returns binary plaintext without XML parsing
-- **ReferenceResolver** (`reference_resolver.go`) — single-method interface `ResolveReference(ctx, uri) (io.ReadCloser, error)` supplying the octet STREAM of an EXTERNAL `xenc:CipherReference`, plus **FSReferenceResolver(fsys, root)**, the only implementation shipped. `uri` is always the JOINED, document-space URI, so a resolver never joins. The package reads the stream (`readBoundedReference`) under the decrypt's remaining budget and the caller's ctx, and it closes every stream a resolver hands over: on completion, over-budget, and cancellation alike, and equally when `ResolveReference` itself returns a stream alongside an error — so the bound and the cancellation hold for a caller-written resolver too. Unlike `xmldsig1.ReferenceResolver`, which returns `[]byte`, so one value does NOT satisfy both; NEITHER package imports the other
-- Zero values are usable: `Encryptor{}`/`Decryptor{}` behave as `NewEncryptor()`/`NewDecryptor()` with nothing configured (`config()` substitutes defaults for a nil `cfg`, mirroring `clone()` and xmldsig1's `Signer.config()`), so a terminal returns `ErrMissingConfig`/`ErrMissingKey` instead of panicking
-- Every encryption and decryption terminal observes `ctx` before and between payload stages, and the rule is uniform across all five: **a live cancellation wins over a stage's own error, and every input-sized walk observes the context as it goes**. `context.go` owns both halves and holds the only two decision points, so no site re-decides them. `abort(ctx, err)` returns the context's error when the context is done and exactly `err` otherwise, and every error return of a ctx-carrying function goes through it — a stage runs to completion once entered (a serialization, a session-key validation, a block encryption or decryption, a key unwrap, a marshal, a plaintext parse), so a cancellation landing inside one is observable only after it returns, and its own error would otherwise be reported as the reason the operation failed. Because a live context returns `err` unchanged, CBC's collapse of every failure to `ErrDecryptionFailed` is untouched and no padding oracle appears. `eachSibling(ctx, first, fn)` walks a node and its following siblings, polling per node (chosen over a stride: the poll is one guarded read against per-node work that serializes a subtree or steps a DOM, and a stride would make the bound depend on a constant nobody can derive from the input); every walk whose length the caller, the ciphertext, or the document chooses runs through it — `serializeChildren`' walk over the caller's subtree, `finishDecrypt`'s two shape walks over the parsed plaintext (`nodeCollector.appendNode` for TypeContent, `appendElementNode` for TypeElement), every sibling walk in `parse.go`. `eachChildElement(ctx, elem, fn)` (`context.go`) is the parse path's form of the same walk: it hands `fn` each ELEMENT child and skips every other child kind, delegating the poll to `eachSibling` so a walk that reads only elements still observes the context at the rate the document writes children. No parse-path value is collected from every child kind any more: the two values that were, an `EncryptedKey`'s `CarriedKeyName` and an `ECKeyValue`'s `dsig11:PublicKey`, are respectively not read at all and read through `decodeBoundedBase64`'s bounded `eachSibling` walk, so `context.go` carries no whole-subtree join and no aggregation reproduction. `TestDecryptObservesContextPerPublicKeyChild` (`context_test.go`) pins that walk the same way `TestDecryptObservesContextPerCipherValueChild` does, over the flat shape alone, since a `dsig11:PublicKey` walk refuses an element child outright and so has no descendant list to observe. The candidate loops of `decryptElement`/`decryptBytes` are identical in shape: each polls at the loop top and routes a failed candidate through `abort` before retaining it, so a cancellation is reported as the context error while `ErrDecryptionFailed` stays reserved for a genuine decrypt failure, and `Decrypt` and `DecryptBytes` return the same verdict for the same cancellation timing (`TestCancellationVerdictIsTheSameFromEveryTerminal`, `context_test.go`, drives one fixture through every terminal to pin that). The tree-mutation commit point in `encrypt` — `elem.Replace`/`removeChildren`/`elem.AddChild` — is deliberately neither a poll site nor an `abort` site: past it the caller's tree is being rewritten, and reporting a cancellation would say nothing happened when children are already unlinked. A nil `ctx` is treated as uncancelled (`contextErr` returns nil for it), so a terminal runs to completion instead of panicking. The parse stage is inside the rule, not beside it: every function from `parseEncryptedData` down takes `ctx` as its first parameter, walks children through `eachChildElement`/`eachSibling`, and routes its error returns through `abort`. Nothing else bounds how long that stage runs — a comment or processing-instruction child of a `CipherValue` is skipped as character data and charged against neither `MaxEncryptedKeyBytes` nor `MaxCipherValueBytes`, so the number of them a document may carry is unbounded, and the per-child poll is what answers a caller who cancels while they are read (`TestDecryptObservesContextPerCipherValueChild`, `context_test.go`, pins the per-child poll and the cancellation together, both measured against the same document, with no poll count written down). The boundary inside `parse.go` is trip count, not depth: `parseConcatKDFParams`' five-element field table is not a poll site because its trip count is five whatever the document says, and the leaf helpers a walk calls per child (`base64CharacterData`, `parseConcatKDFHexAttribute`, `ecdhCurveForURI`) take no `ctx` because the walk that calls them already polled and `abort`s what they return. `ParseEncryptedDataForTest` (`export_test.go`) parses under `context.Background()`, so a parser-only test sees the parse's own verdict
+- **ReferenceResolver** (`reference_resolver.go`) — single-method interface `ResolveReference(ctx, uri)
+  (io.ReadCloser, error)` supplying the octet STREAM of an EXTERNAL `xenc:CipherReference`, plus
+  **FSReferenceResolver(fsys, root)**, the only implementation shipped. `uri` is always the JOINED,
+  document-space URI, so a resolver never joins. The package reads the stream (`readBoundedReference`) under
+  the decrypt's remaining budget and the caller's ctx, and it closes every stream a resolver hands over: on
+  completion, over-budget, and cancellation alike, and equally when `ResolveReference` itself returns a stream
+  alongside an error — so the bound and the cancellation hold for a caller-written resolver too. Unlike
+  `xmldsig1.ReferenceResolver`, which returns `[]byte`, so one value does NOT satisfy both; NEITHER package
+  imports the other
+- Zero values are usable: `Encryptor{}`/`Decryptor{}` behave as `NewEncryptor()`/`NewDecryptor()` with nothing
+  configured (`config()` substitutes defaults for a nil `cfg`, mirroring `clone()` and xmldsig1's
+  `Signer.config()`), so a terminal returns `ErrMissingConfig`/`ErrMissingKey` instead of panicking
+- Every encryption and decryption terminal observes `ctx` before and between payload stages, and the rule is
+  uniform across all five: **a live cancellation wins over a stage's own error, and every input-sized walk
+  observes the context as it goes**. `context.go` owns both halves and holds the only two decision points, so
+  no site re-decides them. `abort(ctx, err)` returns the context's error when the context is done and exactly
+  `err` otherwise, and every error return of a ctx-carrying function goes through it — a stage runs to
+  completion once entered (a serialization, a session-key validation, a block encryption or decryption, a key
+  unwrap, a marshal, a plaintext parse), so a cancellation landing inside one is observable only after it
+  returns, and its own error would otherwise be reported as the reason the operation failed. Because a live
+  context returns `err` unchanged, CBC's collapse of every failure to `ErrDecryptionFailed` is untouched and
+  no padding oracle appears. `eachSibling(ctx, first, fn)` walks a node and its following siblings, polling
+  per node (chosen over a stride: the poll is one guarded read against per-node work that serializes a subtree
+  or steps a DOM, and a stride would make the bound depend on a constant nobody can derive from the input);
+  every walk whose length the caller, the ciphertext, or the document chooses runs through it —
+  `serializeChildren`' walk over the caller's subtree, `finishDecrypt`'s two shape walks over the parsed
+  plaintext (`nodeCollector.appendNode` for TypeContent, `appendElementNode` for TypeElement), every sibling
+  walk in `parse.go`. `eachChildElement(ctx, elem, fn)` (`context.go`) is the parse path's form of the same
+  walk: it hands `fn` each ELEMENT child and skips every other child kind, delegating the poll to
+  `eachSibling` so a walk that reads only elements still observes the context at the rate the document writes
+  children. No parse-path value is collected from every child kind any more: the two values that were, an
+  `EncryptedKey`'s `CarriedKeyName` and an `ECKeyValue`'s `dsig11:PublicKey`, are respectively not read at all
+  and read through `decodeBoundedBase64`'s bounded `eachSibling` walk, so `context.go` carries no
+  whole-subtree join and no aggregation reproduction. `TestDecryptObservesContextPerPublicKeyChild`
+  (`context_test.go`) pins that walk the same way `TestDecryptObservesContextPerCipherValueChild` does, over
+  the flat shape alone, since a `dsig11:PublicKey` walk refuses an element child outright and so has no
+  descendant list to observe. The candidate loops of `decryptElement`/`decryptBytes` are identical in shape:
+  each polls at the loop top and routes a failed candidate through `abort` before retaining it, so a
+  cancellation is reported as the context error while `ErrDecryptionFailed` stays reserved for a genuine
+  decrypt failure, and `Decrypt` and `DecryptBytes` return the same verdict for the same cancellation timing
+  (`TestCancellationVerdictIsTheSameFromEveryTerminal`, `context_test.go`, drives one fixture through every
+  terminal to pin that). The tree-mutation commit point in `encrypt` —
+  `elem.Replace`/`removeChildren`/`elem.AddChild` — is deliberately neither a poll site nor an `abort` site:
+  past it the caller's tree is being rewritten, and reporting a cancellation would say nothing happened when
+  children are already unlinked. A nil `ctx` is treated as uncancelled (`contextErr` returns nil for it), so a
+  terminal runs to completion instead of panicking. The parse stage is inside the rule, not beside it: every
+  function from `parseEncryptedData` down takes `ctx` as its first parameter, walks children through
+  `eachChildElement`/`eachSibling`, and routes its error returns through `abort`. Nothing else bounds how long
+  that stage runs — a comment or processing-instruction child of a `CipherValue` is skipped as character data
+  and charged against neither `MaxEncryptedKeyBytes` nor `MaxCipherValueBytes`, so the number of them a
+  document may carry is unbounded, and the per-child poll is what answers a caller who cancels while they are
+  read (`TestDecryptObservesContextPerCipherValueChild`, `context_test.go`, pins the per-child poll and the
+  cancellation together, both measured against the same document, with no poll count written down). The
+  boundary inside `parse.go` is trip count, not depth: `parseConcatKDFParams`' five-element field table is not
+  a poll site because its trip count is five whatever the document says, and the leaf helpers a walk calls per
+  child (`base64CharacterData`, `parseConcatKDFHexAttribute`, `ecdhCurveForURI`) take no `ctx` because the
+  walk that calls them already polled and `abort`s what they return. `ParseEncryptedDataForTest`
+  (`export_test.go`) parses under `context.Background()`, so a parser-only test sees the parse's own verdict
 - `Decrypt` does **not** mutate the tree (unlike `EncryptElement`/`EncryptContent`, which splice `EncryptedData` in): `elem` stays put and the returned nodes are detached; reinsertion is the caller's call
-- A **non-empty** `Decryptor.SessionKey` is an EARLY RETURN, not a key preference: `decryptElement`/`decryptBytes` use it and return before candidate selection, per-candidate validation, and per-candidate key resolution in `resolveSessionKeyFromEncryptedKey`. The `MaxEncryptedKeys` cap sits ahead of that return and still applies. Both builders gate on `len(sessionKey) > 0`, so an empty or nil slice counts as not set on either side
-- An `EncryptedData` with **no `EncryptionMethod`** decrypts only when the caller states the block algorithm out of band with `Decryptor.BlockAlgorithm(uri)` — W3C xmlenc-core1 §3.1/§3.2 leave the element optional and require the recipient to know the algorithm already, and §4.4 step 1 admits obtaining it out of band. `resolveDecryptBlockAlgorithm` (`xmlenc1.go`) is the single resolution and both `decryptElement` and `decryptBytes` call it ahead of everything that reads the algorithm. The match is STRICT, so the setter can only narrow what a decrypt accepts: absent + unset → `ErrMalformedEncrypted` naming the setter; absent + set → the caller's URI; present + unset → the document's URI; present + set + different → `ErrConflictingBlockAlgorithm` naming both. A document never overrides a caller who stated the algorithm, which would be algorithm confusion. A present `EncryptionMethod` always carries a non-empty `Algorithm` — `parseEncryptionMethod` (`parse.go`) refuses an empty one as `ErrMalformedEncrypted` at the parse gate, ahead of any resolution — so the caller's URI is only ever matched against a real declaration. The resolved URI is the one bound everywhere downstream: the CBC opt-in gate, the AEAD additional data of the two 2001-namespace GCM identifiers, `validateKeySize` on the session key, and the AES key-wrap ciphertext length
-- `EncryptedKey.Recipient` is **parse-only** — populated when reading, never serialized when encrypting. `EncryptedKey.CarriedKeyName` is declared as part of the parsed shape and filled by nothing: `parseEncryptedKey` steps over the `xenc:CarriedKeyName` element, and encrypting never writes one. No decrypt path consults the name and no exported function or method takes or returns an `EncryptedKey`, so no caller can observe it; reading it would cost an unbounded copy of attacker-supplied metadata, since the name is joined from every child at every depth that join reaches and charged against neither `MaxEncryptedKeyBytes` nor `MaxCipherValueBytes`, so a document may spread one over as many CDATA sections as it likes and defeat the XML parser's per-node content cap. `TestCarriedKeyNameIsNotRead` (`parse_test.go`) pins both halves: a document carrying one still parses (the element is skipped, the `EncryptedKey` around it is still a candidate, the field stays zero) and still decrypts, and a 4 MiB name costs a SUCCESSFUL `SessionKey` decrypt no more than the same document without one — measured as a `TotalAlloc` delta across the decrypt of an already-parsed document
-- Parse enforces at-most-one cardinality on every xenc/dsig11 schema singleton it reads — `EncryptionMethod` and `CipherData` per `EncryptedData`/`EncryptedKey`, `ds:KeyInfo` per `EncryptedType`, and `NamedCurve`/`PublicKey` per `dsig11:ECKeyValue` — rejecting a second occurrence with `ErrMalformedEncrypted` (`parse.go`), so a duplicate can never silently overwrite the first
-- `Decryptor.MaxEncryptedKeys(n)` caps trial-decrypted `<EncryptedKey>` candidates (DoS guard): zero → `DefaultMaxEncryptedKeys` (100), negative → unlimited; over-cap fails with `ErrTooManyEncryptedKeys` before the excess candidate is appended to the retained list or any candidate crypto runs. `parseKeyInfoForEncryption` enforces the effective limit while parsing, before the excess candidate's structure is validated or its ciphertext is charged to the `MaxEncryptedKeyBytes` budget; `checkEncryptedKeyCap` is the shared error/count implementation. Both `decryptElement` and `decryptBytes` pass the cap into parsing before consulting configured keys, so it holds in every key configuration. Per-candidate branch dispatch — which of the three decrypt keys a candidate uses and what it costs — is implemented in `resolveSessionKeyFromEncryptedKey` (ECDH-ES in `decryptECDHSessionKey`) and stated by the `Decryptor.MaxEncryptedKeys` godoc. The candidate loop's own `ctx` observation is stated by the cancellation bullet above
-- `Decryptor.MaxEncryptedKeyBytes(n)` caps the TOTAL decoded `<EncryptedKey>` ciphertext of one EncryptedData (memory-amplification guard): zero → `DefaultMaxEncryptedKeyBytes` (64 KiB), negative → unlimited; over-budget fails with `ErrEncryptedKeyBytesExceeded`. It is a separate sentinel from `ErrTooManyEncryptedKeys` because the two bound different things (a count vs a size) and different setters raise them. The budget is threaded into the parse path — `newEncryptedKeyBudget(cfg)` in `decryptElement`/`decryptBytes` → `parseEncryptedData` → `parseKeyInfoForEncryption` → `parseEncryptedKey` → `parseCipherData` — and `decodeCipherValue` (`parse.go`) charges `encryptedKeyBudget.charge` (`xmlenc1.go`) BEFORE anything is built from the value, so an over-budget CipherValue is rejected without being assembled or decoded (the base64 text itself is already in the caller's DOM). It walks the CipherValue's children twice: an `xmlbase64.Counter` counts them, and only after the charge is accepted does a second walk build the whitespace-stripped characters through `xmlbase64.AppendStripped` and decode them with `base64.StdEncoding.Decode` into a buffer sized at the counted `DecodedLen()` — the charged count itself, and not `encoding/base64`'s own padding-blind `DecodedLen`. The stripped characters are handed to the decoder as bytes, so nothing copies them into a string. The lexical text is never joined into one string — xs:base64Binary allows XML whitespace between characters and the value may be spread over any number of text and CDATA children, so the lexical length is attacker-chosen and unrelated to the charge; what is held is bounded by the budget (stripped characters ≤ 4/3 of it, decoded bytes exactly the charged count) and the peak is the largest single child. `Counter` (`internal/xmlbase64`) owns the count and fails closed: exact for base64 the decoder accepts, and never below what a rejected decode allocates — it deducts padding only from a value whose whole lexical shape is otherwise decodable, so neither malformed padding nor a body outside the base64 alphabet can walk a value past the budget. It carries the character count, the padding count, and the decodable-shape flag ACROSS children, so the count is that of the concatenation — counting each child alone and summing would report 0 for every sub-quantum child and bypass the budget entirely. `parseCipherData` receives `payloadCipherValueBudget` for the EncryptedData's own CipherValue, while EncryptedKey ciphertext uses `encryptedKeyBudget`. The budget is charged while parsing for retained candidates only; the candidate cap rejects an excess candidate before the budget, and both checks hold ahead of the `SessionKey` early return
-- `xenc:OAEPparams` is bounded by `maxOAEPParamsBytes` (1024, `parse.go`), which owns the rationale; over-limit fails with an error wrapping `ErrMalformedEncrypted`. `decodeBoundedBase64(ctx, elem, valueName, maxBytes, invalidPhrase)` (`parse.go`) is the single implementation for every xs:base64Binary value this package holds to a FIXED ceiling — the OAEPparams label and an ECDH-ES `dsig11:PublicKey` — and runs from `parseEncryptionMethod`, so it covers BOTH OAEPparams call sites — the `EncryptedData`'s own `EncryptionMethod` (whose decoded label nothing ever reads) and each `EncryptedKey`'s — and both are reached while the document is read, ahead of key resolution and the `SessionKey` early return; an EncryptedKey beyond the candidate cap is not retained. The walk is leaf-only and single-pass. `base64CharacterData` (`parse.go`) classifies each child through `helium.AsNode`: `*helium.Text`/`*helium.CDATASection` contribute their content; a `*helium.EntityRef` contributes ONE hop — its `FirstChild()` asserted to `*helium.Entity`, whose `Content()` is a leaf accessor returning the declared replacement literal without recursing (a CHILDLESS `EntityRef` contributes NO characters and no error: per XML 1.0 "Entity Declared" an undeclared general entity is only fatal under `standalone="yes"` or with neither an external subset nor a parameter-entity reference, so a non-validating parse of a document with either one keeps the reference as an `EntityRef` with no `Entity` under it — a normal parser output, and one `c14n` also treats as empty since it canonicalizes an `EntityRef` by walking its children; an `EntityRef` whose first child is NON-NIL and not an `*Entity` is reachable only in a caller-built tree and is refused; and the `Entity`'s `NextSibling()` is never followed because it is the next DTD declaration, not part of the value), so an entity whose replacement is itself a reference or markup contributes that literal text and the `Counter` marks the value undecodable; `*helium.Comment`/`*helium.ProcessingInstruction` are skipped (reading a comment would splice its text into the base64); and ANY other child kind is refused with `ErrMalformedEncrypted` — an element answers `Content()` by aggregating its whole subtree, so reading one would spend that subtree's text before a limit measured in decoded octets could look at it, and a subtree of whitespace decodes to nothing so the limit would never fire. `decodeBoundedBase64` reads each child exactly once, folding it into an `xmlbase64.Counter` and appending the whitespace-stripped characters through `xmlbase64.AppendStripped`, and stops as soon as the kept characters pass its local char ceiling `(maxBytes+2)/3*4` (the most any acceptable value can hold, and what sizes the character buffer — stopping there is always early, never a different verdict, and the exact `Counter.DecodedLen` test still runs after the walk). The decode is `base64.StdEncoding.Decode` into a buffer sized at that counted `DecodedLen()`, so the stripped characters are never copied into a string and the buffer is exact for a value the decoder accepts, sized by that count instead of `encoding/base64`'s padding-blind estimate. So the lexical text is never joined into one string and what the parse RETAINS is sized by the limit alone. `valueName` names the value in the size and child-kind refusals and `invalidPhrase` in the decoder's, so each caller's wording stays its own (`TestBoundedBase64ErrorsNameTheirOwnValue`, `parse_test.go`, pins that for both callers across all three refusals). What is NOT bounded is the copy `Content()` hands out per child: a DOM offers no read-only view of a node's bytes, so weighing a value costs one copy of its lexical text. That copy is the floor and the walk pays it exactly once — total allocation is one times the lexical length plus fixed overhead, which `TestOAEPParamsAllocation` (`parse_test.go`) pins. The limit is a fixed internal constant with no public knob and is deliberately NOT the `MaxEncryptedKeyBytes` budget: an `EncryptedData`-side label is not `EncryptedKey` ciphertext, and charging it would change what that setter documents itself as covering. Neither existing knob substitutes — the candidate count is checked before each append, and the XML parser's `MaxNodeContentSize` bounds one indivisible content run, which CDATA-splitting defeats. The limit is a POLICY ceiling, not a conformance boundary — xenc-schema types `OAEPparams` as `xs:base64Binary` with no length facet and RFC 8017 bounds the label only at its hash's input limit, so a larger label is conforming and rejected anyway — and it is symmetric: `resolveEncryptConfig` (`xmlenc1.go`) charges `Encryptor.OAEPParams` against the same `maxOAEPParamsBytes` and fails with an error wrapping `ErrEncryptionFailed`, gated on `hasKeyTransport` because key transport is the only mechanism that writes a label, so a label over the limit is neither written nor parsed back and no self-produced ciphertext is un-decryptable. `TestEncryptorOAEPParamsBound` (`keytransport_test.go`) pins the encrypt-side boundary against `MaxOAEPParamsBytesForTest`
-- `Decryptor.MaxCipherValueBytes(n)` caps the decoded ciphertext in the EncryptedData payload's `CipherValue`, independently from the cumulative `EncryptedKey` ciphertext budget: zero selects `DefaultMaxCipherValueBytes` (10 MiB), and a negative value removes the cap. `parseEncryptedData` sends the payload through its own budget before it is assembled or decoded, so split text/CDATA nodes cannot bypass it. An over-budget payload fails with `ErrCipherValueBytesExceeded` before block decryption, candidate selection, or a `SessionKey` return.
-- AES key unwrap is length-bound: `aesKeyUnwrap(kek, ciphertext, keySize)` requires `len(ciphertext) == keySize+8` exactly (RFC 3394 §2.2.2), rejecting with `ErrKeyUnwrapFailed` before the six unwrap rounds. `keySize` is the session-key length of the declared block algorithm, resolved once per decrypt via `keySizeForAlgorithm(paramBlockAlgorithm, alg)` ahead of the candidate loop and threaded through `resolveSessionKeyFromEncryptedKey` into both the plain key-wrap and the ECDH-ES (`decryptECDHSessionKey`) branches. The post-recovery `validateKeySize` in `blockDecrypt` still binds a key that arrived by RSA key transport, whose length is not visible until the private-key decrypt
-- Block encryption: AES-128/256-CBC, XML Encryption 1.1 AES-128/192/256-GCM (`AES128GCM11`/`AES192GCM11`/`AES256GCM11`), and AES-128/256-GCM in the 2001 xmlenc namespace (`AES128GCM`/`AES256GCM`). The 1.1 GCM form uses the standard IV || ciphertext || authentication-tag encoding without additional authenticated data, which is the only AES-GCM xmlenc-core1 §5.2 defines. The two 2001-namespace GCM identifiers are defined by NO XML Security specification, and `blockEncrypt`/`blockDecrypt` bind the `EncryptionMethod/@Algorithm` URI into the AEAD additional authenticated data for those two alone — a package-specific measure against an algorithm substitution on the wire, which no specification requires, and a second reason a document carrying one decrypts here and nowhere else. Both stay exported and reachable through `Encryptor.BlockAlgorithm`, and `Decryptor` accepts them with that AAD binding, so every document this package has emitted still decrypts
-- Secure by default: unset `BlockAlgorithm` → `DefaultBlockAlgorithm`, which is `AES256GCM11` — authenticated AES-256-GCM under the standard XML Encryption 1.1 identifier, so what a caller who configures nothing emits is what a conforming peer recognizes. Selecting a CBC block algorithm for **encryption** requires `Encryptor.AllowLegacyCBC(true)`, else `ErrCBCEncryptionRequiresOptIn`. **Decryption** of CBC requires `Decryptor.AllowUnauthenticatedCBC(true)`, else `ErrCBCRequiresOptIn`
-- CBC unpadding follows xmlenc-core1 §5.2.1 by default: the final octet names the padding length N, `unpadConstantTime` (`block.go`) checks only that N names between one octet and one whole block, and the N-1 octets ahead of it are ARBITRARY and unread. PKCS#7 (every padding octet equals N) is a strict subset, selected by `Decryptor.StrictPKCS7Padding(true)` and carried down the decrypt path as the `cbcPadding` policy type (`cbcPaddingXMLEnc` is the zero value, `cbcPaddingPKCS7` the opt-in) through `decryptCipherValue`/`finishDecrypt` → `blockDecrypt` → `decryptCBC`. The strict rule refuses conforming third-party ciphertext, so it suits only a caller controlling both ends; `pkcs7Pad` writes all-N padding, valid under both, so a document this package produced decrypts either way. A refused padding reports the same `ErrDecryptionFailed` as every other CBC failure. `TestInteropRetrievalMethod` (`interop_test.go`) decrypts the merlin `aes256-cbc` vector end to end as the third-party evidence, and pins its refusal under the opt-in
-- Three mechanisms protect the session key — RSA key transport (`KeyTransportAlgorithm` + `RecipientPublicKey`), ECDH-ES key agreement (`KeyWrapAlgorithm` + `RecipientECPublicKey`), AES key wrap (`KeyWrapAlgorithm` + `KeyEncryptionKey`) — and `conflictingKeyProtection` (`xmlenc1.go`) rejects any pair of them with `ErrConflictingKeyConfig`, since `encryptPlaintext` emits one `<EncryptedKey>` and would silently discard the loser of its transport → agreement → wrap dispatch. The two transport pairs name both algorithm URIs; the agreement-vs-wrap pair names the two setters instead, because both mechanisms share the same `KeyWrapAlgorithm` URI. A `SessionKey` alongside a single mechanism is fine — it supplies the key that mechanism protects
-- `resolveEncryptConfig` decides the payload-independent parts of an `Encryptor`'s configuration — the effective block algorithm and its supported-URI check, the CBC opt-in, presence of a key source, the key-protection conflicts, the RSA-OAEP URI/digest/MGF checks, the RSA-OAEP label size, the key-wrap URI (`validateKeyWrapAlgorithm`, charged to whichever of key agreement and key wrap is in use), the ECDH-ES ConcatKDF parameters (`validateEncryptConcatKDFParams` (`key_agreement.go`): the OtherInfo budget then the digest URI, over the set `effectiveKDFParams` returns, so an empty `DigestMethod` is weighed as the SHA-256 default with no OtherInfo and the caller's discarded fields are never measured), and the ECDH-ES recipient key — and every entry point calls it before any payload work, so a plaintext that fails to serialize never masks those checks, and none of them costs anything proportional to the payload (`TestEncryptConfigRejectionAllocatesNoPayload`, `xmlenc1_test.go`). Session-key length is bound later, inside `encryptPlaintext`
-- Key transport: RSA-OAEP (1.0 + 1.1 with configurable SHA-1/224/256/384/512 digest and MGF; SHA-224 uses the XMLDSig-more digest URI and the XML Encryption 1.1 `mgf1sha224` URI; the OAEP label digest and the MGF1 hash may differ, via `rsa.EncryptOAEPWithOptions`/`OAEPOptions` — requires Go ≥ 1.26)
-- Key wrapping: AES-128/192/256-KeyWrap (RFC 3394). `validateKeyWrapAlgorithm` (`keywrap.go`) is the encrypt-side gate for `Encryptor.KeyWrapAlgorithm` and holds BOTH mechanisms that read it — key agreement, which derives the KEK, and key wrap, which is handed one — to those three URIs, since either declares that URI on the `EncryptedKey` it emits while protecting the session key with `aesKeyWrap`. Anything else, a block-cipher URI above all, would declare an algorithm that did not produce the `CipherValue` — an RFC 3394 wrap under an AES-GCM identifier, which nothing reads back, this package included — and the KEK-length binding cannot stand in for the check, because `keySizeForAlgorithm` answers a length for the block-cipher URIs too. `resolveEncryptConfig` applies it ahead of any payload work and `encryptECDHSessionKey` applies it again on its own way in
-- Key agreement: XML Encryption 1.1 ECDH-ES on P-256, P-384, and P-521 with ConcatKDF using SHA-1/224/256/384/512, in **both** directions — `Decryptor.ECPrivateKey` decrypts, `Encryptor.RecipientECPublicKey` + `KeyWrapAlgorithm` encrypt (the KEK is derived, so `KeyEncryptionKey` belongs to the AES key wrap mechanism). SHA-224 uses the XMLDSig-more digest URI. Each encryption generates a fresh ephemeral key pair; `Encryptor.KeyDerivationParams` sets the ConcatKDF parameters (`effectiveKDFParams`) and its godoc owns the empty-`DigestMethod` fallback. `resolveEncryptConfig` (`xmlenc1.go`) decides the key protection before any entry point serializes plaintext, generates a session key, or block encrypts, so an unusable recipient key costs nothing proportional to the payload; `ecdhRecipientKey` is its single gate for the recipient key and rejects a key with unset coordinates (which `crypto/ecdsa` would otherwise dereference), a curve with no `crypto/ecdh` form, and a curve with no `dsig11:NamedCurve` URI. An EC public key without a `KeyWrapAlgorithm` does not select key agreement, so its curve is never resolved. `serialize.go` emits the `xenc:AgreementMethod` subtree (`KeyDerivationMethod`/`ConcatKDFParams`/`OriginatorKeyInfo` → `ds:KeyValue` → `dsig11:ECKeyValue`); ConcatKDF OtherInfo attributes are hexBinary bit strings whose first octet is the unused-bit count
-- The five ConcatKDF OtherInfo fields are capped **cumulatively** at `maxConcatKDFOtherInfoBytes` (4096, `key_agreement.go`), which owns the rationale; over-budget parameters fail with an error wrapping `ErrMalformedEncrypted`. `checkConcatKDFOtherInfoBudget` is the single implementation and runs at four points, each ahead of any work sized by the fields: `parseConcatKDFParams` applies it to wire data at the first point that holds all five fields, so an oversized document never reaches ECDH or key unwrap; `resolveEncryptConfig` applies it through `validateEncryptConcatKDFParams` to an `Encryptor`'s effective set, so an oversized set is refused before the plaintext is serialized or block encrypted and the error carries `ErrEncryptionFailed` alongside the shared `ErrMalformedEncrypted`; `deriveConcatKDF` applies it before resolving the digest, so a set that is both over budget and names an unsupported digest still fails on the size; and `concatKDFOtherInfo` applies it immediately before packing, which is what makes the limit hold for a caller-built DOM or a caller-built `ConcatKDFParams` that this package never parsed. The one parameter set never measured is an `Encryptor`'s with an empty `DigestMethod`: `effectiveKDFParams` replaces it wholesale with the SHA-256 default carrying empty OtherInfo, so the caller's fields are discarded before any derivation instead of checked, and the encryption succeeds with no OtherInfo on the wire (`ConcatKDFParams`' godoc states this carve-out). The check measures each field against the budget REMAINING instead of summing the five, because the fields may all alias one slice and their sum can wrap `int` on a 32-bit build; the packing's own `len(value)*8`/`totalBits` arithmetic is wrap-free only because the check runs ahead of it. `parseConcatKDFHexAttribute` additionally rules an attribute out from its hex length alone, before `hex.DecodeString` allocates for it, since one field can never exceed the whole set's budget. Nothing else in the package bounds these fields — the XML parser's `MaxNodeContentSize` is a caller-adjustable attribute-value cap, not a ConcatKDF limit
-- `concatKDFOtherInfo` packs the five bit strings into the single bit string ConcatKDF hashes. A field landing on an octet boundary is moved with `copy()` plus at most one masked trailing octet; a field straddling a boundary (only reachable when some earlier field's bit length is not a multiple of eight) falls back to moving one bit at a time, bounded by the OtherInfo budget. Both paths produce identical bytes — `TestConcatKDFOtherInfoMatchesPerBitPacking` pins the production packing against a verbatim per-bit reference over fixed and randomized shapes, because a divergence here silently changes the derived KEK and breaks interoperability
-- Key sizes are bound to the declared algorithm URI on encrypt and decrypt (incl. after unwrap/key transport); mismatch → `KeySizeError`. On encrypt this binds the key actually used: a **non-empty** `Encryptor.SessionKey` of the wrong length is rejected, while an empty or nil one is replaced by a freshly generated key of the right length and never reaches the check (with no key-protection mechanism configured at all, that case is `ErrMissingConfig`). `KeySizeError`'s `Key` field names the offending key ("session key"/"key-encryption key"). `UnsupportedAlgorithmError.Parameter` likewise names the slot that rejected the URI ("block algorithm", "MGF algorithm", ...); both are diagnostic text — match on the type and `Algorithm`
-- `ErrUnsupportedKeyDerivation` (`errors.go`) is raised by `noCandidateError` (`xmlenc1.go`, the single wording site both decrypt terminals share) when key resolution found NO candidate and `encryptedData.offersDerivedKey` is set — i.e. the `ds:KeyInfo` offered the session key only through an `xenc11:DerivedKey`, inline or named by a `ds:RetrievalMethod` `Type` of `#DerivedKey`. It is deliberately not `ErrMissingKey`: no key the caller supplies can decrypt such a document, so the error must name the missing facility instead of sending the caller to audit its key configuration. A document that ALSO carries a usable `xenc:EncryptedKey` decrypts under it (the flag is consulted only on an empty candidate list), and a pre-shared `Decryptor.SessionKey` never reaches it at all
-- `UnsupportedAlgorithmError` and `KeySizeError` each carry a leading blank `_ struct{}` field, so an unkeyed composite literal cannot compile from another package (`implicit assignment to unexported field _`). That is what lets either field set GROW without breaking a caller: nobody can have written the positional form a new field would invalidate. Keyed literals, field reads, and `errors.As` recovery are unaffected; `api_freeze_test.go` pins the guard structurally, so it holds however the field is spelled
-- All three encrypt terminals report a nil operand identically: `ErrEncryptionFailed` wrapped FIRST, then `helium.ErrNilNode` (both with `%w`), so a caller matching the operation sentinel catches it whichever entry point it called and one matching `ErrNilNode` still learns which operand was nil. `EncryptBytes` names the missing document in its message; `encrypt` (shared by `EncryptElement`/`EncryptContent`) names the missing element
-- Error chains: `ErrMissingKey` names the key kind the candidate needs, the algorithm URI the document declared for it (the `EncryptionMethod` URI for RSA key transport and AES key wrap, the `AgreementMethod` URI for ECDH-ES key agreement), and the `Decryptor` setter that supplies the key; `ErrTooManyEncryptedKeys` carries the candidate count and effective limit; a failed AES key unwrap wraps `ErrKeyUnwrapFailed` in `ErrDecryptionFailed`, matching the RSA key-transport path. There is no padding sentinel: CBC collapses nearly every failure to `ErrDecryptionFailed`, message included, so no padding oracle exists; the one exception is a wrong-length pre-shared `Decryptor.SessionKey`, whose length the caller configures and an attacker cannot influence, so a mismatch is reported as a bare `KeySizeError` instead
-- Multi-recipient: `EncryptedData.EncryptedKeys []*EncryptedKey` holds one EncryptedKey per recipient; absent a session key, decrypt tries each candidate through full block decryption + plaintext validation (a bogus prepended key cannot mask the real one). `EncryptedData.EncryptedKey` is the **deprecated** single-key field — `EncryptedKeys` wins when non-empty, else the single field is treated as a one-element list; parse populates both
-- An ECDH-ES originator key's `dsig11:PublicKey` is bounded by `maxECPublicKeyBytes` (133, `parse.go`), which owns the rationale; over-limit fails with an error wrapping `ErrMalformedEncrypted`. `decodeBoundedBase64` (`parse.go`, the same bounded walk the OAEPparams label goes through) reads it, called from `parseECKeyValue` with value name `ECKeyValue PublicKey` and decode-error phrase `invalid ECKeyValue base64`, so it is reached while the document is read — ahead of the key resolution and the `SessionKey` early return; an `EncryptedKey` beyond the candidate cap is never parsed, so its `dsig11:PublicKey` is never read. Unlike the OAEPparams and ConcatKDF ceilings the value is NOT a policy choice: `dsig11:PublicKey` carries a SEC1 uncompressed point, 65 octets on P-256, 97 on P-384 and 133 on P-521, and `crypto/ecdh` refuses the compressed form and every over-length input on all three, so an over-133-octet value is rejected by `curve.NewPublicKey` whatever it holds and the limit only moves that verdict ahead of materializing it. It is the maximum across ALL THREE curves, and the selected curve's own size cannot serve, because `dsig11:ECKeyValue` puts no order on its children: `dsig11:NamedCurve` may follow `dsig11:PublicKey`, and a document with no `NamedCurve` at all still has its `PublicKey` read before the missing-curve error, so at the moment the value is weighed there may be no curve to weigh it by. The walk is leaf-only and single-pass through `eachSibling` over EVERY child kind, classifying children with `base64CharacterData`, folding each into an `xmlbase64.Counter`, appending through `xmlbase64.AppendStripped`, stopping as soon as the kept characters pass the char ceiling `(maxECPublicKeyBytes+2)/3*4` = 180 and applying the exact `Counter.DecodedLen` test afterwards. `internal/xmlbase64.DecodeElement` is deliberately NOT used: it takes no `context.Context` and would drop the per-child cancellation poll. So the lexical text is never joined into one string and what the parse retains is sized by the limit alone; the one cost still following the document is the per-child `Content()` copy, paid exactly once, which `TestECPublicKeyAllocation` (`parse_test.go`) pins at 1x for both a refused and an accepted value. `TestECPublicKeyBound` covers the three curves (including the 133-byte P-521 boundary), both child orders, whitespace-wrapped and CDATA-split values, and the two child-kind rules
-- `CipherValue`, `OAEPparams`, and an ECDH-ES `dsig11:PublicKey` use `base64CharacterData` (`parse.go`): text, CDATA, and one-hop entity-reference data contribute to the base64 value; comments and processing instructions are ignored; every other child, including an element, is rejected before its subtree can be read.
-- Same-document `ds:RetrievalMethod` (§3.5, REQUIRED) is implemented and always on: `parseKeyInfoForEncryption` (`parse.go`) takes an `xenc:EncryptedKey` child and a `ds:RetrievalMethod` child in DOCUMENT ORDER, so a reference-supplied candidate lands at the reference's position in `EncryptedKeys`, wherever that falls among the inline ones (the list is tried in order, so ordering decides which key a multi-candidate document is decrypted under). `parseRetrievalMethod` (`parse.go`) branches on `@Type` FIRST: `typeDerivedKey` (§3.5.2) and any foreign URI are stepped over with no error, no candidate slot, and no URI lookup, and `typeDerivedKey` additionally sets `encryptedData.offersDerivedKey`; `TypeEncryptedKey` must name an `xenc:EncryptedKey` and naming anything else is `ErrMalformedEncrypted`; an absent `@Type` resolves and then uses the target only if it IS an `xenc:EncryptedKey`. `retainEncryptedKey` (`parse.go`) is the SINGLE retention point both branches call — the inline `xenc:EncryptedKey` child and a resolved `ds:RetrievalMethod` target alike — and its three steps run in a fixed order: the visited-set dedup FIRST, then `checkEncryptedKeyCap`, then `parseEncryptedKey`. So an element a document offers BOTH ways, in either order, is one candidate: the peak charge equals the final candidate count exactly, a repeat offer charges nothing and is never trial-decrypted twice, and a reference that retains nothing costs one probe of the id index built once per decrypt. Resolution itself is `reference.go`: `refScope` carries the root, the base URI, and a lazily built id index, and nothing about what has been made of an answer — the visited set of taken candidates sits on `parseState` (`parse.go`), whose `markVisited` `retainEncryptedKey` alone calls; `referenceURIForm` recognizes the four same-document forms XMLDSig core §4.4.3.2-3 defines (`""`, `#id`, `#xpointer(/)`, `#xpointer(id('id'))`) and fails everything else closed; `resolveSameDocument` builds the index once per decrypt through `domutil.BuildIDIndex` (whose ctx-observing walk polls per node and whose FROZEN ID-name rule xmldsig1 shares, so the two cannot disagree about which element carries an id), returning `ErrReferenceNotFound` on zero matches and `ErrAmbiguousReference` on more than one — XML Signature Wrapping applied to encryption. The scope root is the TOPMOST ELEMENT ancestor of the `EncryptedData`, not `OwnerDocument().DocumentElement()`, so a detached `EncryptedData` resolves within its own subtree. A non-same-document URI is `ErrReferenceNotFound` with no setting to lift it, since §3.5 mandates only the same-document form. The `visited` set is DEDUPLICATION for the many ways one element can be offered — the several references §3.5.3 permits, and a reference plus the inline child it names in either order, all yielding one candidate, charged and trial-decrypted once — and is NOT a loop guard: `parseEncryptedKey` reads only `EncryptionMethod`, `CipherData`, and `ds:KeyInfo`→`AgreementMethod` and never looks for a `RetrievalMethod`, so resolution is one step deep BY CONSTRUCTION and §6.5's `A → B → A` cycle is not expressible. All of this runs while the document is READ, so it precedes the `Decryptor.SessionKey` early return: a pre-shared session key does not decrypt past a refused reference, though a skipped foreign `@Type` costs it nothing. `Encryptor` emits no `ds:RetrievalMethod`; §3.5 requires support for reading one, not for writing one
-- `xenc:CipherReference` (§3.3.1, REQUIRED) is implemented. `parseCipherData` (`parse.go`) settles the CipherData choice cardinality in a FIRST walk that reads no member, and only then turns the single member it found into octets — so a document offering two members is refused for offering two whatever they hold, and a schema-invalid document never turns into a dereference. `resolveCipherReference` (`reference.go`) owns the four outcomes: an ABSENT `@URI` is `ErrMalformedEncrypted` (the schema marks it required) while a PRESENT-and-empty one is the valid null URI; a same-document URI with no transform converts the node-set to octets by Canonical XML 1.0 without comments (`canonicalizeCipherReferenceNodeSet`, writing through `newBudgetWriter`, which bounds canonical OUTPUT OCTETS and never the work producing them — c14n's own per-element namespace-visibility scan costs elements times in-scope declarations and can run long while emitting almost nothing — and which also polls the caller's context on every write, the only place a WHOLE-DOCUMENT form (`URI=""` or `#xpointer(/)`) ever observes cancellation, since that form has no node-set collector stage ahead of it; the budget is charged once, with the final total, after the write completes); a same-document URI whose first transform is `#base64` hands the target to `decodeCipherReferenceNodeSet` unchanged; and any other URI is external. The list is a pipeline — the first transform consumes the dereferenced value and every one after it decodes the octets the one before produced (`decodeBase64Octets`, uncharged because base64 only shrinks what was already charged). The whole-document forms naming the document element canonicalize the DOCUMENT (top-level PIs included, per xmldsig-core1 §4.4.3.2); every other form canonicalizes the named element's subtree as the node-set `appendSubtreeNodes` builds (node, in-scope namespace axis, attribute axis, `helium.Children` descent). The result is NEVER re-parsed as a document, so a self-naming reference is inert, terminating at whatever those octets decrypt to, and there is no depth to bound. `parseCipherReferenceTransforms` accepts at most one `xenc:Transforms` (the xenc namespace on the wrapper, `ds:Transform` children), caps the list at `maxCipherReferenceTransforms` (4) as it collects, and validates EVERY declared algorithm before any is executed, accepting only `NamespaceDSig + "base64"` — an unsupported one is `ErrMalformedEncrypted` wrapping an `*UnsupportedAlgorithmError` with `Parameter: paramCipherReferenceTransform`. Refusing XPath and XSLT is conforming: §3.3.1 marks the Transform feature and the particular algorithms OPTIONAL, and either would evaluate a document-chosen expression over an unauthenticated document. An external URI is joined with `helium.ResolveURI` (`joinReferenceURI`) against the base in force AT THE `CipherReference` ELEMENT — `helium.NodeGetBase(elem.OwnerDocument(), elem)`, so `xml:base` between the EncryptedData and the reference counts and a file-parsed document contributes its own URL — and dereferenced through `Decryptor.CipherReferenceResolver`; with none configured it is `ErrReferenceNotFound`, the DEFAULT, because §3.3.1 imports xmldsig-core1's model where §4.4.3.1 makes HTTP dereferencing RECOMMENDED while §4.4.3.2/§4.4.3.3 make the same-document forms MUSTs. Resolution returns a NON-NIL slice even for zero octets, because `parseEncryptedData` reads a nil `CipherValue` as "no CipherData at all". All of it runs while the document is READ, so it precedes block-algorithm resolution, the AES-CBC opt-in gate, and the `SessionKey` early return. `serialize.go` emits only a `CipherValue`; §3.3.1 requires support for reading a `CipherReference`, not for writing one. `parseKeyInfoForEncryption` drops the remaining `ds:KeyInfo` children with no error: `ds:KeyName` (§3.5, RECOMMENDED), `xenc11:DerivedKey` (§3.5.2), which it records on `encryptedData.offersDerivedKey`, and an `xenc:AgreementMethod` in the `EncryptedData`-level `ds:KeyInfo` position §5.6 defines for it — §3.5 marks that OPTIONAL, the same grade as `ds:KeyValue`, so an `EncryptedData` offering its session key only that way carries no candidate and fails with `ErrMissingKey`. The `EncryptedKey`-level position IS read, by `parseAgreementMethodForKeyInfo`, which is how this package performs ECDH-ES key agreement
-<!-- Refutation of a review finding that this bullet still lists only completion, over-budget and cancellation as the close paths, omitting the stream-plus-error case. Checked against this file's bytes at this commit: the bullet below reads "the stream is CLOSED on completion, over-budget, and cancellation alike, and equally when `ResolveReference` itself returns a stream alongside an error", the same clause the ReferenceResolver summary bullet earlier in this section and the `ReferenceResolver` godoc in `xmlenc1/reference_resolver.go` carry, so no stale three-path statement exists here. `grep -n '^- .*alongside an error' .claude/docs/packages.md` prints exactly those two xmlenc1 bullets and nothing else; the `^- ` anchor confines the match to bullet lines, so this comment's own quotation of the clause is not among the results and the count cannot be changed by the comment stating it. The remaining ReferenceResolver close text earlier in this file belongs to `xmldsig1`, whose resolver returns `[]byte` and has no stream to close. -->
-- `ReferenceResolver` + `FSReferenceResolver` (`reference_resolver.go`) inherit `xmldsig1`'s rejection rules and are consulted ONLY for an external CipherReference URI: a URI carrying an RFC 3986 scheme (`uriHasScheme`, Windows drive letter included), a leftover fragment, or a path escaping the root after `path.Clean` + `fs.ValidPath` (`fsNameFromURI`) is refused, every refusal wrapping `ErrReferenceNotFound`. NO HTTP resolver ships — network dereferencing is SSRF and availability risk the caller must own. `FSReferenceResolver(fsys, root)` takes a declared document-space root: `relativizeToRoot` strips it (matched at a segment boundary, with a trailing slash) so an IN-root absolute URI resolves as the remainder below it, while a URI outside the root passes through unchanged and then meets the same containment checks an empty root applies — declaring a root only ever widens, and only within the named space. There is no new size constant: `readBoundedReference` reads `remaining()+1` bytes off the decrypt's own budget (`MaxCipherValueBytes` for a payload reference, `MaxEncryptedKeyBytes` for a key one), so an over-budget resource is never buffered in full and the budget's own sentinel refuses it. The read runs on a goroutine selected against `ctx.Done()` (a blocked `Read` cannot be polled out of) with a per-Read ctx poll, and the stream is CLOSED on completion, over-budget, and cancellation alike, and equally when `ResolveReference` itself returns a stream alongside an error — closing is what releases a blocked read. That makes the bound and the cancellation properties of the INTERFACE, so they hold for any resolver a caller writes; what the package cannot constrain is a resolver buffering internally or blocking inside `ResolveReference`. A resolver returning a nil stream with a nil error is refused as `ErrReferenceNotFound`. `xmlenc1.ReferenceResolver` returns `io.ReadCloser` while `xmldsig1.ReferenceResolver` returns `[]byte`, so one value does NOT satisfy both, and NEITHER package imports the other
-- xmlenc-core1 is implemented except where the package deliberately departs from it, and each departure is named with its reason. Triple DES (`#tripledes-cbc`, §5.2.2 REQUIRED; `#kw-tripledes`, §5.7.1 REQUIRED) is REFUSED, not pending — a 64-bit block cipher is subject to Sweet32 (CVE-2016-2183) and NIST SP 800-131A Rev. 2 disallows TDEA encryption after 2023; the specification marks it REQUIRED because it predates that retirement, and this package follows the retirement, so neither URI will be implemented: block encryption and key wrapping are AES-only, and either URI fails with an error matching the relevant operation sentinel while preserving a typed `*UnsupportedAlgorithmError`, with the two exceptions the README's conformance scope states: `#tripledes-cbc` on an `EncryptedData` carrying no `<EncryptedKey>` and no `SessionKey` reports `ErrMissingKey` from the earlier `len(keys) == 0` check, and `#kw-tripledes` is never reached under a non-empty `SessionKey`, which decrypts past it. `AES192CBC` is likewise absent but §5.2.3 marks it OPTIONAL, so it is not a conformance gap
-- The committed `xmlenc1/summary-xmlenc11.md` snapshot (10 pass / 0 skip / 0 fail, generator output — never hand-edit it) exercises key protection only: six ECDH-ES ConcatKDF vectors on EC-P256/P384/P521 and four rsa-oaep vectors on RSA-2048/3072/4096, all of them AES-GCM. It is evidence for no CBC block algorithm, for the refused Triple DES algorithms, for no `ds:RetrievalMethod`, for no `xenc:CipherReference`, and it is not the merlin corpus. The 1.1 interop corpus holds no Triple DES vector, so the ten are the suite in full and nothing is skipped. `xmlenc1/README.md`'s "Conformance scope" section is the user-facing statement of all of this
-- NO third-party interop vector covers `xenc:CipherReference` at any level of transform support: the only one in the Santuario corpus needs BOTH an XPath transform and `aes192-cbc`, neither of which this package implements. Do not add a skip entry implying a vector is being passed over — there is no runnable vector to run
-- `xmlenc1/testdata/interop/` holds the one third-party `ds:RetrievalMethod` vector, `encrypt-element-aes256-cbc-retrieved-kw-aes256.xml` from the Baltimore/Merlin examples in the Apache Santuario corpus, run by `TestInteropRetrievalMethod` (`interop_test.go`) under the published key-encryption key `abcdefghijklmnopqrstuvwxyz012345` (the corpus name "jed"). It is asserted as far as this package decrypts it: the reference resolves and the session key unwraps, pinned by the error being `ErrDecryptionFailed` with neither `ErrMissingKey`/`ErrReferenceNotFound` nor `ErrKeyUnwrapFailed` in the chain. The block decryption then fails on the padding, which is a property of the vector and NOT of the reference — xmlenc-core1 §5.2.1 pads with N-1 ARBITRARY octets plus a final octet N, while `pkcs7UnpadConstantTime` (`block.go`) requires every padding octet to equal N — so this vector cannot yield plaintext until the CBC path accepts §5.2.1 padding
-- The xmlenc-core1 wire structs (`types.go`) are UNEXPORTED — `encryptedData`, `encryptedKey`, `encryptionMethod`, `agreementMethod`, `keyDerivationMethod`, `ecKeyValue`. No exported function, method, or variable takes or returns one, so they are not API and no field of any of them is a compatibility promise. `ConcatKDFParams` is the one wire-adjacent struct that stays exported, because `Encryptor.KeyDerivationParams` takes it. `export_test.go` declares one exported alias per struct (`EncryptedData = encryptedData` and so on), compiled only under test, so the external `xmlenc1_test` package can still assemble and inspect a wire shape directly. The fields those tests read stay exported on the unexported struct; the two nothing outside the package reads, `encryptedKey.recipient` and `ecKeyValue.curve`, are unexported as well
-- Files: `xmlenc1.go` (API), `context.go` (cancellation helpers), `constants.go`, `block.go`, `keytransport.go`, `keywrap.go`, `key_agreement.go`, `reference.go` (same-document `ds:RetrievalMethod` and `xenc:CipherReference` resolution), `reference_resolver.go` (`ReferenceResolver`, `FSReferenceResolver`, URI joining), `types.go`, `serialize.go`, `parse.go`, `errors.go`
+- A **non-empty** `Decryptor.SessionKey` is an EARLY RETURN, not a key preference:
+  `decryptElement`/`decryptBytes` use it and return before candidate selection, per-candidate validation, and
+  per-candidate key resolution in `resolveSessionKeyFromEncryptedKey`. The `MaxEncryptedKeys` cap sits ahead
+  of that return and still applies. Both builders gate on `len(sessionKey) > 0`, so an empty or nil slice
+  counts as not set on either side
+- An `EncryptedData` with **no `EncryptionMethod`** decrypts only when the caller states the block algorithm
+  out of band with `Decryptor.BlockAlgorithm(uri)` — W3C xmlenc-core1 §3.1/§3.2 leave the element optional and
+  require the recipient to know the algorithm already, and §4.4 step 1 admits obtaining it out of band.
+  `resolveDecryptBlockAlgorithm` (`xmlenc1.go`) is the single resolution and both `decryptElement` and
+  `decryptBytes` call it ahead of everything that reads the algorithm. The match is STRICT, so the setter can
+  only narrow what a decrypt accepts: absent + unset → `ErrMalformedEncrypted` naming the setter; absent + set
+  → the caller's URI; present + unset → the document's URI; present + set + different →
+  `ErrConflictingBlockAlgorithm` naming both. A document never overrides a caller who stated the algorithm,
+  which would be algorithm confusion. A present `EncryptionMethod` always carries a non-empty `Algorithm` —
+  `parseEncryptionMethod` (`parse.go`) refuses an empty one as `ErrMalformedEncrypted` at the parse gate,
+  ahead of any resolution — so the caller's URI is only ever matched against a real declaration. The resolved
+  URI is the one bound everywhere downstream: the CBC opt-in gate, the AEAD additional data of the two
+  2001-namespace GCM identifiers, `validateKeySize` on the session key, and the AES key-wrap ciphertext length
+- `EncryptedKey.Recipient` is **parse-only** — populated when reading, never serialized when encrypting.
+  `EncryptedKey.CarriedKeyName` is declared as part of the parsed shape and filled by nothing:
+  `parseEncryptedKey` steps over the `xenc:CarriedKeyName` element, and encrypting never writes one. No
+  decrypt path consults the name and no exported function or method takes or returns an `EncryptedKey`, so no
+  caller can observe it; reading it would cost an unbounded copy of attacker-supplied metadata, since the name
+  is joined from every child at every depth that join reaches and charged against neither
+  `MaxEncryptedKeyBytes` nor `MaxCipherValueBytes`, so a document may spread one over as many CDATA sections
+  as it likes and defeat the XML parser's per-node content cap. `TestCarriedKeyNameIsNotRead`
+  (`parse_test.go`) pins both halves: a document carrying one still parses (the element is skipped, the
+  `EncryptedKey` around it is still a candidate, the field stays zero) and still decrypts, and a 4 MiB name
+  costs a SUCCESSFUL `SessionKey` decrypt no more than the same document without one — measured as a
+  `TotalAlloc` delta across the decrypt of an already-parsed document
+- Parse enforces at-most-one cardinality on every xenc/dsig11 schema singleton it reads — `EncryptionMethod`
+  and `CipherData` per `EncryptedData`/`EncryptedKey`, `ds:KeyInfo` per `EncryptedType`, and
+  `NamedCurve`/`PublicKey` per `dsig11:ECKeyValue` — rejecting a second occurrence with
+  `ErrMalformedEncrypted` (`parse.go`), so a duplicate can never silently overwrite the first
+- `Decryptor.MaxEncryptedKeys(n)` caps trial-decrypted `<EncryptedKey>` candidates (DoS guard): zero →
+  `DefaultMaxEncryptedKeys` (100), negative → unlimited; over-cap fails with `ErrTooManyEncryptedKeys` before
+  the excess candidate is appended to the retained list or any candidate crypto runs.
+  `parseKeyInfoForEncryption` enforces the effective limit while parsing, before the excess candidate's
+  structure is validated or its ciphertext is charged to the `MaxEncryptedKeyBytes` budget;
+  `checkEncryptedKeyCap` is the shared error/count implementation. Both `decryptElement` and `decryptBytes`
+  pass the cap into parsing before consulting configured keys, so it holds in every key configuration.
+  Per-candidate branch dispatch — which of the three decrypt keys a candidate uses and what it costs — is
+  implemented in `resolveSessionKeyFromEncryptedKey` (ECDH-ES in `decryptECDHSessionKey`) and stated by the
+  `Decryptor.MaxEncryptedKeys` godoc. The candidate loop's own `ctx` observation is stated by the cancellation
+  bullet above
+- `Decryptor.MaxEncryptedKeyBytes(n)` caps the TOTAL decoded `<EncryptedKey>` ciphertext of one EncryptedData
+  (memory-amplification guard): zero → `DefaultMaxEncryptedKeyBytes` (64 KiB), negative → unlimited;
+  over-budget fails with `ErrEncryptedKeyBytesExceeded`. It is a separate sentinel from
+  `ErrTooManyEncryptedKeys` because the two bound different things (a count vs a size) and different setters
+  raise them. The budget is threaded into the parse path — `newEncryptedKeyBudget(cfg)` in
+  `decryptElement`/`decryptBytes` → `parseEncryptedData` → `parseKeyInfoForEncryption` → `parseEncryptedKey` →
+  `parseCipherData` — and `decodeCipherValue` (`parse.go`) charges `encryptedKeyBudget.charge` (`xmlenc1.go`)
+  BEFORE anything is built from the value, so an over-budget CipherValue is rejected without being assembled
+  or decoded (the base64 text itself is already in the caller's DOM). It walks the CipherValue's children
+  twice: an `xmlbase64.Counter` counts them, and only after the charge is accepted does a second walk build
+  the whitespace-stripped characters through `xmlbase64.AppendStripped` and decode them with
+  `base64.StdEncoding.Decode` into a buffer sized at the counted `DecodedLen()` — the charged count itself,
+  and not `encoding/base64`'s own padding-blind `DecodedLen`. The stripped characters are handed to the
+  decoder as bytes, so nothing copies them into a string. The lexical text is never joined into one string —
+  xs:base64Binary allows XML whitespace between characters and the value may be spread over any number of text
+  and CDATA children, so the lexical length is attacker-chosen and unrelated to the charge; what is held is
+  bounded by the budget (stripped characters ≤ 4/3 of it, decoded bytes exactly the charged count) and the
+  peak is the largest single child. `Counter` (`internal/xmlbase64`) owns the count and fails closed: exact
+  for base64 the decoder accepts, and never below what a rejected decode allocates — it deducts padding only
+  from a value whose whole lexical shape is otherwise decodable, so neither malformed padding nor a body
+  outside the base64 alphabet can walk a value past the budget. It carries the character count, the padding
+  count, and the decodable-shape flag ACROSS children, so the count is that of the concatenation — counting
+  each child alone and summing would report 0 for every sub-quantum child and bypass the budget entirely.
+  `parseCipherData` receives `payloadCipherValueBudget` for the EncryptedData's own CipherValue, while
+  EncryptedKey ciphertext uses `encryptedKeyBudget`. The budget is charged while parsing for retained
+  candidates only; the candidate cap rejects an excess candidate before the budget, and both checks hold ahead
+  of the `SessionKey` early return
+- `xenc:OAEPparams` is bounded by `maxOAEPParamsBytes` (1024, `parse.go`), which owns the rationale;
+  over-limit fails with an error wrapping `ErrMalformedEncrypted`. `decodeBoundedBase64(ctx, elem, valueName,
+  maxBytes, invalidPhrase)` (`parse.go`) is the single implementation for every xs:base64Binary value this
+  package holds to a FIXED ceiling — the OAEPparams label and an ECDH-ES `dsig11:PublicKey` — and runs from
+  `parseEncryptionMethod`, so it covers BOTH OAEPparams call sites — the `EncryptedData`'s own
+  `EncryptionMethod` (whose decoded label nothing ever reads) and each `EncryptedKey`'s — and both are reached
+  while the document is read, ahead of key resolution and the `SessionKey` early return; an EncryptedKey
+  beyond the candidate cap is not retained. The walk is leaf-only and single-pass. `base64CharacterData`
+  (`parse.go`) classifies each child through `helium.AsNode`: `*helium.Text`/`*helium.CDATASection` contribute
+  their content; a `*helium.EntityRef` contributes ONE hop — its `FirstChild()` asserted to `*helium.Entity`,
+  whose `Content()` is a leaf accessor returning the declared replacement literal without recursing (a
+  CHILDLESS `EntityRef` contributes NO characters and no error: per XML 1.0 "Entity Declared" an undeclared
+  general entity is only fatal under `standalone="yes"` or with neither an external subset nor a
+  parameter-entity reference, so a non-validating parse of a document with either one keeps the reference as
+  an `EntityRef` with no `Entity` under it — a normal parser output, and one `c14n` also treats as empty since
+  it canonicalizes an `EntityRef` by walking its children; an `EntityRef` whose first child is NON-NIL and not
+  an `*Entity` is reachable only in a caller-built tree and is refused; and the `Entity`'s `NextSibling()` is
+  never followed because it is the next DTD declaration, not part of the value), so an entity whose
+  replacement is itself a reference or markup contributes that literal text and the `Counter` marks the value
+  undecodable; `*helium.Comment`/`*helium.ProcessingInstruction` are skipped (reading a comment would splice
+  its text into the base64); and ANY other child kind is refused with `ErrMalformedEncrypted` — an element
+  answers `Content()` by aggregating its whole subtree, so reading one would spend that subtree's text before
+  a limit measured in decoded octets could look at it, and a subtree of whitespace decodes to nothing so the
+  limit would never fire. `decodeBoundedBase64` reads each child exactly once, folding it into an
+  `xmlbase64.Counter` and appending the whitespace-stripped characters through `xmlbase64.AppendStripped`, and
+  stops as soon as the kept characters pass its local char ceiling `(maxBytes+2)/3*4` (the most any acceptable
+  value can hold, and what sizes the character buffer — stopping there is always early, never a different
+  verdict, and the exact `Counter.DecodedLen` test still runs after the walk). The decode is
+  `base64.StdEncoding.Decode` into a buffer sized at that counted `DecodedLen()`, so the stripped characters
+  are never copied into a string and the buffer is exact for a value the decoder accepts, sized by that count
+  instead of `encoding/base64`'s padding-blind estimate. So the lexical text is never joined into one string
+  and what the parse RETAINS is sized by the limit alone. `valueName` names the value in the size and
+  child-kind refusals and `invalidPhrase` in the decoder's, so each caller's wording stays its own
+  (`TestBoundedBase64ErrorsNameTheirOwnValue`, `parse_test.go`, pins that for both callers across all three
+  refusals). What is NOT bounded is the copy `Content()` hands out per child: a DOM offers no read-only view
+  of a node's bytes, so weighing a value costs one copy of its lexical text. That copy is the floor and the
+  walk pays it exactly once — total allocation is one times the lexical length plus fixed overhead, which
+  `TestOAEPParamsAllocation` (`parse_test.go`) pins. The limit is a fixed internal constant with no public
+  knob and is deliberately NOT the `MaxEncryptedKeyBytes` budget: an `EncryptedData`-side label is not
+  `EncryptedKey` ciphertext, and charging it would change what that setter documents itself as covering.
+  Neither existing knob substitutes — the candidate count is checked before each append, and the XML parser's
+  `MaxNodeContentSize` bounds one indivisible content run, which CDATA-splitting defeats. The limit is a
+  POLICY ceiling, not a conformance boundary — xenc-schema types `OAEPparams` as `xs:base64Binary` with no
+  length facet and RFC 8017 bounds the label only at its hash's input limit, so a larger label is conforming
+  and rejected anyway — and it is symmetric: `resolveEncryptConfig` (`xmlenc1.go`) charges
+  `Encryptor.OAEPParams` against the same `maxOAEPParamsBytes` and fails with an error wrapping
+  `ErrEncryptionFailed`, gated on `hasKeyTransport` because key transport is the only mechanism that writes a
+  label, so a label over the limit is neither written nor parsed back and no self-produced ciphertext is
+  un-decryptable. `TestEncryptorOAEPParamsBound` (`keytransport_test.go`) pins the encrypt-side boundary
+  against `MaxOAEPParamsBytesForTest`
+- `Decryptor.MaxCipherValueBytes(n)` caps the decoded ciphertext in the EncryptedData payload's `CipherValue`,
+  independently from the cumulative `EncryptedKey` ciphertext budget: zero selects
+  `DefaultMaxCipherValueBytes` (10 MiB), and a negative value removes the cap. `parseEncryptedData` sends the
+  payload through its own budget before it is assembled or decoded, so split text/CDATA nodes cannot bypass
+  it. An over-budget payload fails with `ErrCipherValueBytesExceeded` before block decryption, candidate
+  selection, or a `SessionKey` return.
+- AES key unwrap is length-bound: `aesKeyUnwrap(kek, ciphertext, keySize)` requires `len(ciphertext) ==
+  keySize+8` exactly (RFC 3394 §2.2.2), rejecting with `ErrKeyUnwrapFailed` before the six unwrap rounds.
+  `keySize` is the session-key length of the declared block algorithm, resolved once per decrypt via
+  `keySizeForAlgorithm(paramBlockAlgorithm, alg)` ahead of the candidate loop and threaded through
+  `resolveSessionKeyFromEncryptedKey` into both the plain key-wrap and the ECDH-ES (`decryptECDHSessionKey`)
+  branches. The post-recovery `validateKeySize` in `blockDecrypt` still binds a key that arrived by RSA key
+  transport, whose length is not visible until the private-key decrypt
+- Block encryption: AES-128/256-CBC, XML Encryption 1.1 AES-128/192/256-GCM
+  (`AES128GCM11`/`AES192GCM11`/`AES256GCM11`), and AES-128/256-GCM in the 2001 xmlenc namespace
+  (`AES128GCM`/`AES256GCM`). The 1.1 GCM form uses the standard IV || ciphertext || authentication-tag
+  encoding without additional authenticated data, which is the only AES-GCM xmlenc-core1 §5.2 defines. The two
+  2001-namespace GCM identifiers are defined by NO XML Security specification, and
+  `blockEncrypt`/`blockDecrypt` bind the `EncryptionMethod/@Algorithm` URI into the AEAD additional
+  authenticated data for those two alone — a package-specific measure against an algorithm substitution on the
+  wire, which no specification requires, and a second reason a document carrying one decrypts here and nowhere
+  else. Both stay exported and reachable through `Encryptor.BlockAlgorithm`, and `Decryptor` accepts them with
+  that AAD binding, so every document this package has emitted still decrypts
+- Secure by default: unset `BlockAlgorithm` → `DefaultBlockAlgorithm`, which is `AES256GCM11` — authenticated
+  AES-256-GCM under the standard XML Encryption 1.1 identifier, so what a caller who configures nothing emits
+  is what a conforming peer recognizes. Selecting a CBC block algorithm for **encryption** requires
+  `Encryptor.AllowLegacyCBC(true)`, else `ErrCBCEncryptionRequiresOptIn`. **Decryption** of CBC requires
+  `Decryptor.AllowUnauthenticatedCBC(true)`, else `ErrCBCRequiresOptIn`
+- CBC unpadding follows xmlenc-core1 §5.2.1 by default: the final octet names the padding length N,
+  `unpadConstantTime` (`block.go`) checks only that N names between one octet and one whole block, and the N-1
+  octets ahead of it are ARBITRARY and unread. PKCS#7 (every padding octet equals N) is a strict subset,
+  selected by `Decryptor.StrictPKCS7Padding(true)` and carried down the decrypt path as the `cbcPadding`
+  policy type (`cbcPaddingXMLEnc` is the zero value, `cbcPaddingPKCS7` the opt-in) through
+  `decryptCipherValue`/`finishDecrypt` → `blockDecrypt` → `decryptCBC`. The strict rule refuses conforming
+  third-party ciphertext, so it suits only a caller controlling both ends; `pkcs7Pad` writes all-N padding,
+  valid under both, so a document this package produced decrypts either way. A refused padding reports the
+  same `ErrDecryptionFailed` as every other CBC failure. `TestInteropRetrievalMethod` (`interop_test.go`)
+  decrypts the merlin `aes256-cbc` vector end to end as the third-party evidence, and pins its refusal under
+  the opt-in
+- Three mechanisms protect the session key — RSA key transport (`KeyTransportAlgorithm` +
+  `RecipientPublicKey`), ECDH-ES key agreement (`KeyWrapAlgorithm` + `RecipientECPublicKey`), AES key wrap
+  (`KeyWrapAlgorithm` + `KeyEncryptionKey`) — and `conflictingKeyProtection` (`xmlenc1.go`) rejects any pair
+  of them with `ErrConflictingKeyConfig`, since `encryptPlaintext` emits one `<EncryptedKey>` and would
+  silently discard the loser of its transport → agreement → wrap dispatch. The two transport pairs name both
+  algorithm URIs; the agreement-vs-wrap pair names the two setters instead, because both mechanisms share the
+  same `KeyWrapAlgorithm` URI. A `SessionKey` alongside a single mechanism is fine — it supplies the key that
+  mechanism protects
+- `resolveEncryptConfig` decides the payload-independent parts of an `Encryptor`'s configuration — the
+  effective block algorithm and its supported-URI check, the CBC opt-in, presence of a key source, the
+  key-protection conflicts, the RSA-OAEP URI/digest/MGF checks, the RSA-OAEP label size, the key-wrap URI
+  (`validateKeyWrapAlgorithm`, charged to whichever of key agreement and key wrap is in use), the ECDH-ES
+  ConcatKDF parameters (`validateEncryptConcatKDFParams` (`key_agreement.go`): the OtherInfo budget then the
+  digest URI, over the set `effectiveKDFParams` returns, so an empty `DigestMethod` is weighed as the SHA-256
+  default with no OtherInfo and the caller's discarded fields are never measured), and the ECDH-ES recipient
+  key — and every entry point calls it before any payload work, so a plaintext that fails to serialize never
+  masks those checks, and none of them costs anything proportional to the payload
+  (`TestEncryptConfigRejectionAllocatesNoPayload`, `xmlenc1_test.go`). Session-key length is bound later,
+  inside `encryptPlaintext`
+- Key transport: RSA-OAEP (1.0 + 1.1 with configurable SHA-1/224/256/384/512 digest and MGF; SHA-224 uses the
+  XMLDSig-more digest URI and the XML Encryption 1.1 `mgf1sha224` URI; the OAEP label digest and the MGF1 hash
+  may differ, via `rsa.EncryptOAEPWithOptions`/`OAEPOptions` — requires Go ≥ 1.26)
+- Key wrapping: AES-128/192/256-KeyWrap (RFC 3394). `validateKeyWrapAlgorithm` (`keywrap.go`) is the
+  encrypt-side gate for `Encryptor.KeyWrapAlgorithm` and holds BOTH mechanisms that read it — key agreement,
+  which derives the KEK, and key wrap, which is handed one — to those three URIs, since either declares that
+  URI on the `EncryptedKey` it emits while protecting the session key with `aesKeyWrap`. Anything else, a
+  block-cipher URI above all, would declare an algorithm that did not produce the `CipherValue` — an RFC 3394
+  wrap under an AES-GCM identifier, which nothing reads back, this package included — and the KEK-length
+  binding cannot stand in for the check, because `keySizeForAlgorithm` answers a length for the block-cipher
+  URIs too. `resolveEncryptConfig` applies it ahead of any payload work and `encryptECDHSessionKey` applies it
+  again on its own way in
+- Key agreement: XML Encryption 1.1 ECDH-ES on P-256, P-384, and P-521 with ConcatKDF using
+  SHA-1/224/256/384/512, in **both** directions — `Decryptor.ECPrivateKey` decrypts,
+  `Encryptor.RecipientECPublicKey` + `KeyWrapAlgorithm` encrypt (the KEK is derived, so `KeyEncryptionKey`
+  belongs to the AES key wrap mechanism). SHA-224 uses the XMLDSig-more digest URI. Each encryption generates
+  a fresh ephemeral key pair; `Encryptor.KeyDerivationParams` sets the ConcatKDF parameters
+  (`effectiveKDFParams`) and its godoc owns the empty-`DigestMethod` fallback. `resolveEncryptConfig`
+  (`xmlenc1.go`) decides the key protection before any entry point serializes plaintext, generates a session
+  key, or block encrypts, so an unusable recipient key costs nothing proportional to the payload;
+  `ecdhRecipientKey` is its single gate for the recipient key and rejects a key with unset coordinates (which
+  `crypto/ecdsa` would otherwise dereference), a curve with no `crypto/ecdh` form, and a curve with no
+  `dsig11:NamedCurve` URI. An EC public key without a `KeyWrapAlgorithm` does not select key agreement, so its
+  curve is never resolved. `serialize.go` emits the `xenc:AgreementMethod` subtree
+  (`KeyDerivationMethod`/`ConcatKDFParams`/`OriginatorKeyInfo` → `ds:KeyValue` → `dsig11:ECKeyValue`);
+  ConcatKDF OtherInfo attributes are hexBinary bit strings whose first octet is the unused-bit count
+- The five ConcatKDF OtherInfo fields are capped **cumulatively** at `maxConcatKDFOtherInfoBytes` (4096,
+  `key_agreement.go`), which owns the rationale; over-budget parameters fail with an error wrapping
+  `ErrMalformedEncrypted`. `checkConcatKDFOtherInfoBudget` is the single implementation and runs at four
+  points, each ahead of any work sized by the fields: `parseConcatKDFParams` applies it to wire data at the
+  first point that holds all five fields, so an oversized document never reaches ECDH or key unwrap;
+  `resolveEncryptConfig` applies it through `validateEncryptConcatKDFParams` to an `Encryptor`'s effective
+  set, so an oversized set is refused before the plaintext is serialized or block encrypted and the error
+  carries `ErrEncryptionFailed` alongside the shared `ErrMalformedEncrypted`; `deriveConcatKDF` applies it
+  before resolving the digest, so a set that is both over budget and names an unsupported digest still fails
+  on the size; and `concatKDFOtherInfo` applies it immediately before packing, which is what makes the limit
+  hold for a caller-built DOM or a caller-built `ConcatKDFParams` that this package never parsed. The one
+  parameter set never measured is an `Encryptor`'s with an empty `DigestMethod`: `effectiveKDFParams` replaces
+  it wholesale with the SHA-256 default carrying empty OtherInfo, so the caller's fields are discarded before
+  any derivation instead of checked, and the encryption succeeds with no OtherInfo on the wire
+  (`ConcatKDFParams`' godoc states this carve-out). The check measures each field against the budget REMAINING
+  instead of summing the five, because the fields may all alias one slice and their sum can wrap `int` on a
+  32-bit build; the packing's own `len(value)*8`/`totalBits` arithmetic is wrap-free only because the check
+  runs ahead of it. `parseConcatKDFHexAttribute` additionally rules an attribute out from its hex length
+  alone, before `hex.DecodeString` allocates for it, since one field can never exceed the whole set's budget.
+  Nothing else in the package bounds these fields — the XML parser's `MaxNodeContentSize` is a
+  caller-adjustable attribute-value cap, not a ConcatKDF limit
+- `concatKDFOtherInfo` packs the five bit strings into the single bit string ConcatKDF hashes. A field landing
+  on an octet boundary is moved with `copy()` plus at most one masked trailing octet; a field straddling a
+  boundary (only reachable when some earlier field's bit length is not a multiple of eight) falls back to
+  moving one bit at a time, bounded by the OtherInfo budget. Both paths produce identical bytes —
+  `TestConcatKDFOtherInfoMatchesPerBitPacking` pins the production packing against a verbatim per-bit
+  reference over fixed and randomized shapes, because a divergence here silently changes the derived KEK and
+  breaks interoperability
+- Key sizes are bound to the declared algorithm URI on encrypt and decrypt (incl. after unwrap/key transport);
+  mismatch → `KeySizeError`. On encrypt this binds the key actually used: a **non-empty**
+  `Encryptor.SessionKey` of the wrong length is rejected, while an empty or nil one is replaced by a freshly
+  generated key of the right length and never reaches the check (with no key-protection mechanism configured
+  at all, that case is `ErrMissingConfig`). `KeySizeError`'s `Key` field names the offending key ("session
+  key"/"key-encryption key"). `UnsupportedAlgorithmError.Parameter` likewise names the slot that rejected the
+  URI ("block algorithm", "MGF algorithm", ...); both are diagnostic text — match on the type and `Algorithm`
+- `ErrUnsupportedKeyDerivation` (`errors.go`) is raised by `noCandidateError` (`xmlenc1.go`, the single
+  wording site both decrypt terminals share) when key resolution found NO candidate and
+  `encryptedData.offersDerivedKey` is set — i.e. the `ds:KeyInfo` offered the session key only through an
+  `xenc11:DerivedKey`, inline or named by a `ds:RetrievalMethod` `Type` of `#DerivedKey`. It is deliberately
+  not `ErrMissingKey`: no key the caller supplies can decrypt such a document, so the error must name the
+  missing facility instead of sending the caller to audit its key configuration. A document that ALSO carries
+  a usable `xenc:EncryptedKey` decrypts under it (the flag is consulted only on an empty candidate list), and
+  a pre-shared `Decryptor.SessionKey` never reaches it at all
+- `UnsupportedAlgorithmError` and `KeySizeError` each carry a leading blank `_ struct{}` field, so an unkeyed
+  composite literal cannot compile from another package (`implicit assignment to unexported field _`). That is
+  what lets either field set GROW without breaking a caller: nobody can have written the positional form a new
+  field would invalidate. Keyed literals, field reads, and `errors.As` recovery are unaffected;
+  `api_freeze_test.go` pins the guard structurally, so it holds however the field is spelled
+- All three encrypt terminals report a nil operand identically: `ErrEncryptionFailed` wrapped FIRST, then
+  `helium.ErrNilNode` (both with `%w`), so a caller matching the operation sentinel catches it whichever entry
+  point it called and one matching `ErrNilNode` still learns which operand was nil. `EncryptBytes` names the
+  missing document in its message; `encrypt` (shared by `EncryptElement`/`EncryptContent`) names the missing
+  element
+- Error chains: `ErrMissingKey` names the key kind the candidate needs, the algorithm URI the document
+  declared for it (the `EncryptionMethod` URI for RSA key transport and AES key wrap, the `AgreementMethod`
+  URI for ECDH-ES key agreement), and the `Decryptor` setter that supplies the key; `ErrTooManyEncryptedKeys`
+  carries the candidate count and effective limit; a failed AES key unwrap wraps `ErrKeyUnwrapFailed` in
+  `ErrDecryptionFailed`, matching the RSA key-transport path. There is no padding sentinel: CBC collapses
+  nearly every failure to `ErrDecryptionFailed`, message included, so no padding oracle exists; the one
+  exception is a wrong-length pre-shared `Decryptor.SessionKey`, whose length the caller configures and an
+  attacker cannot influence, so a mismatch is reported as a bare `KeySizeError` instead
+- Multi-recipient: `EncryptedData.EncryptedKeys []*EncryptedKey` holds one EncryptedKey per recipient; absent
+  a session key, decrypt tries each candidate through full block decryption + plaintext validation (a bogus
+  prepended key cannot mask the real one). `EncryptedData.EncryptedKey` is the **deprecated** single-key field
+  — `EncryptedKeys` wins when non-empty, else the single field is treated as a one-element list; parse
+  populates both
+- An ECDH-ES originator key's `dsig11:PublicKey` is bounded by `maxECPublicKeyBytes` (133, `parse.go`), which
+  owns the rationale; over-limit fails with an error wrapping `ErrMalformedEncrypted`. `decodeBoundedBase64`
+  (`parse.go`, the same bounded walk the OAEPparams label goes through) reads it, called from
+  `parseECKeyValue` with value name `ECKeyValue PublicKey` and decode-error phrase `invalid ECKeyValue
+  base64`, so it is reached while the document is read — ahead of the key resolution and the `SessionKey`
+  early return; an `EncryptedKey` beyond the candidate cap is never parsed, so its `dsig11:PublicKey` is never
+  read. Unlike the OAEPparams and ConcatKDF ceilings the value is NOT a policy choice: `dsig11:PublicKey`
+  carries a SEC1 uncompressed point, 65 octets on P-256, 97 on P-384 and 133 on P-521, and `crypto/ecdh`
+  refuses the compressed form and every over-length input on all three, so an over-133-octet value is rejected
+  by `curve.NewPublicKey` whatever it holds and the limit only moves that verdict ahead of materializing it.
+  It is the maximum across ALL THREE curves, and the selected curve's own size cannot serve, because
+  `dsig11:ECKeyValue` puts no order on its children: `dsig11:NamedCurve` may follow `dsig11:PublicKey`, and a
+  document with no `NamedCurve` at all still has its `PublicKey` read before the missing-curve error, so at
+  the moment the value is weighed there may be no curve to weigh it by. The walk is leaf-only and single-pass
+  through `eachSibling` over EVERY child kind, classifying children with `base64CharacterData`, folding each
+  into an `xmlbase64.Counter`, appending through `xmlbase64.AppendStripped`, stopping as soon as the kept
+  characters pass the char ceiling `(maxECPublicKeyBytes+2)/3*4` = 180 and applying the exact
+  `Counter.DecodedLen` test afterwards. `internal/xmlbase64.DecodeElement` is deliberately NOT used: it takes
+  no `context.Context` and would drop the per-child cancellation poll. So the lexical text is never joined
+  into one string and what the parse retains is sized by the limit alone; the one cost still following the
+  document is the per-child `Content()` copy, paid exactly once, which `TestECPublicKeyAllocation`
+  (`parse_test.go`) pins at 1x for both a refused and an accepted value. `TestECPublicKeyBound` covers the
+  three curves (including the 133-byte P-521 boundary), both child orders, whitespace-wrapped and CDATA-split
+  values, and the two child-kind rules
+- `CipherValue`, `OAEPparams`, and an ECDH-ES `dsig11:PublicKey` use `base64CharacterData` (`parse.go`): text,
+  CDATA, and one-hop entity-reference data contribute to the base64 value; comments and processing
+  instructions are ignored; every other child, including an element, is rejected before its subtree can be
+  read.
+- Same-document `ds:RetrievalMethod` (§3.5, REQUIRED) is implemented and always on:
+  `parseKeyInfoForEncryption` (`parse.go`) takes an `xenc:EncryptedKey` child and a `ds:RetrievalMethod` child
+  in DOCUMENT ORDER, so a reference-supplied candidate lands at the reference's position in `EncryptedKeys`,
+  wherever that falls among the inline ones (the list is tried in order, so ordering decides which key a
+  multi-candidate document is decrypted under). `parseRetrievalMethod` (`parse.go`) branches on `@Type` FIRST:
+  `typeDerivedKey` (§3.5.2) and any foreign URI are stepped over with no error, no candidate slot, and no URI
+  lookup, and `typeDerivedKey` additionally sets `encryptedData.offersDerivedKey`; `TypeEncryptedKey` must
+  name an `xenc:EncryptedKey` and naming anything else is `ErrMalformedEncrypted`; an absent `@Type` resolves
+  and then uses the target only if it IS an `xenc:EncryptedKey`. `retainEncryptedKey` (`parse.go`) is the
+  SINGLE retention point both branches call — the inline `xenc:EncryptedKey` child and a resolved
+  `ds:RetrievalMethod` target alike — and its three steps run in a fixed order: the visited-set dedup FIRST,
+  then `checkEncryptedKeyCap`, then `parseEncryptedKey`. So an element a document offers BOTH ways, in either
+  order, is one candidate: the peak charge equals the final candidate count exactly, a repeat offer charges
+  nothing and is never trial-decrypted twice, and a reference that retains nothing costs one probe of the id
+  index built once per decrypt. Resolution itself is `reference.go`: `refScope` carries the root, the base
+  URI, and a lazily built id index, and nothing about what has been made of an answer — the visited set of
+  taken candidates sits on `parseState` (`parse.go`), whose `markVisited` `retainEncryptedKey` alone calls;
+  `referenceURIForm` recognizes the four same-document forms XMLDSig core §4.4.3.2-3 defines (`""`, `#id`,
+  `#xpointer(/)`, `#xpointer(id('id'))`) and fails everything else closed; `resolveSameDocument` builds the
+  index once per decrypt through `domutil.BuildIDIndex` (whose ctx-observing walk polls per node and whose
+  FROZEN ID-name rule xmldsig1 shares, so the two cannot disagree about which element carries an id),
+  returning `ErrReferenceNotFound` on zero matches and `ErrAmbiguousReference` on more than one — XML
+  Signature Wrapping applied to encryption. The scope root is the TOPMOST ELEMENT ancestor of the
+  `EncryptedData`, not `OwnerDocument().DocumentElement()`, so a detached `EncryptedData` resolves within its
+  own subtree. A non-same-document URI is `ErrReferenceNotFound` with no setting to lift it, since §3.5
+  mandates only the same-document form. The `visited` set is DEDUPLICATION for the many ways one element can
+  be offered — the several references §3.5.3 permits, and a reference plus the inline child it names in either
+  order, all yielding one candidate, charged and trial-decrypted once — and is NOT a loop guard:
+  `parseEncryptedKey` reads only `EncryptionMethod`, `CipherData`, and `ds:KeyInfo`→`AgreementMethod` and
+  never looks for a `RetrievalMethod`, so resolution is one step deep BY CONSTRUCTION and §6.5's `A → B → A`
+  cycle is not expressible. All of this runs while the document is READ, so it precedes the
+  `Decryptor.SessionKey` early return: a pre-shared session key does not decrypt past a refused reference,
+  though a skipped foreign `@Type` costs it nothing. `Encryptor` emits no `ds:RetrievalMethod`; §3.5 requires
+  support for reading one, not for writing one
+- `xenc:CipherReference` (§3.3.1, REQUIRED) is implemented. `parseCipherData` (`parse.go`) settles the
+  CipherData choice cardinality in a FIRST walk that reads no member, and only then turns the single member it
+  found into octets — so a document offering two members is refused for offering two whatever they hold, and a
+  schema-invalid document never turns into a dereference. `resolveCipherReference` (`reference.go`) owns the
+  four outcomes: an ABSENT `@URI` is `ErrMalformedEncrypted` (the schema marks it required) while a
+  PRESENT-and-empty one is the valid null URI; a same-document URI with no transform converts the node-set to
+  octets by Canonical XML 1.0 without comments (`canonicalizeCipherReferenceNodeSet`, writing through
+  `newBudgetWriter`, which bounds canonical OUTPUT OCTETS and never the work producing them — c14n's own
+  per-element namespace-visibility scan costs elements times in-scope declarations and can run long while
+  emitting almost nothing — and which also polls the caller's context on every write, the only place a
+  WHOLE-DOCUMENT form (`URI=""` or `#xpointer(/)`) ever observes cancellation, since that form has no node-set
+  collector stage ahead of it; the budget is charged once, with the final total, after the write completes); a
+  same-document URI whose first transform is `#base64` hands the target to `decodeCipherReferenceNodeSet`
+  unchanged; and any other URI is external. The list is a pipeline — the first transform consumes the
+  dereferenced value and every one after it decodes the octets the one before produced (`decodeBase64Octets`,
+  uncharged because base64 only shrinks what was already charged). The whole-document forms naming the
+  document element canonicalize the DOCUMENT (top-level PIs included, per xmldsig-core1 §4.4.3.2); every other
+  form canonicalizes the named element's subtree as the node-set `appendSubtreeNodes` builds (node, in-scope
+  namespace axis, attribute axis, `helium.Children` descent). The result is NEVER re-parsed as a document, so
+  a self-naming reference is inert, terminating at whatever those octets decrypt to, and there is no depth to
+  bound. `parseCipherReferenceTransforms` accepts at most one `xenc:Transforms` (the xenc namespace on the
+  wrapper, `ds:Transform` children), caps the list at `maxCipherReferenceTransforms` (4) as it collects, and
+  validates EVERY declared algorithm before any is executed, accepting only `NamespaceDSig + "base64"` — an
+  unsupported one is `ErrMalformedEncrypted` wrapping an `*UnsupportedAlgorithmError` with `Parameter:
+  paramCipherReferenceTransform`. Refusing XPath and XSLT is conforming: §3.3.1 marks the Transform feature
+  and the particular algorithms OPTIONAL, and either would evaluate a document-chosen expression over an
+  unauthenticated document. An external URI is joined with `helium.ResolveURI` (`joinReferenceURI`) against
+  the base in force AT THE `CipherReference` ELEMENT — `helium.NodeGetBase(elem.OwnerDocument(), elem)`, so
+  `xml:base` between the EncryptedData and the reference counts and a file-parsed document contributes its own
+  URL — and dereferenced through `Decryptor.CipherReferenceResolver`; with none configured it is
+  `ErrReferenceNotFound`, the DEFAULT, because §3.3.1 imports xmldsig-core1's model where §4.4.3.1 makes HTTP
+  dereferencing RECOMMENDED while §4.4.3.2/§4.4.3.3 make the same-document forms MUSTs. Resolution returns a
+  NON-NIL slice even for zero octets, because `parseEncryptedData` reads a nil `CipherValue` as "no CipherData
+  at all". All of it runs while the document is READ, so it precedes block-algorithm resolution, the AES-CBC
+  opt-in gate, and the `SessionKey` early return. `serialize.go` emits only a `CipherValue`; §3.3.1 requires
+  support for reading a `CipherReference`, not for writing one. `parseKeyInfoForEncryption` drops the
+  remaining `ds:KeyInfo` children with no error: `ds:KeyName` (§3.5, RECOMMENDED), `xenc11:DerivedKey`
+  (§3.5.2), which it records on `encryptedData.offersDerivedKey`, and an `xenc:AgreementMethod` in the
+  `EncryptedData`-level `ds:KeyInfo` position §5.6 defines for it — §3.5 marks that OPTIONAL, the same grade
+  as `ds:KeyValue`, so an `EncryptedData` offering its session key only that way carries no candidate and
+  fails with `ErrMissingKey`. The `EncryptedKey`-level position IS read, by `parseAgreementMethodForKeyInfo`,
+  which is how this package performs ECDH-ES key agreement
+<!-- Refutation of a review finding that this bullet still lists only completion, over-budget and cancellation
+as the close paths, omitting the stream-plus-error case. Checked against this file's bytes at this commit: the
+bullet below reads "the stream is CLOSED on completion, over-budget, and cancellation alike, and equally when
+`ResolveReference` itself returns a stream alongside an error", the same clause the ReferenceResolver summary
+bullet earlier in this section and the `ReferenceResolver` godoc in `xmlenc1/reference_resolver.go` carry, so
+no stale three-path statement exists here. `grep -n '^- .*alongside an error' .claude/docs/packages.md` prints
+exactly those two xmlenc1 bullets and nothing else; the `^- ` anchor confines the match to bullet lines, so
+this comment's own quotation of the clause is not among the results and the count cannot be changed by the
+comment stating it. The remaining ReferenceResolver close text earlier in this file belongs to `xmldsig1`,
+whose resolver returns `[]byte` and has no stream to close. -->
+- `ReferenceResolver` + `FSReferenceResolver` (`reference_resolver.go`) inherit `xmldsig1`'s rejection rules
+  and are consulted ONLY for an external CipherReference URI: a URI carrying an RFC 3986 scheme
+  (`uriHasScheme`, Windows drive letter included), a leftover fragment, or a path escaping the root after
+  `path.Clean` + `fs.ValidPath` (`fsNameFromURI`) is refused, every refusal wrapping `ErrReferenceNotFound`.
+  NO HTTP resolver ships — network dereferencing is SSRF and availability risk the caller must own.
+  `FSReferenceResolver(fsys, root)` takes a declared document-space root: `relativizeToRoot` strips it
+  (matched at a segment boundary, with a trailing slash) so an IN-root absolute URI resolves as the remainder
+  below it, while a URI outside the root passes through unchanged and then meets the same containment checks
+  an empty root applies — declaring a root only ever widens, and only within the named space. There is no new
+  size constant: `readBoundedReference` reads `remaining()+1` bytes off the decrypt's own budget
+  (`MaxCipherValueBytes` for a payload reference, `MaxEncryptedKeyBytes` for a key one), so an over-budget
+  resource is never buffered in full and the budget's own sentinel refuses it. The read runs on a goroutine
+  selected against `ctx.Done()` (a blocked `Read` cannot be polled out of) with a per-Read ctx poll, and the
+  stream is CLOSED on completion, over-budget, and cancellation alike, and equally when `ResolveReference`
+  itself returns a stream alongside an error — closing is what releases a blocked read. That makes the bound
+  and the cancellation properties of the INTERFACE, so they hold for any resolver a caller writes; what the
+  package cannot constrain is a resolver buffering internally or blocking inside `ResolveReference`. A
+  resolver returning a nil stream with a nil error is refused as `ErrReferenceNotFound`.
+  `xmlenc1.ReferenceResolver` returns `io.ReadCloser` while `xmldsig1.ReferenceResolver` returns `[]byte`, so
+  one value does NOT satisfy both, and NEITHER package imports the other
+- xmlenc-core1 is implemented except where the package deliberately departs from it, and each departure is
+  named with its reason. Triple DES (`#tripledes-cbc`, §5.2.2 REQUIRED; `#kw-tripledes`, §5.7.1 REQUIRED) is
+  REFUSED, not pending — a 64-bit block cipher is subject to Sweet32 (CVE-2016-2183) and NIST SP 800-131A Rev.
+  2 disallows TDEA encryption after 2023; the specification marks it REQUIRED because it predates that
+  retirement, and this package follows the retirement, so neither URI will be implemented: block encryption
+  and key wrapping are AES-only, and either URI fails with an error matching the relevant operation sentinel
+  while preserving a typed `*UnsupportedAlgorithmError`, with the two exceptions the README's conformance
+  scope states: `#tripledes-cbc` on an `EncryptedData` carrying no `<EncryptedKey>` and no `SessionKey`
+  reports `ErrMissingKey` from the earlier `len(keys) == 0` check, and `#kw-tripledes` is never reached under
+  a non-empty `SessionKey`, which decrypts past it. `AES192CBC` is likewise absent but §5.2.3 marks it
+  OPTIONAL, so it is not a conformance gap
+- The committed `xmlenc1/summary-xmlenc11.md` snapshot (10 pass / 0 skip / 0 fail, generator output — never
+  hand-edit it) exercises key protection only: six ECDH-ES ConcatKDF vectors on EC-P256/P384/P521 and four
+  rsa-oaep vectors on RSA-2048/3072/4096, all of them AES-GCM. It is evidence for no CBC block algorithm, for
+  the refused Triple DES algorithms, for no `ds:RetrievalMethod`, for no `xenc:CipherReference`, and it is not
+  the merlin corpus. The 1.1 interop corpus holds no Triple DES vector, so the ten are the suite in full and
+  nothing is skipped. `xmlenc1/README.md`'s "Conformance scope" section is the user-facing statement of all of
+  this
+- NO third-party interop vector covers `xenc:CipherReference` at any level of transform support: the only one
+  in the Santuario corpus needs BOTH an XPath transform and `aes192-cbc`, neither of which this package
+  implements. Do not add a skip entry implying a vector is being passed over — there is no runnable vector to
+  run
+- `xmlenc1/testdata/interop/` holds the one third-party `ds:RetrievalMethod` vector,
+  `encrypt-element-aes256-cbc-retrieved-kw-aes256.xml` from the Baltimore/Merlin examples in the Apache
+  Santuario corpus, run by `TestInteropRetrievalMethod` (`interop_test.go`) under the published key-encryption
+  key `abcdefghijklmnopqrstuvwxyz012345` (the corpus name "jed"). It is asserted as far as this package
+  decrypts it: the reference resolves and the session key unwraps, pinned by the error being
+  `ErrDecryptionFailed` with neither `ErrMissingKey`/`ErrReferenceNotFound` nor `ErrKeyUnwrapFailed` in the
+  chain. The block decryption then fails on the padding, which is a property of the vector and NOT of the
+  reference — xmlenc-core1 §5.2.1 pads with N-1 ARBITRARY octets plus a final octet N, while
+  `pkcs7UnpadConstantTime` (`block.go`) requires every padding octet to equal N — so this vector cannot yield
+  plaintext until the CBC path accepts §5.2.1 padding
+- The xmlenc-core1 wire structs (`types.go`) are UNEXPORTED — `encryptedData`, `encryptedKey`,
+  `encryptionMethod`, `agreementMethod`, `keyDerivationMethod`, `ecKeyValue`. No exported function, method, or
+  variable takes or returns one, so they are not API and no field of any of them is a compatibility promise.
+  `ConcatKDFParams` is the one wire-adjacent struct that stays exported, because
+  `Encryptor.KeyDerivationParams` takes it. `export_test.go` declares one exported alias per struct
+  (`EncryptedData = encryptedData` and so on), compiled only under test, so the external `xmlenc1_test`
+  package can still assemble and inspect a wire shape directly. The fields those tests read stay exported on
+  the unexported struct; the two nothing outside the package reads, `encryptedKey.recipient` and
+  `ecKeyValue.curve`, are unexported as well
+- Files: `xmlenc1.go` (API), `context.go` (cancellation helpers), `constants.go`, `block.go`,
+  `keytransport.go`, `keywrap.go`, `key_agreement.go`, `reference.go` (same-document `ds:RetrievalMethod` and
+  `xenc:CipherReference` resolution), `reference_resolver.go` (`ReferenceResolver`, `FSReferenceResolver`, URI
+  joining), `types.go`, `serialize.go`, `parse.go`, `errors.go`
 - Imports: helium, c14n
 
 ## shim/
@@ -539,7 +2143,11 @@ String cursor for character-by-character parsing.
 
 ## internal/unparsedtext/
 
-Shared resource loading for `fn:doc`, `fn:doc-available`, `fn:json-doc`, `fn:unparsed-text`, `fn:unparsed-text-available`, `fn:unparsed-text-lines`. Secure by default: with no `URIResolver` and no `HTTPClient`, every retrieval errors out (no implicit `http.DefaultClient`, no implicit `os.ReadFile`). Constructors: `NewHTTPResolver(*http.Client)`, `NewFileResolver(fs.FS)`; `FileURIResolver{BaseDir}` refuses `..` traversal outside `BaseDir`.
+Shared resource loading for `fn:doc`, `fn:doc-available`, `fn:json-doc`, `fn:unparsed-text`,
+`fn:unparsed-text-available`, `fn:unparsed-text-lines`. Secure by default: with no `URIResolver` and no
+`HTTPClient`, every retrieval errors out (no implicit `http.DefaultClient`, no implicit `os.ReadFile`).
+Constructors: `NewHTTPResolver(*http.Client)`, `NewFileResolver(fs.FS)`; `FileURIResolver{BaseDir}` refuses
+`..` traversal outside `BaseDir`.
 
 - Files: `unparsedtext.go`
 - Imports: `internal/encoding`, `internal/lexicon`
@@ -568,7 +2176,11 @@ Generic bitset operations for bitmask types.
 Parser option bitset type and constants. Bit positions match libxml2's XML_PARSE_* constants.
 
 - **Option** — int-based bitset type for parser flags
-- Constants: `Recover`, `NoEnt`, `DTDLoad`, `DTDAttr`, `DTDValid`, `NoError`, `NoWarning`, `Pedantic`, `NoBlanks`, `XInclude`, `NoNet`, `NoDict`, `NsClean`, `NoCDATA`, `NoXIncNode`, `Compact`, `NoBaseFix`, `IgnoreEnc`, `BigLines`, `NoXXE`, `NoUnzip`, `NoSysCatalog`, `CatalogPI`, `SkipIDs`, `LenientXMLDecl` (the `Huge`/`XML_PARSE_HUGE` bit is retired — replaced by the `Parser` per-limit knobs `MaxNameLength`/`MaxEntityAmplification`/`MaxContentModelDepth`)
+- Constants: `Recover`, `NoEnt`, `DTDLoad`, `DTDAttr`, `DTDValid`, `NoError`, `NoWarning`, `Pedantic`,
+  `NoBlanks`, `XInclude`, `NoNet`, `NoDict`, `NsClean`, `NoCDATA`, `NoXIncNode`, `Compact`, `NoBaseFix`,
+  `IgnoreEnc`, `BigLines`, `NoXXE`, `NoUnzip`, `NoSysCatalog`, `CatalogPI`, `SkipIDs`, `LenientXMLDecl` (the
+  `Huge`/`XML_PARSE_HUGE` bit is retired — replaced by the `Parser` per-limit knobs
+  `MaxNameLength`/`MaxEntityAmplification`/`MaxContentModelDepth`)
 - Methods: `Set(Option)`, `Clear(Option)`, `IsSet(Option) → bool`
 - Files: `options.go`
 - Imports: internal/bitset

--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -59,7 +59,10 @@ Central state struct (`parserctx.go`). Key fields:
 - `getCursor()` — current cursor; auto-pops exhausted ones, caches the active cursor between calls
 
 ### Parser State Machine
-States: `psStart`, `psContent`, `psPrologue`, `psEpilogue`, `psCDATA`, `psDTD`, `psEntityDecl`, `psAttributeValue`, `psComment`, `psStartTag`, `psEndTag`, `psSystemLiteral`, `psPublicLiteral`, `psEntityValue`, `psIgnore`, `psMisc`, `psPI`, `psEOF`. State affects parsing rules (e.g. external entity refs forbidden in `psAttributeValue`; PE handling restricted in `psDTD`).
+States: `psStart`, `psContent`, `psPrologue`, `psEpilogue`, `psCDATA`, `psDTD`, `psEntityDecl`,
+`psAttributeValue`, `psComment`, `psStartTag`, `psEndTag`, `psSystemLiteral`, `psPublicLiteral`,
+`psEntityValue`, `psIgnore`, `psMisc`, `psPI`, `psEOF`. State affects parsing rules (e.g. external entity refs
+forbidden in `psAttributeValue`; PE handling restricted in `psDTD`).
 
 ### Element/Namespace Stacks
 - `nodeTab` (nodeStack) — element nesting stack
@@ -70,19 +73,61 @@ States: `psStart`, `psContent`, `psPrologue`, `psEpilogue`, `psCDATA`, `psDTD`, 
 ### XML 1.1 Version-Gated Rules
 `pctx.isXML11()` gates version-specific rules; every non-1.1 document stays byte-identical:
 - Namespace prefix undeclaration (`xmlns:pfx=""`) — `parser_element.go` `validatePrefixedNamespaceDecl`
-- Restricted characters — raw literal values reject in text, attributes, comments, PIs, CDATA, non-PUBLIC DTD literals, cached external-PE bodies, and external-DTD `IGNORE` sections via `parser_content.go` `isLiteralCharValue`, `parser_dtd_attr.go` `scanQuotedLiteral`, and `parser_dtd_subset.go` `parseConditionalSections` / `loadExternalParameterEntityContent`; cached PE bodies use their effective TextDecl version. `IGNORE` scans decode non-delimiter UTF-8 as runes before validation. Character references accept their XML 1.1 values via `parser_entity_ref.go` `parseCharRef` / `parseStringCharRef` / `isXML11CharValue`; parsed internal entity values retain XML 1.1 restricted-character-reference segments for nested reparse while `Entity.Content()` remains decoded
+- Restricted characters — raw literal values reject in text, attributes, comments, PIs, CDATA, non-PUBLIC DTD
+  literals, cached external-PE bodies, and external-DTD `IGNORE` sections via `parser_content.go`
+  `isLiteralCharValue`, `parser_dtd_attr.go` `scanQuotedLiteral`, and `parser_dtd_subset.go`
+  `parseConditionalSections` / `loadExternalParameterEntityContent`; cached PE bodies use their effective
+  TextDecl version. `IGNORE` scans decode non-delimiter UTF-8 as runes before validation. Character references
+  accept their XML 1.1 values via `parser_entity_ref.go` `parseCharRef` / `parseStringCharRef` /
+  `isXML11CharValue`; parsed internal entity values retain XML 1.1 restricted-character-reference segments for
+  nested reparse while `Entity.Content()` remains decoded
 
 ### SAX & Tree Building
 - `sax` (sax.SAX2Handler) — callbacks (default: TreeBuilder; `Parser.SAXHandler(nil)` restores that default, so this is never nil at parse time)
 - `doc *Document` — parsed document; `elem *Element` — current element
 
 ### DTD & Entities
-- `attsSpecial` / `attsSpecialExternal` — DTD special-attribute normalization keying + external-markup provenance (§2.9 standalone VC); see `addSpecialAttribute` / `parseAttribute` (`parser_element.go`). `xml:id` unconditional normalization is a deliberate XPath-3.1/xml:id-§4 divergence from libxml2
+- `attsSpecial` / `attsSpecialExternal` — DTD special-attribute normalization keying + external-markup
+  provenance (§2.9 standalone VC); see `addSpecialAttribute` / `parseAttribute` (`parser_element.go`).
+  `xml:id` unconditional normalization is a deliberate XPath-3.1/xml:id-§4 divergence from libxml2
 - `attsDefault` — DTD default attributes
 - `inSubset int` — 0=none, 1=internal, 2=external
 - `replaceEntities bool` — expand entity refs (SubstituteEntities(true))
-- `fsys fs.FS` — filesystem for external DTDs/entities; defaults to `internal/iofs.DenyAll{}` (safe-by-default), overridden via `Parser.FS()`; `catalogOpenName` (`tree_builder.go`) maps `file:` URIs to local paths. `openExternalResource` (`tree_builder.go`) opens through `fsys`: it tries the raw resolved name first (a `file:` URI/absolute path verbatim, so `iofs.PermissiveRoot`/os.Open and a file-URI-keyed FS are unchanged), and on an `fs.ErrInvalid` rejection — returned by `os.DirFS`/`os.Root.FS`/`fs.Sub`, never by PermissiveRoot/DenyAll — retries with the name made relative to the **fixed top-level document base**'s directory (`documentBaseURI`, captured once at parse start via `parserCtx.init` and carried through nested sub-parses by `inheritNestedParserState`, NOT the moving per-resource `baseURI`), via `catalogOpenName`→`baseRelativeFSName`, so a confined FS rooted at the document's directory resolves a SYSTEM id — including a nested resource in a subdirectory (relativized against the document root). The retry fires **only for an originally-relative reference**: `openExternalResource` takes a `retryEligible` bool gated by `systemIDRetryEligible` on the SYSTEM id **as declared** (before URI resolution / catalog mapping) — ineligible when the id is an absolute path, carries a URI scheme, **or has a colon anywhere in its first path segment** (the part before the first `/`/`\`; this catches a one-letter RFC 3986 scheme like `x:opaque` and a bare drive letter, which `HasURIScheme`'s 2-char minimum does not) — so an originally-absolute, `file:`-URI, or otherwise scheme-carrying SYSTEM id is never retried, even one naming an in-root file whose base-relative form would be a valid `fs.ValidPath` (`filepath.Rel` would re-relativize it, so eligibility, NOT the retry name's path-shape, enforces the promise). Eligibility is passed directly by `ExternalSubset`; for entity resolution the two entity loaders (`parseExternalEntityPrivate`, `loadExternalParameterEntityContent`) set `parserCtx.extRefRelative` from the entity's declared `systemID` around the `ResolveEntity` call. The supported confined-FS document base is an **absolute path or `file:` URI** (as `ParseFile` sets); a relative document base is out of scope — `BuildURI` yields a valid-but-absent relative path that fails with `fs.ErrNotExist` (not `fs.ErrInvalid`), so the retry never fires (`helium.DirFS(root)` — `internal/iofs.ConfinedDir`, which serves an in-root absolute name directly — is the general fix for an FS rooted elsewhere than the document directory). The retry name is a validated `fs.ValidPath` (leading `/` or surviving `..` disqualifies it → blocks `../`/absolute path escape; does NOT confine symlinks — `os.DirFS` follows an in-root symlink out of root, only `os.Root.FS` is symlink-safe). `openExternalResource` is the single network-guard enforcement point: `networkAccessForbidden` runs on the primary AND the retry name (returning `ErrNetworkAccessForbidden`), so a base-relative retry that becomes a network-scheme name is refused too
-- Entity sub-parsers seed nested context via `inheritNestedParserState` (`parser_entity_decl.go`) — copies policy + running resource-accounting (depth, `ebcdicConsumed`). An external DTD or external parsed parameter/general entity uses its compatible TextDecl version only while its replacement text is parsed; input-pop restoration preserves the parent parser state and the document's recorded version; see the parser context and entity-loader doc comments
+- `fsys fs.FS` — filesystem for external DTDs/entities; defaults to `internal/iofs.DenyAll{}`
+  (safe-by-default), overridden via `Parser.FS()`; `catalogOpenName` (`tree_builder.go`) maps `file:` URIs to
+  local paths. `openExternalResource` (`tree_builder.go`) opens through `fsys`: it tries the raw resolved name
+  first (a `file:` URI/absolute path verbatim, so `iofs.PermissiveRoot`/os.Open and a file-URI-keyed FS are
+  unchanged), and on an `fs.ErrInvalid` rejection — returned by `os.DirFS`/`os.Root.FS`/`fs.Sub`, never by
+  PermissiveRoot/DenyAll — retries with the name made relative to the **fixed top-level document base**'s
+  directory (`documentBaseURI`, captured once at parse start via `parserCtx.init` and carried through nested
+  sub-parses by `inheritNestedParserState`, NOT the moving per-resource `baseURI`), via
+  `catalogOpenName`→`baseRelativeFSName`, so a confined FS rooted at the document's directory resolves a
+  SYSTEM id — including a nested resource in a subdirectory (relativized against the document root). The retry
+  fires **only for an originally-relative reference**: `openExternalResource` takes a `retryEligible` bool
+  gated by `systemIDRetryEligible` on the SYSTEM id **as declared** (before URI resolution / catalog mapping)
+  — ineligible when the id is an absolute path, carries a URI scheme, **or has a colon anywhere in its first
+  path segment** (the part before the first `/`/`\`; this catches a one-letter RFC 3986 scheme like `x:opaque`
+  and a bare drive letter, which `HasURIScheme`'s 2-char minimum does not) — so an originally-absolute,
+  `file:`-URI, or otherwise scheme-carrying SYSTEM id is never retried, even one naming an in-root file whose
+  base-relative form would be a valid `fs.ValidPath` (`filepath.Rel` would re-relativize it, so eligibility,
+  NOT the retry name's path-shape, enforces the promise). Eligibility is passed directly by `ExternalSubset`;
+  for entity resolution the two entity loaders (`parseExternalEntityPrivate`,
+  `loadExternalParameterEntityContent`) set `parserCtx.extRefRelative` from the entity's declared `systemID`
+  around the `ResolveEntity` call. The supported confined-FS document base is an **absolute path or `file:`
+  URI** (as `ParseFile` sets); a relative document base is out of scope — `BuildURI` yields a valid-but-absent
+  relative path that fails with `fs.ErrNotExist` (not `fs.ErrInvalid`), so the retry never fires
+  (`helium.DirFS(root)` — `internal/iofs.ConfinedDir`, which serves an in-root absolute name directly — is the
+  general fix for an FS rooted elsewhere than the document directory). The retry name is a validated
+  `fs.ValidPath` (leading `/` or surviving `..` disqualifies it → blocks `../`/absolute path escape; does NOT
+  confine symlinks — `os.DirFS` follows an in-root symlink out of root, only `os.Root.FS` is symlink-safe).
+  `openExternalResource` is the single network-guard enforcement point: `networkAccessForbidden` runs on the
+  primary AND the retry name (returning `ErrNetworkAccessForbidden`), so a base-relative retry that becomes a
+  network-scheme name is refused too
+- Entity sub-parsers seed nested context via `inheritNestedParserState` (`parser_entity_decl.go`) — copies
+  policy + running resource-accounting (depth, `ebcdicConsumed`). An external DTD or external parsed
+  parameter/general entity uses its compatible TextDecl version only while its replacement text is parsed;
+  input-pop restoration preserves the parent parser state and the document's recorded version; see the parser
+  context and entity-loader doc comments
 
 ### Entity Amplification Guard
 - `sizeentcopy` (cumulative expansion bytes), `maxAmpl` (5 default; 0 with MaxEntityAmplification(-1)), `inputSize`
@@ -93,9 +138,15 @@ States: `psStart`, `psContent`, `psPrologue`, `psEpilogue`, `psCDATA`, `psDTD`, 
 
 ## Encoding Detection
 
-`detectEncoding()` order: UCS-4 BE/LE/2143/3412 (PEEK, not consume) → EBCDIC invariant prefix → UTF-8 BOM → UTF-16 BOM → UTF-16 by context → default ASCII/UTF-8. `switchEncoding()` pops the ByteCursor, pushes a RuneCursor wrapping the encoder. UTF-16 switches encoding before parsing the decl; EBCDIC extracts the name from the invariant charset (default IBM-037); ASCII-compatible parses the decl at byte level then switches.
+`detectEncoding()` order: UCS-4 BE/LE/2143/3412 (PEEK, not consume) → EBCDIC invariant prefix → UTF-8 BOM →
+UTF-16 BOM → UTF-16 by context → default ASCII/UTF-8. `switchEncoding()` pops the ByteCursor, pushes a
+RuneCursor wrapping the encoder. UTF-16 switches encoding before parsing the decl; EBCDIC extracts the name
+from the invariant charset (default IBM-037); ASCII-compatible parses the decl at byte level then switches.
 
-- BOM vs declared encoding — `checkBOMEncodingConflict` (`parser_encoding.go`): a declared name resolving to a different Unicode family than a consumed BOM is fatal `ErrEncodingBOMMismatch` (§4.3.3; stricter than libxml2). Reads `pctx.declaredEncoding` (recorded unconditionally at the leaf EncName parsers), so it fires under `IgnoreEncoding`/`LenientXMLDecl`.
+- BOM vs declared encoding — `checkBOMEncodingConflict` (`parser_encoding.go`): a declared name resolving to a
+  different Unicode family than a consumed BOM is fatal `ErrEncodingBOMMismatch` (§4.3.3; stricter than
+  libxml2). Reads `pctx.declaredEncoding` (recorded unconditionally at the leaf EncName parsers), so it fires
+  under `IgnoreEncoding`/`LenientXMLDecl`.
 - Strict fixed-width decode — `withStrictDecode` (`internal/encoding/strict.go`): malformed UTF-16/32/UCS-2/4 → fatal `ErrInvalidEncodedChar`; surfaced via `UTF8Cursor.Err()` at the document-end gate.
 - Strict US-ASCII decode — `asciiEncoding` (`internal/encoding/ascii.go`): any byte ≥ 0x80 → fatal `ErrInvalidASCII`.
 
@@ -113,15 +164,38 @@ Each file's functions carry the spec citations (XML/Namespaces clauses, W3C test
 
 ## Entity Expansion
 
-Flow: `parseReference()` → `parseEntityRef()` → `entityCheck()` → parse content (`parseBalancedChunkInternal` / `parseExternalEntityPrivate`) → deliver to SAX (expand + replay node children when `replaceEntities`, else fire `Reference`). Each invariant lives at its function:
+Flow: `parseReference()` → `parseEntityRef()` → `entityCheck()` → parse content (`parseBalancedChunkInternal`
+/ `parseExternalEntityPrivate`) → deliver to SAX (expand + replay node children when `replaceEntities`, else
+fire `Reference`). Each invariant lives at its function:
 
 - Amplification guard — `entityCheck` / `entityCheckBytes` (`parser_entity_ref.go`); external content read through `io.LimitReader` (`externalEntityMaxBytes` 10 MiB) charged raw-only to avoid double-counting the fixed cost
 - WFC Entity Declared under standalone="yes" (§4.1/§2.9) — `getEntity` / `undeclaredEntityValidityError` (`parser_entity_ref.go`)
-- Balanced replacement text (WFC §4.3.2) — `parseBalancedChunkInternal` → `ErrEntityNotWellBalanced`; nested internal-entity parsing inherits the parent effective XML version, and its lexical replacement form retains XML 1.1 restricted-character-reference origin so XML 1.1 validates a reference separately from a raw literal
-- External entity/DTD TextDecl handling + version check (§4.3.1/§4.3.4) — `parseExternalEntityPrivate` (`parser_entity_decl.go`), `decodeExternalPEContentVersion` / `decodeFixedWidthExternalContent`, `checkEntityVersion`; the effective compatible TextDecl version is scoped to the decoded external DTD or parameter/general-entity input
-- Document XMLDecl VersionNum constraint (§2.8) — `checkDocumentVersion` (`parser_xml_decl.go`), applied on all four document-declaration paths (`parseXMLDecl`, `parseXMLDeclFromCursor`, and both `LenientXMLDecl` variants — that option relaxes pseudo-attribute ORDER only), never on a TextDecl. `versionNumLen` (`parser_decl.go`) is the single definition of the VersionNum grammar and accepts the looser `[0-9] '.' [0-9]+` (a faithful port of libxml2 `xmlParseVersionNum`); BOTH version parsers scan through it — the byte path (`parseVersionNum`) and the rune-cursor path used for UTF-16/UCS-4 (`parseVersionInfoFromCursor`) — so the two accept exactly the same VersionNum language. The remaining constraint is enforced separately, mirroring libxml2 `xmlParseXMLDecl`: `1.0`/`1.1` pass silently; another `1.x` warns (`XML_WAR_UNKNOWN_VERSION`) and parsing continues with the declared version retained; anything outside the 1.x family is fatal `ErrUnsupportedXMLVersion` (`XML_ERR_UNKNOWN_VERSION`). libxml2 warns on `1.1` too — helium implements XML 1.1 (`isXML11`), so it stays silent there. Both halves are load-bearing for the roundtrip invariant — every version the parser accepts serializes through the `Writer`, whose `'1.' [0-9]+` check (`isValidXMLVersion`) is stricter than the grammar: the family check alone would pass a non-VersionNum like `1.x` (it has the `1.` prefix) and the grammar alone would pass `2.0`. A path enforcing only one of the two reopens the accept-then-fail-to-serialize gap
+- Balanced replacement text (WFC §4.3.2) — `parseBalancedChunkInternal` → `ErrEntityNotWellBalanced`; nested
+  internal-entity parsing inherits the parent effective XML version, and its lexical replacement form retains
+  XML 1.1 restricted-character-reference origin so XML 1.1 validates a reference separately from a raw literal
+- External entity/DTD TextDecl handling + version check (§4.3.1/§4.3.4) — `parseExternalEntityPrivate`
+  (`parser_entity_decl.go`), `decodeExternalPEContentVersion` / `decodeFixedWidthExternalContent`,
+  `checkEntityVersion`; the effective compatible TextDecl version is scoped to the decoded external DTD or
+  parameter/general-entity input
+- Document XMLDecl VersionNum constraint (§2.8) — `checkDocumentVersion` (`parser_xml_decl.go`), applied on
+  all four document-declaration paths (`parseXMLDecl`, `parseXMLDeclFromCursor`, and both `LenientXMLDecl`
+  variants — that option relaxes pseudo-attribute ORDER only), never on a TextDecl. `versionNumLen`
+  (`parser_decl.go`) is the single definition of the VersionNum grammar and accepts the looser `[0-9] '.'
+  [0-9]+` (a faithful port of libxml2 `xmlParseVersionNum`); BOTH version parsers scan through it — the byte
+  path (`parseVersionNum`) and the rune-cursor path used for UTF-16/UCS-4 (`parseVersionInfoFromCursor`) — so
+  the two accept exactly the same VersionNum language. The remaining constraint is enforced separately,
+  mirroring libxml2 `xmlParseXMLDecl`: `1.0`/`1.1` pass silently; another `1.x` warns
+  (`XML_WAR_UNKNOWN_VERSION`) and parsing continues with the declared version retained; anything outside the
+  1.x family is fatal `ErrUnsupportedXMLVersion` (`XML_ERR_UNKNOWN_VERSION`). libxml2 warns on `1.1` too —
+  helium implements XML 1.1 (`isXML11`), so it stays silent there. Both halves are load-bearing for the
+  roundtrip invariant — every version the parser accepts serializes through the `Writer`, whose `'1.' [0-9]+`
+  check (`isValidXMLVersion`) is stricter than the grammar: the family check alone would pass a non-VersionNum
+  like `1.x` (it has the `1.` prefix) and the grammar alone would pass `2.0`. A path enforcing only one of the
+  two reopens the accept-then-fail-to-serialize gap
 - Character-reference provenance (element-content validity, §3.2.1 E15) — `charDataFromCharRef` flag in `parseReference`; `fromCharRef` node field (see `node-types.md`)
-- Parameter entity refs — `parsePEReference` (`parser_dtd_subset.go`): charges the PE's OWN replacement bytes (not post-expansion), `padPEContent` §4.4.8; external PE load via `loadExternalParameterEntityContent` (XXE-gated, base-URI- and TextDecl-version-scoped, active-PE recursion guard)
+- Parameter entity refs — `parsePEReference` (`parser_dtd_subset.go`): charges the PE's OWN replacement bytes
+  (not post-expansion), `padPEContent` §4.4.8; external PE load via `loadExternalParameterEntityContent`
+  (XXE-gated, base-URI- and TextDecl-version-scoped, active-PE recursion guard)
 - PE references inside/adjacent to markup decls (external subset) — `skipBlanksPE` (`parser_whitespace.go`) + `dtdRefetch`; boundary violations → `ErrEntityBoundary` (VC Proper Declaration/Group/PE Nesting)
 - WFC PEs in Internal Subset (§2.8) — `expandEntityValueForRefCheck` `%` branch → `ErrPEReferenceInInternalSubset`
 - Attribute-value entity WFCs (No External Ref / No `<` / Entity Declared) — `checkEntityInAttValue` / `lookupGeneralEntity`, memoized via `entWFCValidated`/`entWFCChecked`; DTD defaults re-scanned by `validateAttributeDefaultsWFC`
@@ -137,7 +211,16 @@ Flow: `parseReference()` → `parseEntityRef()` → `entityCheck()` → parse co
 - `Characters` → AppendText (merges adjacent text)
 - `CDataBlock` → CDATASection; `Comment` → Comment; `ProcessingInstruction` → PI
 - `InternalSubset` → internal DTD
-- `ExternalSubset` → load decision resolved ONCE from three independent intents (matching libxml2): load iff `parseDTDValid` (ValidateDTD) OR `DetectIDs` (LoadExternalDTD → parseDTDLoad) OR `CompleteAttrs` (DefaultDTDAttributes → parseDTDAttr) — so call order never changes whether the subset loads. The `LoadExternalDTD`/`DefaultDTDAttributes`/`ValidateDTD` setters each touch only their own option bit. A requested-but-failed `fsys.Open` (the gate passed, so loading WAS requested) emits a non-fatal `warning` (naming the resolved URI, gated by `parseNoWarning`) instead of a silent drop, then continues; under validation the missing content model surfaces downstream as `ErrDTDValidationFailed`. Then bounded read (`maxExtDTDSize`, `io.LimitReader`), baseURI scoping, TextDecl decode with input-scoped XML version, PE-expanding declaration loop (`parseExternalSubsetDeclStep`), conditional sections — see the function's doc comments
+- `ExternalSubset` → load decision resolved ONCE from three independent intents (matching libxml2): load iff
+  `parseDTDValid` (ValidateDTD) OR `DetectIDs` (LoadExternalDTD → parseDTDLoad) OR `CompleteAttrs`
+  (DefaultDTDAttributes → parseDTDAttr) — so call order never changes whether the subset loads. The
+  `LoadExternalDTD`/`DefaultDTDAttributes`/`ValidateDTD` setters each touch only their own option bit. A
+  requested-but-failed `fsys.Open` (the gate passed, so loading WAS requested) emits a non-fatal `warning`
+  (naming the resolved URI, gated by `parseNoWarning`) instead of a silent drop, then continues; under
+  validation the missing content model surfaces downstream as `ErrDTDValidationFailed`. Then bounded read
+  (`maxExtDTDSize`, `io.LimitReader`), baseURI scoping, TextDecl decode with input-scoped XML version,
+  PE-expanding declaration loop (`parseExternalSubsetDeclStep`), conditional sections — see the function's doc
+  comments
 - `GetEntity`/`GetParameterEntity` → document entity table lookup
 
 Parent selection: DTD subset → add to DTD; no current element → add to document; else → append as child.
@@ -146,47 +229,96 @@ DOM fast path: when the default parser builds a DOM, start-tag attribute/ID/chil
 
 ## Hardening / Resource-Bound Pointers
 
-Each cap is enforced DURING accumulation (fail-closed before the whole run buffers) and its rationale (DoS intent, spec, strict-greater edges, cancellation) lives at the function. `NewParser` applies secure defaults; the negative-sentinel option disables the cap for trusted input.
+Each cap is enforced DURING accumulation (fail-closed before the whole run buffers) and its rationale (DoS
+intent, spec, strict-greater edges, cancellation) lives at the function. `NewParser` applies secure defaults;
+the negative-sentinel option disables the cap for trusted input.
 
-- **Node-content cap** (`MaxNodeContentSize`, 10 MiB; `resolveLimit`/`nodeContentTooLong`) — caps a single indivisible run: CDATA/comment/PI (`parseCDataContent`/`parsePI`/`parseComment`, `parser_content.go`), DTD quoted literals (`scanQuotedLiteral`, `parser_dtd_attr.go`), char data (`parseCharDataContent` via `nodeContentScanBudget` + `ScanCharDataSlice`/`ScanCharDataInto`), attribute values (`parseAttributeValueInternal` fast path + `writeAttr*`/`attrEntitySink` slow path). Over-cap → `ErrNodeContentTooLarge`. Entity sub-parses inherit the cap via `inheritNestedParserState`; the streaming-SAX char-data path is exempt (already chunked).
-- **Blank-run cap** (`skipBlankRun`/`blankRunLimit`, `parser_whitespace.go`) — the same cap bounds a contiguous whitespace run in 4 KiB chunks; sticky `blankRunErr`, preferred by `errorAtLevel`. DTD subset/INCLUDE loops call `skipBlankRun` directly (not `skipBlanks`, which consumes `%pe;` unexpanded).
+- **Node-content cap** (`MaxNodeContentSize`, 10 MiB; `resolveLimit`/`nodeContentTooLong`) — caps a single
+  indivisible run: CDATA/comment/PI (`parseCDataContent`/`parsePI`/`parseComment`, `parser_content.go`), DTD
+  quoted literals (`scanQuotedLiteral`, `parser_dtd_attr.go`), char data (`parseCharDataContent` via
+  `nodeContentScanBudget` + `ScanCharDataSlice`/`ScanCharDataInto`), attribute values
+  (`parseAttributeValueInternal` fast path + `writeAttr*`/`attrEntitySink` slow path). Over-cap →
+  `ErrNodeContentTooLarge`. Entity sub-parses inherit the cap via `inheritNestedParserState`; the
+  streaming-SAX char-data path is exempt (already chunked).
+- **Blank-run cap** (`skipBlankRun`/`blankRunLimit`, `parser_whitespace.go`) — the same cap bounds a
+  contiguous whitespace run in 4 KiB chunks; sticky `blankRunErr`, preferred by `errorAtLevel`. DTD
+  subset/INCLUDE loops call `skipBlankRun` directly (not `skipBlanks`, which consumes `%pe;` unexpanded).
 - **Character buffering** (`deliverCharacters`, `CharBufferSize`) — UTF-8-boundary-respecting chunking; bounded streaming-SAX char-data path `parseCharDataChunkedSAX` (no DOM built) with a documented over-budget blank-run reclassification policy.
-- **UTF-8 fast paths** — `parseQName`/`parseNCName`/`parseAttributeValueInternal` try `ScanQNameBytes`/`ScanNCNameBytes`/`ScanSimpleAttrValue`, intern before advancing (advance may compact the cursor buffer, invalidating borrowed slices), and use `AdvanceFast()` when the run is proven newline-free. See `internal/strcursor/utf8cursor.go`.
+- **UTF-8 fast paths** — `parseQName`/`parseNCName`/`parseAttributeValueInternal` try
+  `ScanQNameBytes`/`ScanNCNameBytes`/`ScanSimpleAttrValue`, intern before advancing (advance may compact the
+  cursor buffer, invalidating borrowed slices), and use `AdvanceFast()` when the run is proven newline-free.
+  See `internal/strcursor/utf8cursor.go`.
 - **Name interning** (`intern.go`) — global lexicon seed with a `(first byte, length)` cheap-check before the map probe.
 - **Entity-amplification / external bounds** — see Entity Expansion above.
-- **Start-tag duplicate detection** (`parser_element.go` `attrDupSetThreshold` = 32) — per-start-tag attribute (qualified-name and expanded-name) and namespace-declaration duplicate checks scan the tag's own `attrs`/`nsDeclared` linearly below the threshold (unchanged, no allocation); at or above it each switches once to a map-backed set (`ensureAttrSet`/`ensureNsSet`, keyed by `attrKey`{local, prefix-or-URI} or bare prefix string), so a tag with many attributes or namespace declarations is linear instead of quadratic. `addAttributeDefault` (`parser_dtd_attr.go`) uses a map with no threshold (`parserCtx.attsDefaultSeen`, shared with `attsDefault` via `inheritNestedParserState`), since it already does a map probe/store per call. That map is DTD-only, so it is allocated lazily by `attributeDefaultSeen` on the first `<!ATTLIST>` default and a document without a DTD allocates nothing for it; `inheritNestedParserState` materializes it through that accessor so parent and nested sub-parse share ONE set (a plain copy of a nil map would let the sub-parse build its own and lose cross-boundary dedup). `parser_attlist_test.go` pins the no-DTD parse allocation count.
+- **Start-tag duplicate detection** (`parser_element.go` `attrDupSetThreshold` = 32) — per-start-tag attribute
+  (qualified-name and expanded-name) and namespace-declaration duplicate checks scan the tag's own
+  `attrs`/`nsDeclared` linearly below the threshold (unchanged, no allocation); at or above it each switches
+  once to a map-backed set (`ensureAttrSet`/`ensureNsSet`, keyed by `attrKey`{local, prefix-or-URI} or bare
+  prefix string), so a tag with many attributes or namespace declarations is linear instead of quadratic.
+  `addAttributeDefault` (`parser_dtd_attr.go`) uses a map with no threshold (`parserCtx.attsDefaultSeen`,
+  shared with `attsDefault` via `inheritNestedParserState`), since it already does a map probe/store per call.
+  That map is DTD-only, so it is allocated lazily by `attributeDefaultSeen` on the first `<!ATTLIST>` default
+  and a document without a DTD allocates nothing for it; `inheritNestedParserState` materializes it through
+  that accessor so parent and nested sub-parse share ONE set (a plain copy of a nil map would let the
+  sub-parse build its own and lose cross-boundary dedup). `parser_attlist_test.go` pins the no-DTD parse
+  allocation count.
 
 ## Context Cancellation (parse abort)
 
-`context.Canceled`/`context.DeadlineExceeded` BYPASS recovery (even under `RecoverOnError`), return a nil document + the context error (never a partial tree), and do NOT invoke the SAX `Error` handler. Checked BETWEEN reads/parse steps — an in-progress `io.Reader.Read` cannot be interrupted generically (`Parse([]byte)` has no blocking read; `ParseReader` needs a context-honoring reader; the push parser's stream wait is a `sync.Cond` unblocked by a watcher goroutine on `ctx.Done()`). Bounded scanners (blank scan, char-data, char-ref) re-check `ctx.Err()` and disambiguate exhaustion from a sticky cursor read error via `HasByteAt`/`Err()` for push-cancel safety. See `parseDocument`, `skipBlankRun`, and the `push` package.
+`context.Canceled`/`context.DeadlineExceeded` BYPASS recovery (even under `RecoverOnError`), return a nil
+document + the context error (never a partial tree), and do NOT invoke the SAX `Error` handler. Checked
+BETWEEN reads/parse steps — an in-progress `io.Reader.Read` cannot be interrupted generically (`Parse([]byte)`
+has no blocking read; `ParseReader` needs a context-honoring reader; the push parser's stream wait is a
+`sync.Cond` unblocked by a watcher goroutine on `ctx.Done()`). Bounded scanners (blank scan, char-data,
+char-ref) re-check `ctx.Err()` and disambiguate exhaustion from a sticky cursor read error via
+`HasByteAt`/`Err()` for push-cancel safety. See `parseDocument`, `skipBlankRun`, and the `push` package.
 
 ## Push Parser
 
 Both push parsers use the `push` package (`push.Parser[T]`): a background goroutine reading a thread-safe stream via `ParseReader`; `pp.Push(chunk)` / `doc, err := pp.Close()`.
 
 - **XML** (`parser.go` + `push/`) — progressive from the first byte; stream `Read` returns available bytes without waiting to fill, context-aware wait (see Context Cancellation)
-- **HTML** (`html/html.go` + `push/`) — progressive only AFTER the 1024-byte (or EOF) charset prescan (`wrapReaderForHTML`, `html/encoding_reader.go`) and once a streamable encoding is settled; an undeclared valid-UTF-8 stream defers to EOF/Close (`deferredLatin1Reader`, bounded by `contentLimit()`, fail-closed at the cap)
+- **HTML** (`html/html.go` + `push/`) — progressive only AFTER the 1024-byte (or EOF) charset prescan
+  (`wrapReaderForHTML`, `html/encoding_reader.go`) and once a streamable encoding is settled; an undeclared
+  valid-UTF-8 stream defers to EOF/Close (`deferredLatin1Reader`, bounded by `contentLimit()`, fail-closed at
+  the cap)
 - `ParseFile` (XML/HTML) opens the file and delegates to `ParseReader` so limits + cancellation apply during the read
-- **EBCDIC over a reader** (`parser_document.go` `encEBCDIC` branch) — non-ASCII-compatible; the name is recovered by `encoding.ExtractEBCDICEncoding` from a bounded sniff prefix, then STREAM-decoded (not buffered whole); `countingReader`/`ebcdicConsumed` feeds the amplification guard the real consumed-byte count. See `ParseReader` doc comments.
+- **EBCDIC over a reader** (`parser_document.go` `encEBCDIC` branch) — non-ASCII-compatible; the name is
+  recovered by `encoding.ExtractEBCDICEncoding` from a bounded sniff prefix, then STREAM-decoded (not buffered
+  whole); `countingReader`/`ebcdicConsumed` feeds the amplification guard the real consumed-byte count. See
+  `ParseReader` doc comments.
 
 ## HTML Content Bounding (`html/parser.go`, `html/options.go`)
 
 `Parser.MaxContentSize` (`parseConfig.maxContentSize`, effective via `contentLimit()`, 16 MiB default). Two meanings; rationale at each function:
 
-- **Soft cap (chunkable)**: normal data-state text (`parseCharacters`), raw-text (`parseRawContent`), RCDATA (`parseRCDATAContent`), plaintext (`parsePlaintext`) — chunk boundaries never split a rune (`clampTextChunkToRune`, `peekRuneToken`); a section over the cap still parses, in multiple chunks
+- **Soft cap (chunkable)**: normal data-state text (`parseCharacters`), raw-text (`parseRawContent`), RCDATA
+  (`parseRCDATAContent`), plaintext (`parsePlaintext`) — chunk boundaries never split a rune
+  (`clampTextChunkToRune`, `peekRuneToken`); a section over the cap still parses, in multiple chunks
 - **Hard cap (indivisible)**: comments/bogus comments/PIs (`parseComment`/`parseBogusComment`/`parsePI`) → `fatalErr` wrapping `ErrContentSizeExceeded`
 - **Hard cap (tag-level tokens)**: `parseName`/`parseAttrName`/`skipWhitespace` bound `PeekAt` growth against `scanTokenLimit()` (floored at 16 MiB so a small `MaxContentSize` never rejects `script`)
 - **Leading-whitespace deferral** — `emitCharacters` + `pendingWS`/`deferPendingWS`: significance (`StripBlanks`) + implied-`<body>` insertion are decided at the first non-whitespace byte; `pendingWS` bounded by `contentLimit()`, fail-closed
-- **Char-ref bounding** — `parseCharRefBounded` (shared by normal data + RCDATA): fixed 32-byte name lookahead; unresolved-literal / ambiguous-legacy-prefix work charged against the cap; `consumeNumericCharRefBounded` (saturating digit run), `parseSaturatedCharRefLiteral` (bounded spool, no emit before the resolve-vs-literal-vs-error decision)
-- **Surfacing** — `parser.fatalErr` (in-band overruns) and `p.cur.Err()` (deferred-reader `capErr`) both match `errors.Is(err, ErrContentSizeExceeded)`; `parseWhileMaxErr` disambiguates exhaustion from a read error via `HasByteAt`. Every bounded scanner checks `ctx.Err()` between steps and unwinds without emitting a partial node.
+- **Char-ref bounding** — `parseCharRefBounded` (shared by normal data + RCDATA): fixed 32-byte name
+  lookahead; unresolved-literal / ambiguous-legacy-prefix work charged against the cap;
+  `consumeNumericCharRefBounded` (saturating digit run), `parseSaturatedCharRefLiteral` (bounded spool, no
+  emit before the resolve-vs-literal-vs-error decision)
+- **Surfacing** — `parser.fatalErr` (in-band overruns) and `p.cur.Err()` (deferred-reader `capErr`) both match
+  `errors.Is(err, ErrContentSizeExceeded)`; `parseWhileMaxErr` disambiguates exhaustion from a read error via
+  `HasByteAt`. Every bounded scanner checks `ctx.Err()` between steps and unwinds without emitting a partial
+  node.
 
 ## Attribute Default Application
 
-After parsing a start tag (`parser_element.go`): (1) DTD lookup; (2) apply default `xmlns` first — only if the default namespace was NOT explicitly declared on the same tag; (3) apply default `xmlns:prefix` next — only if that prefix (incl. reserved `xml`) was NOT explicitly declared; (4) remaining defaults (skip if an explicit attr exists). Explicit namespace declarations always win over ATTLIST defaults.
+After parsing a start tag (`parser_element.go`): (1) DTD lookup; (2) apply default `xmlns` first — only if the
+default namespace was NOT explicitly declared on the same tag; (3) apply default `xmlns:prefix` next — only if
+that prefix (incl. reserved `xml`) was NOT explicitly declared; (4) remaining defaults (skip if an explicit
+attr exists). Explicit namespace declarations always win over ATTLIST defaults.
 
 ## Recovery Mode / Early Termination
 
-- **RecoverOnError** — on a recoverable error in `parseContent()`: save `recoverErr`, `disableSAX=true`, `skipToRecoverPoint()` (advance to next `<`), continue, return partial document + saved error. Applies to genuine parse errors only — NOT context cancellation (above).
+- **RecoverOnError** — on a recoverable error in `parseContent()`: save `recoverErr`, `disableSAX=true`,
+  `skipToRecoverPoint()` (advance to next `<`), continue, return partial document + saved error. Applies to
+  genuine parse errors only — NOT context cancellation (above).
 - **StopParser(ctx)** — `stopped=true`, `instate=psEOF`; returns the parsed-so-far document + nil error (partial document, unlike cancellation's nil document + context error).
 
 ## Key Parser Fluent Method Effects

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -216,8 +216,19 @@ result for the current run live in the header comment of
 - Bound fuzz input sizes early. Return on oversize inputs.
 - Prefer in-memory stubs over filesystem/network access.
 - Parse/compile/validate/transform fuzz targets MUST tolerate invalid intermediate inputs by returning early instead of asserting.
-- `xmlenc1`'s `FuzzDecrypt` puts FIXED RSA, EC, and AES key material on one `Decryptor` (all three are settable together) and leaves `SessionKey` unset, so the input alone selects which key-protection path runs — RSA-OAEP, ECDH-ES, or AES key wrap — and every branch is reachable from the one target. The keys are fixed, because a crasher written under `testdata/fuzz` must reproduce across runs.
-- The `xslt3` targets time each input's parse+compile (and transform) inline and fail via `t.Errorf` when it crosses `slowInputThreshold()` (`fuzz_test.go` `flagIfSlow`), so the fuzzing engine persists the exact bytes as a crasher. Go's own worker already turns a genuine hang into a crasher via a 10s deadlock detector (`internal/fuzz` `worker.go`), so this targets the slow-but-finite input (a few seconds) that 10s net misses — the input that drags run throughput toward the fuzztime deadline and surfaces only as an unactionable `context deadline exceeded` with no reproducer. The threshold MUST stay below Go's 10s worker deadline to fire first; it defaults to 5s (ample headroom over any legitimate compile, so no false trips under CI scheduler jitter) and is overridable via `HELIUM_FUZZ_SLOW_INPUT` (a Go duration). Timing inline (not in a child goroutine) keeps panics on `testing`'s normal minimizable-crasher path.
+- `xmlenc1`'s `FuzzDecrypt` puts FIXED RSA, EC, and AES key material on one `Decryptor` (all three are
+  settable together) and leaves `SessionKey` unset, so the input alone selects which key-protection path runs
+  — RSA-OAEP, ECDH-ES, or AES key wrap — and every branch is reachable from the one target. The keys are
+  fixed, because a crasher written under `testdata/fuzz` must reproduce across runs.
+- The `xslt3` targets time each input's parse+compile (and transform) inline and fail via `t.Errorf` when it
+  crosses `slowInputThreshold()` (`fuzz_test.go` `flagIfSlow`), so the fuzzing engine persists the exact bytes
+  as a crasher. Go's own worker already turns a genuine hang into a crasher via a 10s deadlock detector
+  (`internal/fuzz` `worker.go`), so this targets the slow-but-finite input (a few seconds) that 10s net misses
+  — the input that drags run throughput toward the fuzztime deadline and surfaces only as an unactionable
+  `context deadline exceeded` with no reproducer. The threshold MUST stay below Go's 10s worker deadline to
+  fire first; it defaults to 5s (ample headroom over any legitimate compile, so no false trips under CI
+  scheduler jitter) and is overridable via `HELIUM_FUZZ_SLOW_INPUT` (a Go duration). Timing inline (not in a
+  child goroutine) keeps panics on `testing`'s normal minimizable-crasher path.
 
 ## Fuzz CI
 
@@ -268,15 +279,31 @@ result for the current run live in the header comment of
 
 ### 4. QT3 Tests (XPath 3.1) — moved out of this module
 
-The W3C QT3 (XPath/XQuery 3.1) conformance suite lives in the **sibling `github.com/lestrrat-go/helium-w3c-tests` module**, not here. That module owns the generator (`internal/suites/qt3`), the harness and generated per-category case tables (`xpath3/qt3_*_gen_test.go`, run via one `TestQT3W3C`), the on-demand-fetched context/resource fixtures plus the committed curated overlay (`fixtures/qt3ts`), and the skip/expectation metadata (`expectations/qt3.json`); it `replace`s `helium => ../helium` and uses a local `go.work`. Run it from there: `go run ./cmd/w3cgen fetch qt3 && go run ./cmd/w3cgen generate qt3 && go run ./cmd/w3ctest qt3`. Helium keeps only the xpath3 **unit** tests.
+The W3C QT3 (XPath/XQuery 3.1) conformance suite lives in the **sibling
+`github.com/lestrrat-go/helium-w3c-tests` module**, not here. That module owns the generator
+(`internal/suites/qt3`), the harness and generated per-category case tables (`xpath3/qt3_*_gen_test.go`, run
+via one `TestQT3W3C`), the on-demand-fetched context/resource fixtures plus the committed curated overlay
+(`fixtures/qt3ts`), and the skip/expectation metadata (`expectations/qt3.json`); it `replace`s `helium =>
+../helium` and uses a local `go.work`. Run it from there: `go run ./cmd/w3cgen fetch qt3 && go run
+./cmd/w3cgen generate qt3 && go run ./cmd/w3ctest qt3`. Helium keeps only the xpath3 **unit** tests.
 
 ### 5. W3C XSLT 3.0 Tests — moved out of this module
 
-The W3C XSLT 3.0 conformance suite lives in the **sibling `github.com/lestrrat-go/helium-w3c-tests` module**, not here. That module owns the generator (`internal/suites/xslt30`), the harness and generated per-category case tables (`xslt3/xslt30_*_gen_test.go`, run via one `TestXSLT30W3C`), the on-demand-fetched fixtures plus the committed curated overlay (`fixtures/xslt30`), and the skip/expectation metadata (`expectations/xslt30.json`); it `replace`s `helium => ../helium` and uses a local `go.work`. Run it from there: `go run ./cmd/w3cgen fetch xslt30 && go run ./cmd/w3cgen generate xslt30 && go run ./cmd/w3ctest xslt30`. Helium keeps only the xslt3 **unit** tests.
+The W3C XSLT 3.0 conformance suite lives in the **sibling `github.com/lestrrat-go/helium-w3c-tests` module**,
+not here. That module owns the generator (`internal/suites/xslt30`), the harness and generated per-category
+case tables (`xslt3/xslt30_*_gen_test.go`, run via one `TestXSLT30W3C`), the on-demand-fetched fixtures plus
+the committed curated overlay (`fixtures/xslt30`), and the skip/expectation metadata
+(`expectations/xslt30.json`); it `replace`s `helium => ../helium` and uses a local `go.work`. Run it from
+there: `go run ./cmd/w3cgen fetch xslt30 && go run ./cmd/w3cgen generate xslt30 && go run ./cmd/w3ctest
+xslt30`. Helium keeps only the xslt3 **unit** tests.
 
 ### 6. W3C XML Schema Test Suite (XSTS) — moved out of this module
 
-The heavyweight W3C XML Schema (XSD 1.1) conformance suite lives in the **sibling `github.com/lestrrat-go/helium-w3c-tests` module**, not here. That module owns the generated tests, the on-demand-fetched fixtures, and the skip/expectation metadata (`expectations/xsd11.json`); it `replace`s `helium => ../helium` and uses a local `go.work` to test against an in-progress branch. Run it from there: `go run ./cmd/w3cgen fetch xsd11 && go run ./cmd/w3cgen generate xsd11 && go test ./...`.
+The heavyweight W3C XML Schema (XSD 1.1) conformance suite lives in the **sibling
+`github.com/lestrrat-go/helium-w3c-tests` module**, not here. That module owns the generated tests, the
+on-demand-fetched fixtures, and the skip/expectation metadata (`expectations/xsd11.json`); it `replace`s
+`helium => ../helium` and uses a local `go.work` to test against an in-progress branch. Run it from there: `go
+run ./cmd/w3cgen fetch xsd11 && go run ./cmd/w3cgen generate xsd11 && go test ./...`.
 
 Helium keeps only the **unit regression** `xsd/union_cycle_overflow_test.go` (cyclic simpleType must error, not stack-overflow), guarding the in-tree fix (`baseChain` in `simplevalue_core.go`, `checkCircularSimpleTypes` in `check_facets.go`).
 

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -4,49 +4,1225 @@ Three validation engines: XSD (grammar-based), RELAX NG (pattern-based), Schemat
 
 ## XSD
 
-Files: `xsd/xsd.go` (API), `compile*.go` + `read_*.go` + `link_refs.go` + `restriction_particle.go` + `check_*.go` (compile/read/resolve/constraint pipeline), `validate.go` + `validate_elem.go` (content validation), `validate_idc.go` (IDC), `simplevalue_core.go` + `simplevalue_facets.go` (simple-value validation), `schema.go` (model)
+Files: `xsd/xsd.go` (API), `compile*.go` + `read_*.go` + `link_refs.go` + `restriction_particle.go` +
+`check_*.go` (compile/read/resolve/constraint pipeline), `validate.go` + `validate_elem.go` (content
+validation), `validate_idc.go` (IDC), `simplevalue_core.go` + `simplevalue_facets.go` (simple-value
+validation), `schema.go` (model)
 
-**XSD version (1.0 default, 1.1 opt-in):** `Compiler.Version(xsd.Version11)` selects 1.1; `resolveVersion` (`compile.go`) resolves in order: a forced explicit `Version()` (always wins) → a `vc:minVersion` hint (ns `lexicon.NamespaceXSDVersioning`) off the root `<xs:schema>`, selecting 1.1 iff it is `>= 1.1` → a configured `Compiler.DefaultVersion(v)` (the opt-in fallback for a schema silent on version — never overrides a forced version or a vc hint) → `Version10`. `Validator.SkipDatatypeIntegrityChecks(true)` (`cfg.skipDatatypeIntegrity`) suppresses the 1.1 document-wide xs:ID/IDREF/IDREFS and xs:ENTITY/ENTITIES integrity walks in `validateDocument` (content-model/type/IDC validation unaffected) for fragment-validating callers like xslt3. The hint is parsed with the SAME rules as the conditional-inclusion pre-pass — ASCII XML whitespace trim only (trims the XSD set space/tab/CR/LF, not `strings.TrimSpace`, so an NBSP-padded value is not silently accepted) and EXACT xs:decimal comparison (`isValidXSDDecimal` + `value.CompareDecimal` against `"1.1"`, not float64) — so a malformed/NBSP value does not auto-select 1.1 (treated as no hint → 1.0) and a high-precision value just below 1.1 is not float-rounded up into 1.1. The resolved `Version` is stored on `compiler.version`, propagated to the import sub-compiler (`compile_imports.go`), and frozen onto `Schema.version`; `validationContext.version` is seeded from it (`newValidationContext`) and from `c.version` for the compile-time facet sub-contexts (`check_facets.go`). The lexical gate lives in `internal/xsd/value.ValidateBuiltin(value, builtinLocal, version)` — `validateFloat` selects `floatRegex10` (no `+INF`) for 1.0; the date validators reject year `0000` for 1.0 (`yearForbiddenInXSD10`). The value package's comparison/canonicalization guards pass `value.Version11` (they run on already-validated values). relaxng pins its `ValidateBuiltin` calls to `value.Version10`. xsd threads the version into `validateBuiltinValue` via `vc.version`; `fixedUnionActiveMember` takes a `version Version` param threaded from every caller (`fixedUnionMatches`/`crossMemberValueEqual(Depth)`/`fixedValueMatches`/`fixedListMatches` carry it, runtime callers pass `vc.version`, and the compile-time restriction-derivation chain in `restriction_particle.go` passes `c.version`), so the throwaway context it builds applies the schema's real version — a 1.1-only lexical form (e.g. `+INF`) inside a union fixed-value or enumeration literal is accepted in 1.1 mode. `vc.typeAcceptsValue` (`validate_idc.go`, IDC field active-member) threads the live validation context (version + schema) into `validateValue`, so IDC active-member probing honors 1.1 lexical forms and schema-aware union selection. The standalone `TypeDef.Validate` helper remains on the `Version10`/nil-schema default — a documented Phase-1 gap for standalone validation only. The 1.1 built-in datatypes (xs:dateTimeStamp, xs:dayTimeDuration, xs:yearMonthDuration, xs:anyAtomicType, xs:error) are registered only in 1.1 mode by `registerBuiltinTypes11` (`compile.go`), with `BaseType` linked to their primitives; `Compare`/`CanonicalKey` route dateTimeStamp→dateTime and the durations→duration. **UPA weakening** is implemented: `entriesOverlap` (`check_upa.go`) takes the automaton's `schema.version` and, in 1.1, treats an element-vs-wildcard pair as non-overlapping (the element wins), so such a content model compiles; element-vs-element and wildcard-vs-wildcard are unchanged. Element-over-wildcard precedence is ENFORCED at validation for the CHOICE case (`validate_elem.go` `matchChoice`'s `matchAt`/`matchOnce` and `tryMatchChoice`'s `scanOnce`, both gated on `vc.version == Version11`): a branch that consumes the current child via an element leaf AS ITS FIRST CONSUMING TERM is tried before any branch that would consume it via a wildcard, regardless of declaration order or nesting, so a `skip`/`lax` wildcard declared BEFORE a typed element does not steal the element's child (which would false-accept an invalid value like `<a>not-int</a>` against `xs:int`). The selection is COMMIT-NO-FALLBACK: if ANY branch is element-first for the current child, the choice MUST use an element-first branch and MUST NOT fall back to a wildcard branch — even when the chosen element branch then fails structurally (a later required term is absent, e.g. `choice(sequence(a:int, b:int), any skip)` with only `<a>`) or by content. `matchOnce` first tries each element-first branch via `matchAt`; if none matches fully it commits to the first element-first branch and surfaces its real `matchParticle` failure (recording the genuine content/missing-element error) instead of entering the wildcard pass, and `tryMatchChoice`'s `scanOnce` mirrors this — once an element-first branch exists for the child it returns that branch's success/failure and never falls back — so lookahead and real passes agree. Only when NO branch is element-first for the child may the wildcard pass run. This stays bounded (the commit is to the first element-first branch in declaration order; no backtracking). The classifier `particleConsumesViaElement` delegates to `particleFirstConsumerKind`/`groupFirstConsumerKind` (consumerKind = element/wildcard/none), which is PATH-AWARE: it walks sequence members in order respecting occurrences and emptiable prefixes (reusing `restriction_particle.go`'s `particleEmptiable`), so a LEADING wildcard inside a sequence — e.g. `sequence(any skip, element a)` — is classified wildcard-first and does NOT win element precedence even though a later element leaf in the same group also matches the child; choice/all are element-first iff some member is. This is bounded first-consumer determination, not full backtracking. XSD 1.0 keeps pure declaration-order matching (byte-identical path). The SEQUENCE case is also enforced (`matchSequence`/`tryMatchSequenceOnce`/`tryMatchSequence` via `sequenceElementReservedLimit`, Version11-gated): before matching each particle, the children a LATER element particle in the same sequence is element-first-consumer for are reserved (the particle sees a truncated `children[:limit]`), so a leading minOccurs=0 wildcard (direct or nested as a sub-sequence's first term, e.g. `sequence( any{0,unbounded} lax, state, currency, zip )` from extending a wildcard-only base) cannot greedily consume the required named elements. The reservation fires ONLY when the current particle would consume the child via a wildcard, not an element leaf (element-vs-element stays in declaration order), AND only for a later element REACHABLE from the current position — every intervening particle is emptiable (`particleEmptiable`), so a required element between the wildcard and a trailing optional element keeps its child (no over-rejection); bounded lookahead, no backtracking, no-op for all-element sequences and XSD 1.0. The cos-nonambig position automaton carries a per-position ORIGIN tag (`firstSetEntry.origin`, `positionAutomaton.nextOrigin`): `applyOccurs` RESETS the counter before each occurrence copy it walks, so all occurrence-copies of ONE textual element leaf (any nesting depth, e.g. `(a{1,2}){1,2}`) share an origin while two DISTINCT textual leaves get distinct origins even when same-named and even sharing an `*ElementDecl` via a group ref; in 1.1 `entriesOverlap` treats same-name/same-origin positions as one particle (never a UPA violation) and same-name/DIFFERENT-origin as a violation (`choice(a,a)`, `choice(ref g, ref g)`). Element-vs-element competition is VERSION-INDEPENDENT: occurrence-copies of ONE textual leaf share an origin (reset by `applyOccurs` before each copy) and do NOT compete (e.g. `sequence maxOccurs="100"(a maxOccurs="unbounded")`), while two DISTINCT same-named leaves do. Only the element-vs-wildcard case is version-specific (1.1 weak wildcards: the element wins). **Assertions (xs:assert on complex types)** are implemented (`assert.go`): `parseAssert` reads `@test` from `<xs:assert>` children of complexType/restriction/extension (1.1 only), captures the in-scope namespaces (`collectNSContext`), and pre-compiles via `xpath3.NewCompiler().Compile` (a missing/malformed test is a fatal schema error, mirroring IDC); the result is stored on `TypeDef.Assertions` (the `Assertion` struct mirrors `IDConstraint`). `validateElementContent` extracts the content switch into `validateContentByType` and, after attributes+content validate, calls `checkAssertions`, which walks the type's base chain and evaluates each test with the element as context node via `xpath3.NewEvaluator(...).Namespaces(a.Namespaces).Evaluate(ctx, expr, elem)` then `xpath3.EBV` — false → validity error. StrictPrefixes is intentionally NOT set so xs:/fn: keep default bindings. `parseAssert` also handles `<xs:assert>` inside a simpleContent extension/restriction (`parseSimpleContentChildren`). `$value` is bound (via `Evaluator.Variables`) to the element's TYPED simple value for a simpleContent type (`assertValueSequence`→`buildValueSequence`; empty sequence for complex content). For an EMPTY element `assertValueSequence` substitutes the declaration's fixed/default effective value (from `edecl`, threaded through `checkAssertions`) before typing — mirroring `validateSimpleContent` — so `$value` is the schema-normalized value, not the empty sequence. A QName/NOTATION fixed/default value substituted into an empty element resolves its prefix against the DECLARATION's namespace context (`ElementDecl.FixedNS`/`DefaultNS`, selected by `effectiveValueNS`), not the instance's, for both content validation (1.1 branch) and `$value`; XSD 1.0 keeps instance-context resolution. A materialized QName/NOTATION DEFAULT/FIXED ATTRIBUTE value is prepared by `materializeQNameAttrValue` (1.1 only): it whitespace-COLLAPSES the value before extracting the prefix/local (so `default=" p:x "` still binds `p`), resolves the ACTIVE type — for a UNION attribute type it calls `fixedUnionActiveMember(ctx, collapsed, declNS, …, vc.schema, vc.version)` so a `memberTypes="xs:QName xs:string"` default active in its QName member is materialized too — declares the value's prefix (from `AttrUse.FixedNS`/`DefaultNS`) on the element, minting a fresh non-colliding prefix and rewriting the value (with the collapsed local) if the instance already binds that prefix to a different URI, so an xs:assert/IDC atomizing the attribute resolves it in the schema value space. The whole materialization block is gated on `vc.version == Version11`, so XSD 1.0 inserts the default/fixed value exactly as authored with no namespace-declaration rewrite — byte-identical serialization (no golden exercises this case, so the gate is the only guard). **XDM context isolation** (`isolatedAssertTree`): the test is evaluated against a deep copy (`helium.CopyNode`) of the element rooted in NO document and with comment/PI nodes removed (`stripCommentsAndPIs`), so an absolute path `/`/`//` raises XPDY0050 (root is not a document node) — the assertion cannot navigate outside the element subtree — while the element's in-scope namespaces — INCLUDING an inherited default namespace (prefix "", when not already on the copy), so `namespace-uri-for-prefix('', .)` and unprefixed resolution survive isolation — are re-declared on the copy root and the PSVI type annotations are carried onto DESCENDANT elements and ALL attributes (`mapAssertAnnotations`, fed to `Evaluator.TypeAnnotations`) so a typed attribute (e.g. `@length eq count(...)`) atomizes in its value space and node-scope QName resolution works. The assertion-tree ROOT element is deliberately left UNannotated (an xs:assert is part of determining the element's own validity, so its type is not yet assigned — `data(.)` on the root is untyped, matching Saxon/the conformance tests). The PSVI annotations come from `validationContext.assertAnnotations`, an always-on map (1.1 only) populated by `annotateElement`/`annotateAttrUse`. A single-schema `xpath3.SchemaDeclarations` adapter (`schema_decls.go`, `schemaDecls`, via `vc.assertSchemaDecls()`, carrying `vc.version`) is passed to the evaluator so a node annotated with a NAMED user simple type atomizes through its builtin base (e.g. `data(@x) instance of xs:integer`) and instance-of/schema-element tests see the type hierarchy. The assert/assertion-facet evaluators also set `Evaluator.QNameValueNoDefaultNamespace()` (xpath3) so an UNPREFIXED xs:QName/xs:NOTATION VALUE atomizes to NO namespace — XSD value-space semantics (a QName value, unlike a name, does not pick up the in-scope default namespace; a prefixed value still resolves). The option is off by default, so general XPath/XQuery and XSLT atomization keep resolving an unprefixed QName value against the default namespace. Its `ValidateCast`/`ValidateCastWithNS` run `validateValue` with a `validationContext{schema, version, NilErrorHandler}` (NOT `TypeDef.Validate`, which hardcodes the 1.0 default), so a user-defined `cast`/`castable` inside a 1.1 assertion accepts 1.1-only lexical forms (e.g. year `0000`). BOTH the `castable` AND `cast` evaluation paths (`xpath3/eval_types.go` `evalCastableExpr`/`evalCastExpr`) are namespace-aware for QName/NOTATION-derived USER types: when context-free `CastAtomic` fails and SchemaDeclarations resolve the type's builtin base to `xs:QName`/`xs:NOTATION`, `cast` validates via `ValidateCastWithNS` and returns the namespace-RESOLVED QName/NOTATION value (`castToQName`) carrying the user type annotation — additive, so existing xpath3 cast behavior (no SchemaDeclarations) is unchanged. A self-referential cast (`cast`/`castable as t:T` inside t:T's own assertion) is bounded by a per-validation `(type, value)` cast stack carried in the context (`castGuardKey`, lazily created on the first `validateCast`, self-clearing as the recursion unwinds): a repeat fails closed (treated as not castable / a cast failure) instead of recursing `validateCast → validateValue → checkSimpleTypeAssertions → Evaluate → validateCast …` to a stack overflow. `xpathDefaultNamespace` on `<xs:assert>`/`<xs:assertion>`/root `<xs:schema>` is honored (`resolveXPathDefaultNS`/`assertionNamespaces`): the raw value (element-local OR schema-level) is whitespace-COLLAPSED (schema-for-schemas whiteSpace="collapse") before the empty check and the sentinel switch, so `" ##targetNamespace "` resolves as the sentinel, its surrounding space gone before anything could read it as a URI literal; the default element namespace is governed SOLELY by it (the bare `xmlns=""` default is dropped), with `##targetNamespace`/`##defaultNamespace`/`##local` resolved and tracked across chameleon includes (`compile_imports.go` saves/restores `compiler.schemaXPathDefaultNS`) AND carried into the IMPORT sub-compiler (`impC.schemaXPathDefaultNS = getAttr(impRoot, attrXPathDefaultNamespace)` before `parseSchemaChildren`), so an imported schema's assertions resolve their own root default namespace. **xs:assertion simple-type facet** (`assertion_facet.go`): `parseFacets` reads `<xs:assertion>` into `FacetSet.Assertions`; `validateValue` (after lexical+facet validation, factored as `validateValueByVariety`) calls `checkSimpleTypeAssertions`, which binds `$value` to the typed value (`buildValueSequence`/`typedAtomic`/`atomicForType`: a sequence for a list with each item typed by its active member, a NAMED user-defined type's identity PRESERVED (`atomicForType` stamps the user type name as `TypeName`, builtin cast type as `BaseType`, via `builtinAtomicForType`, mirroring `AtomizeItem`/`data()`) so `$value instance of t:T` holds, a union resolved to its active member via SCHEMA-AWARE probing in `buildValueSequence` (so a union whose ACTIVE member is a LIST — e.g. `memberTypes="IntList xs:string"` with value `1 2` — yields the list-item sequence, not a single untypedAtomic) — `typedAtomic`/`buildValueSequence` thread `vc.schema` into `fixedUnionActiveMember` so a member whose own assertion needs `castable as t:T` is selectable, matching the real validation path — a QName/NOTATION lexical resolved against in-scope namespaces into an `xpath3.QNameValue`) and evaluates each assertion along the restriction chain (ANDed) with NO context item — so `.`/`position()`/`last()` raise a dynamic error → unsatisfied; the SchemaDeclarations adapter is passed here too. Because `validateValue` evaluates these facets, the COMPILE-TIME throwaway contexts that reach it are built with `schema: c.schema`: the attribute default/fixed constraint check (`checkAttrUseConstraints`, `link_refs.go`) and the facet value-against-base / enumeration-member / union-member checks (`check_facets.go`). Without it, a schema-aware cast in a facet assertion (`castable as t:T`) would fail closed and reject a VALID schema at compile time. (Standalone `TypeDef.Validate` stays on the Version10/nil-schema default — the documented Phase-1 gap.) XSD 1.1 **attribute inheritance** (`finalizeEffectiveAttrs`, run in `resolveRefs`, gated to 1.1): EVERY derived complex type (extension OR restriction) inherits each base attribute use it does not redeclare. This is mandatory, not optional — `checkRestrictionAttrs` does not report a non-redeclared required base attribute as "missing" in 1.1, so the merge is what actually keeps that inherited requirement enforced (without it an instance omitting the attribute would wrongly validate). The merge is TOPOLOGICAL across BOTH derivation kinds: the base is finalized FIRST (memoized recursion with `merged`/`visiting` sets, following the base pointer regardless of derivation kind), THEN the derivation attribute check runs against td's OWN declarations and the finalized base (`checkRestrictionAttrs` for a restriction, `checkExtensionAttrDuplicates` for an extension — both run in the finalizer in 1.1 so they read a complete base set), THEN td inherits the non-redeclared base uses (a restriction inherits the base wildcard when it declares none; an extension also unions its own wildcard with the base's). Because both the extension and restriction passes DEFER all attribute work to this finalizer in 1.1, an extension-of-restriction or restriction-of-extension at any depth inherits correctly regardless of source order. The passes keep their content-model merge and `checkRestrictionParticles`. XSD 1.0 folds base attributes into extension types in-loop (so `checkRestrictionAttrs` on a restriction-of-extension still sees historically merged extension bases) and then finalizes effective attribute USES topologically across BOTH extension and restriction via `finalizeAttrUses10` (folds non-redeclared base uses into restriction types, re-folds uses a restriction base gained onto extensions that copied a stale snapshot, and re-runs `checkExtensionAttrDuplicates` against the FINALIZED base — with the extension's OWN uses snapshotted in `extOwnAttrUses` before the in-loop fold, and `extAttrDupReported` suppressing a second report of a collision the in-loop check already emitted — so an extension redeclaring an attribute its base merely INHERITS is a ct-props-correct.4 duplicate in 1.0 as in 1.1; `checkRestrictionAttrs` is NOT repeated there; the in-loop fold builds a FRESH slice via `concatAttrUses` — `append(base.Attributes, own...)` would park the derived type's own uses in the base slice's spare capacity, where a sibling derivation's fold or `finalizeAttrUses10`'s inheriting append silently overwrites them; the base {attribute wildcard} is NOT inherited on restriction — a 1.0 restriction's wildcard is computed solely from its own content), so an extension of a restriction inherits undeclared grandbase attributes and an inherited attribute on an instance validates (W3C ctF013/ctG001/ctG013/particlesZ002/sunData combined 009) while an empty restriction of a wildcard-bearing base still admits no wildcard-matched attribute (sunData combined 008). **simpleContent content-type narrowing** (`TypeDef.ContentSimpleType`, built by `parseSimpleContentRestrictionType`): a simpleContent `<xs:restriction>` narrows the base content type via a nested `<xs:simpleType>` AND/OR its direct facets — `parseSimpleContentRestrictionType` composes BOTH (a restriction of the inline type carrying the sibling facets when both are present), so sibling facets are not dropped when an inline type is also given. Each synthetic restriction it returns is recorded in `typeDefSources` so `checkFacetConsistency` runs facet applicability / value-against-base checks on it — an inapplicable sibling facet (e.g. `xs:minInclusive` on an `xs:string` base) is a compile error, so it can never be silently ignored. The EFFECTIVE content simple type is composed across the WHOLE simpleContent derivation chain by `effectiveContentSimpleType`, which recurses through simpleContent complex types (marked `TypeDef.IsSimpleContent`, set in `parseSimpleContent`) and stops at the underlying simpleType/builtin (which IS its own content type). It terminates via a VISITED-SET cycle guard (tracking `*TypeDef` pointers), NOT a depth cap, so an arbitrarily deep finite acyclic chain is walked fully and a narrowing facet far down the chain (which lives on `ContentSimpleType`, not `Facets`) is never silently skipped; a facet-only narrowing (the synthetic `ContentSimpleType` whose `BaseType` is the owning complex type) is re-based on the effective base content type so ancestor and derived facets compose. `validateSimpleContent` (1.1) validates the text against the composed type whenever `simpleContentNeedsValidation` reports it constrains the value (list/union variety, a non-string builtin, or any facet/assertion along its chain); `assertValueSequence` types `$value` from the same composed type. A NESTED `<xs:simpleType>` content type carries its OWN declared base chain (it is returned by `effectiveContentSimpleType` as-is, NOT re-based onto the base content), so the base complex type's inherited content facets would otherwise be bypassed; `validateSimpleContent` therefore walks the simpleContent base chain and ALSO validates the value against each ancestor `effectiveContentSimpleType(cur.BaseType)` where `cur.ContentSimpleType.BaseType != cur` (nested-type and inline-type-plus-sibling-facets cases — re-based facet-only synthetic excluded), so inline narrowing AND inherited base facets apply through later derivation hops (XSD §3.4.2.2: a nested simpleType RESTRICTS, it does not REPLACE, the base content type — e.g. a `maxLength` on the base still rejects an over-long value the nested type alone would accept). So a simpleContent EXTENSION of a named faceted/asserted simple type enforces that base type's facets/assertions, and a narrowed content type (e.g. an ancestor enumeration) is inherited through a further restriction OR extension. In XSD 1.0 `validateSimpleContent` validates against the declared type `td` (not the composed `ContentSimpleType`), but its gate is likewise `simpleContentNeedsValidation(td)` (a facet ANYWHERE along td's base chain), so a simpleContent EXTENSION of a named faceted type enforces the base's facets in 1.0 too; a direct facet on a simpleContent RESTRICTION lives on `ContentSimpleType` (built in both versions and recorded in `typeDefSources`), so it is compile-checked by `checkFacetConsistency` in 1.0 but not yet instance-enforced there. `resolveWhiteSpace` treats `xs:anySimpleType` as whiteSpace="preserve" (both versions), so a fixed value on an `xs:anySimpleType` element keeps surrounding whitespace significant. The complexContent-extension-over-simple-base check (cos-ct-extends-1-1) also flags the empty/attribute-only case in 1.1. **Conditional type assignment (xs:alternative)** is implemented (`alternative.go`): `parseTypeAlternatives` reads the `<xs:alternative>` children of an xs:element (1.1 only) in order — each carries an optional `@test` (absent = unconditional default) pre-compiled via xpath3 and a `@type` reference registered on `compiler.altTypeRefs` and resolved by `resolveAltTypeRefs` in `resolveRefs`; results are stored on `ElementDecl.Alternatives` (the `TypeAlternative` struct). At validation `applyTypeAlternatives` runs at every type-selection site (root `validateRootElement`, and `matchAll`/`matchElementParticle`/`matchWildcardParticle`/`validateWildcardChild` plus the xs:anyType/lax-descendant path in `validate_elem.go`) between `effectiveDeclType` and `resolveXsiType`: when no xsi:type is present (`elementHasXsiType`) it returns the type of the first alternative whose `@test` EBV is true (or the testless default), else the declared type — so xsi:type still wins; a failing alternative test is treated as not-matched. At the wildcard/anyType sites CTA selects the governing type FIRST, then the cvc-elt.4.3 derivation-block check and the idc lax-assessment/ID-pass (`assessLaxElement`, `assessed=true`) run against the SELECTED type. An `<xs:alternative>` may carry an INLINE anonymous `<xs:complexType>`/`<xs:simpleType>` (`parseTypeAlternative`; a present-but-empty `@type` is itself a governing-type source, so `@type=""` plus an inline type is a conflict and a bare `@type=""` is an invalid QName), `type="xs:error"` (a selected xs:error invalidates the element even through the xsi:nil nilled path), and `@xpathDefaultNamespace` (`effectiveXPathDefaultNS`: local value resolved against the alternative else inherited from the schema-level default; affects only unprefixed element name tests). The @test runs against a DETACHED single-node CTA context (`inherited_attrs.go` `ctaContextNode`: an orphan element bearing the element's own attributes PLUS inheritable attributes from ancestors (`inheritedAttributes`, decl `inheritable="true"`), in-scope namespaces, position()=last()=1, an `emptyCollectionResolver`, schema base URI, no children/parent — so @test cannot navigate to ancestors/siblings). A non-default `@type`/inline alternative must be VALIDLY SUBSTITUTABLE for the declared type (`checkAltSubstitutability`, compile time): `strictBuiltinAwareDerivedFrom` (`builtin_hierarchy.go`) accepts a genuine `isDerivedFrom` derivation (user types), the built-in simple-type hierarchy via the `builtinSimpleBase` table (the 1.0 built-ins are NOT BaseType-linked), or the anySimpleType simple-content rule; a union declared type also admits any of its base-chain-resolved member types (`resolveVariety`/`resolveUnionMembers`); there is NO permissive simple-vs-simple fallback. The block check is built-in-aware (`isDerivationBlocked`). Per-document xpathDefaultNamespace/base-URI and the `altTypeRefs`/`ctaElems` worklists are saved/restored across include/redefine and seeded onto import sub-compilers. The xs:alternative @test is statically restricted (`alternative.go` `checkCTATestStaticContext`, via the new `xpath3.Expression.StaticReferences(namespaces)`, which resolves every type/function name to a namespace URI — uniform across prefixed, unprefixed, and braced-URI `Q{uri}local` forms — so the check is a pure URI allowlist): a FREE variable reference (cta9002err), a non-built-in type named in cast/castable/instance of/treat as / element()/attribute() kind tests / path-step node tests — verified against the XPath/XDM type hierarchy `xpath3.IsKnownXSDType` so XDM-only names (xs:untyped/xs:untypedAtomic/xs:anyType) are accepted but an unknown xs: name (xs:noSuchType, XPST0008) is rejected (cta9003err, ibm typeAlternatives s3_12ii06) — or an unknown/wrong-arity function call/`#arity` ref/arrow target — verified against the STANDARD registry `xpath3.StandardFunctionAcceptsArity(uri,local,arity)`, which holds the F&O 3.1 fn/math/map/array functions AND the xs: type constructors but EXCLUDES helium extension functions (fn:flatten/array:flat-map), so user-namespace functions, user-type CONSTRUCTOR calls, unknown functions, extension functions, and wrong-arity calls (XPST0017) all reject (arrow arity counts the prepended left operand; an inline-function literal call references no named function and is in-context) — OR a schema-element()/schema-attribute() node test (which references a GLOBAL declaration absent from the CTA static context, §F.2) — is a schema error; a testless (no-`@test`) alternative that is NOT the LAST in document order is rejected (`parseTypeAlternatives`, cta9001err). The inherited schema-level `@xpathDefaultNamespace` is resolved against the HOST alternative element, not the schema root: `effectiveXPathDefaultNS` re-resolves the RAW token (`compiler.schemaXPathDefaultNSToken`, per-document like `xpathDefaultNSSet`) at `elem`, so `##defaultNamespace` uses the alternative's own `xmlns` redeclaration (cta0005) per the {xpath default namespace} mapping (host in-scope namespaces); `##targetNamespace`/`##local`/URI resolve identically either way. `ctaContextNode` carries the INSTANCE document's URI onto the synthetic document so `fn:base-uri(.)` in @test resolves to the instance (cta0021; `fn:static-base-uri()` stays the schema URI). Two element declarations sharing an expanded name in one content model must have EQUIVALENT {type table}s (Element Declarations Consistent extended to type tables, cta9009err/cta9010err), and an element restriction's {type table} must be both-absent or both-present-and-EQUIVALENT to the base's (`restriction_particle.go` `elementRestrictsElement`, Particle Valid (Restriction) clause 4.6, cta0043) — equivalence is the conservative structural comparison (`alternative.go` `typeTablesEquivalent`: same length, identical `@test`s, same {type definition}s via `elementTypesConsistent`). **Open content (xs:openContent + xs:defaultOpenContent)** is implemented (`opencontent.go`): `parseOpenContent` reads `<xs:openContent>` (mode interleave/suffix/none; the `<xs:any>` child becomes the wildcard and must NOT carry minOccurs/maxOccurs — `parseOpenContentWildcard`; mode="none" must not carry a wildcard; at most one annotation) on complexType/restriction/extension into `TypeDef.OpenContent`, setting `TypeDef.openContentExplicit`. The schema-level **`<xs:defaultOpenContent>`** (`readDefaultOpenContent`) is PER-DOCUMENT — saved/reset/restored across xs:include/xs:redefine/xs:override/import like the form defaults (an xs:override/xs:redefine REPLACEMENT child uses the OVERRIDDEN/redefining document's default per §4.2.5, threaded back via `overrideLoadTarget`'s returned `*OpenContent`) — must precede component declarations, and carries mode interleave|suffix (NOT none) plus `appliesToEmpty` (default false). It is captured onto each complex type lacking an explicit openContent as `TypeDef.pendingDefaultOpenContent`. `resolveOpenContent`/`computeEffectiveOpenContent` (in `resolveRefs`, after content models/types are finalized, BASE-FIRST) computes each complex type's EFFECTIVE open content: the explicit one (mode="none" → absent, suppresses the default) else the per-document default (applied unless the content type is empty and appliesToEmpty=false — `contentTypeEmptyForOpenContent`); an EXTENSION inherits/merges the base's (§3.4.2.2 — base interleave mode wins, wildcards union; an extension may not relax a base interleave to suffix — §3.4.6.2) and a RESTRICTION's validity is checked (§3.4.6.4 `checkOpenContentRestriction` — may not add open content to a closed base, subset wildcard, ≥ processContents, mode compatible; all WAIVED when the restriction content model is empty). `validateContentByType` routes the element-only/mixed/empty path through `validateContentModelOpen` when present: **suffix** matches the declared model (`matchContentModelSuffix` — for an `xs:all` it uses the lenient `matchAll11` that stops at the first non-member instead of erroring) then requires every trailing child to match the wildcard (a trailing declared-named child is "not expected"); **interleave** partitions children — those whose expanded name is NOT in `collectModelElementNames(mg)` and which match the wildcard are the open set, the rest must satisfy the declared model — then `refineInterleavePartition` moves a declared-named child the model cannot place (and which matches the wildcard) into the open set (§3.4.4.3.2 existential partition, via a `suppressDepth`-guarded trial match), so open content and declared content may match the same names. Open children are validated via `matchWildcardParticle` (lax/strict/skip). `<xs:complexContent>`/@mixed is honored and must agree with `<xs:complexType>`/@mixed, and an extension and its base must both be mixed or both element-only (§3.4.6.2 cos-ct-extends) — both version-INDEPENDENT (enforced in XSD 1.0 and 1.1). The complexType schema-representation grammar (the `(annotation?, (restriction|extension))` wrapper via `parseDerivationWrapper`, the restriction/extension derivation-body order/cardinality via `parseComplexContentDerivationBody`/`parseSimpleContentChildren`, the direct-complexType annotation-first/at-most-one rule, and the global `<xs:complexType>`/@name `xs:NCName` check) is likewise enforced in both versions; only the 1.1-construct cases (openContent/assert) and the direct-complexType stray-child default stay Version11-gated. KNOWN GAPS (skipped): whitespace in a genuinely-empty (`<xs:sequence/>`) element-only content type is tolerated (open012.n3); schema-component `@id` uniqueness/NCName validity IS enforced (`check_ids.go`, a version-independent XSD rule run in BOTH 1.0 and 1.1: a per-document DOM walk validating each XSD-namespace element's `id` as a valid xs:ID — NCName after whitespace-collapse — and unique within the schema document; run on the entry document AND every nested document loaded by xs:include/xs:redefine/xs:import/xs:override with a fresh per-document `seen` set after conditional-inclusion pruning, so a duplicate/invalid @id in an included/imported/overridden document is caught while the same value may recur across documents; the walk skips xs:appinfo/xs:documentation payload (an xs:annotation's own @id still counts); fixes open038/open039). **xs:all relaxations (XSD 1.1)** are implemented (Saxon `All.testSet` 61/62; all gated on `Version11`, 1.0 byte-identical). (0) The all group's OWN maxOccurs may be 0 or 1 in 1.1 (`validateAllOccurs` accepts `{0,1}`; 1.0 requires exactly 1 — mgO001/mgO018). (1) Element members may carry `minOccurs`/`maxOccurs>1`/`unbounded`: `checkAllElementParticleOccurs` (`check_elements.go`) skips the all-specific 0/1 rule in 1.1 (the generic lexical / min≤max checks still apply). (2) `xs:all` may contain element WILDCARDS, and an `xs:group ref` resolving to an all group may be nested directly inside another `xs:all` with occurrence exactly 1/1 (flattened into the parent); `checkAllGroupRef` (`link_refs.go`, via `groupRefSource.parentCompositor`) allows this in 1.1 and rejects a referenced sequence/choice group, an occurrence ≠ 1/1, or any nested all-group ref in 1.0; an INLINE `<xs:all>` directly inside an `<xs:all>` is rejected too (cos-all-limited — `read_particles.go`, Version11-gated, so it never reaches the flatteners). (3) `matchAll`/`tryMatchAll` (`validate_elem.go`) DISPATCH by version: XSD 1.0 uses the legacy boolean-`seen[]` matcher (`matchAll10`/`tryMatchAll10`), BYTE-IDENTICAL to the pre-1.1 path — a wildcard particle the parser tolerates inside a 1.0 xs:all is never matched and a required one is reported missing (a wildcard particle is not tracked in the 1.0 required-member bookkeeping, guarded by `TestAll10WildcardOnlyRegression`). The per-child content validator `validateAllMatchedChild` (shared by both matchers) rejects a child that resolves to an ABSTRACT element declaration matched directly (`msgAbstractElement`, cvc-elt.2) in BOTH versions — the 1.0 matcher maps an element member's own name directly, so an abstract head used in the instance instead of a concrete substitution member reaches here and is caught (the 1.1 `allMemberForChild` already filters it via `elemMatchesDeclOrSubst`). XSD 1.1 uses a FLAT member list (`flattenAllMembers` — elements, wildcards, and members of a flattened nested 1/1 all) with PER-MEMBER occurrence COUNTING (`matchAll11`/`tryMatchAll11`), matched ORDER-INDEPENDENTLY against each member's min/max; an element member is matched only when the child is ADMISSIBLY substitutable for it (`allMemberForChild`→`elemMatchesDeclOrSubst`, honoring block="substitution"/derivation-block and rejecting abstract heads AND abstract substitution members), and weak-wildcard precedence holds (a declared element with remaining budget wins over a wildcard). (4) Restriction subsumption of a base `xs:all` is occurrence-COUNTING per BASE MEMBER (`all_subsumption.go` `allRestrictsByCounting`/`memberContributions`, routed from `groupRestrictsGroup` for Version11 no-wildcard all:all / sequence:all / choice:all): `memberContributions` computes, per BASE-MEMBER INDEX, the (min,max) the derived side can emit (summing across a sequence/all, merging a choice's branches by per-base-member min/max so alternative branches CORRELATE on the base member, and distinct derived names are not summed, scaling by group occurrence); a non-emitting particle (prohibited wildcard / empty group) contributes nothing (checked before rejecting a wildcard term); a derived element maps to a base member by name or substitution group via the shared `admissibleSubstitutionMember` predicate (concrete member, head allows substitution, member's EFFECTIVE type substitutable for the head's — `findBaseAllMember`); the contribution per base member must lie within that member's range and every unmapped base member must be emptiable. Several derived particles (e.g. substitution-group members) may thus collectively restrict ONE base member with maxOccurs>1. The wildcard cases route to `allRestrictsWithWildcards`, which FLATTENS nested 1/1 all-groups on both sides (`flattenAllParticles`) and SUMS concrete derived elements per base element before accounting remaining concrete/wildcard contributions against the base wildcards' cardinality; a nested NON-all derived group (sequence/choice) that survives flattening is NOT decomposed/accounted and is rejected (fail-closed), so it cannot smuggle an out-of-namespace element past a base wildcard. When the syntactic Particle Valid (Restriction) check FAILS in 1.1, a SOUND fallback (`restriction_subsume.go` `particleLanguageSubset`) PROVES `L(derived) ⊆ L(base)` by product simulation of the two content-model automata over the finite alphabet of names the derived model can emit (element leaves expanded to instance-admissible substitution members; a base wildcard matches every admitted name via `wildcardAllowsName`; per-element type/nillable/fixed checked by `elementRestrictsElement`). It is FAIL-CLOSED — a DERIVED wildcard, an xs:all group, or an over-large occurrence unroll (`subsumeNFAStateCap`/`subsumePairStateCap`/`subsumeUnrollCap`) returns "not proven" (keep the rejection) — and runs only as a fallback that ACCEPTS, so it never rejects more (particlesHa161/Hb008/Hb011/Z001/Z028). XSD 1.0 keeps the syntactic verdict, byte-identical. Circular attribute group definitions are also permitted in 1.1 (W3C bug 15795 / attgC010-D015): the direct self-reference (`read_particles.go`) and indirect cycle (`link_refs.go` `checkCircularAttrGroupRefs`) are dropped/cut without a diagnostic (the back-edge is still CUT so the walks terminate); 1.0 rejects both (src-attribute_group.3), byte-identical. (5) An `xs:all` may be EXTENDED by another `xs:all`: the extension content-merge loop (`link_refs.go`) merges the two member sets into a SINGLE all group — both content models must be all groups with the SAME minOccurs; a sequence/choice extending an all, an all extending a sequence/choice, or a minOccurs mismatch is rejected; an open-content `interleave` base may not be extended to `suffix` mode. (6) UPA over all members (`check_upa.go` `walkAllBody`) is fed by MULTI-HEAD substitution groups (`substitutionGroup="a b"` registers the member under every head — `read_elements.go` parses the list into `ElementDecl.SubstitutionGroups`, `buildSubstGroups` registers each), so an element substitutable for two distinct all members is a cos-nonambig violation. UPA competition is by DECLARATION membership: an ABSTRACT substitution member STILL competes (XSD 1.1 §3.8.6.4 / bug 4337, W3C wgData/sg/upa.xsd) even though it can never appear in an instance, so `walkTerm` does NOT skip abstract members. Substitution-group membership is resolved through a TRANSITIVE cycle-guarded closure (`substitutableMembersForUncached`, `subst_closure.go`) that SEPARATES traversal from inclusion: an edge is traversed unless block/derivation-blocked (`substTypeDerivationBlocked`, abstract ALLOWED) so a concrete descendant behind an abstract intermediate (`h<-abstract m1<-concrete m2`) is reached, while `block="substitution"`/derivation-block prune. The two variants differ only in INCLUSION: `instanceSubstMembers` includes a reached member only when CONCRETE (abstract excluded) for runtime matching (`elemMatchesDeclOrSubst`) and subsumption (`findBaseAllMember`); `substitutableMembersFor` includes abstract members (DECLARATION membership) for UPA (`walkTerm`) and the byte-identical 1.0 matcher (`matchAll10`/`tryMatchAll10`/`resolveSubstDecl`). Both walk the full chain (`h<-m1<-m2`) — a direct `substGroups[head]` lookup misses multi-level members — and the abstract-included-vs-excluded split keeps UPA competition distinct from instance admissibility. The closure of every global head is precomputed once, at the end of `compileSchema`, into `Schema.substClosures` (`subst_closure.go` `buildSubstClosures`); `substitutableMembersFor`/`instanceSubstMembers`/`substMemberFor` resolve through `lookupSubstClosure`, and every compile-time caller above still runs the uncached walk directly since `substClosures` is nil until `compileSchema` returns. (7) A nilled element (`xsi:nil`) with whitespace-only character content is rejected in 1.1 (`validateNilledElement`, cvc-elt.3.2.1; 1.0 still tolerates it); a nilled element whose declaration carries a fixed {value constraint} (`ElementDecl.Fixed != nil`) is rejected in BOTH versions (`validateNilledElement`, cvc-elt.3.2.2 — a fixed value and xsi:nil are contradictory; the declaration may still legally carry the fixed value, only the actual xsi:nil="true" instance is invalid). KNOWN GAP: `all308` (an empty mixed `xs:all` base extended by an all — Saxon bug 6202, where Saxon itself treats the schema as a valid extension) is accepted, not rejected. **Wildcard Element Declarations Consistent (EDC)** is implemented (Version11-gated). The STATIC type-table check (`check_element_consistent.go` `checkWildcardElementConsistent`/`collectModelGroupParticles`/`typeTablesConsistent`/`anyWildcardAllows`, run from `checkElementConsistent` over every complex type AND named group) rejects a content model whose LOCAL element declaration particle and a same-named GLOBAL element declaration reachable through a lax/strict (non-skip) wildcard have inconsistent {type table}s (conditional type assignment). Only the type TABLE is compared, NOT the type DEFINITION (a wildcard admits differently-typed elements, so a type-def difference is permitted — e.g. a local union(date,time) element plus a wildcard matching an xs:duration global of the same name is valid); the asymmetric empty-vs-present case is flagged (under-strict, never false-rejecting two distinct-but-present tables). The DYNAMIC check (`validate_elem.go` `validateWildcardElementConsistent` + `edcLocalDecls`) walks the matched type's BASE chain via `vc.edcType` (set/restored by `validateContentByType` in `validate.go`) in addition to the current content model: a restriction that drops a base's local element declaration but admits the name through a wildcard must have its wildcard governing type validly substitutable for the base's local type, else the instance is invalid. **Skip-wildcard IDC selector scoping** is implemented: `annotateSkipChildren` (`validate.go`) records every element inside a `processContents="skip"` subtree in `vc.skipContentNodes`, and `evaluateIDC` (`validate_idc.go`) drops those un-assessed nodes from the selector node-set, so an ancestor `xs:key`/`xs:unique`/`xs:keyref` does not constrain them (the pass-3 ID/IDREF datatype pass already excluded skip content; this fixes the pass-2 selector). 1.1 only — `skipContentNodes` is nil/empty in 1.0, byte-identical.
+**XSD version (1.0 default, 1.1 opt-in):** `Compiler.Version(xsd.Version11)` selects 1.1; `resolveVersion`
+(`compile.go`) resolves in order: a forced explicit `Version()` (always wins) → a `vc:minVersion` hint (ns
+`lexicon.NamespaceXSDVersioning`) off the root `<xs:schema>`, selecting 1.1 iff it is `>= 1.1` → a configured
+`Compiler.DefaultVersion(v)` (the opt-in fallback for a schema silent on version — never overrides a forced
+version or a vc hint) → `Version10`. `Validator.SkipDatatypeIntegrityChecks(true)`
+(`cfg.skipDatatypeIntegrity`) suppresses the 1.1 document-wide xs:ID/IDREF/IDREFS and xs:ENTITY/ENTITIES
+integrity walks in `validateDocument` (content-model/type/IDC validation unaffected) for fragment-validating
+callers like xslt3. The hint is parsed with the SAME rules as the conditional-inclusion pre-pass — ASCII XML
+whitespace trim only (trims the XSD set space/tab/CR/LF, not `strings.TrimSpace`, so an NBSP-padded value is
+not silently accepted) and EXACT xs:decimal comparison (`isValidXSDDecimal` + `value.CompareDecimal` against
+`"1.1"`, not float64) — so a malformed/NBSP value does not auto-select 1.1 (treated as no hint → 1.0) and a
+high-precision value just below 1.1 is not float-rounded up into 1.1. The resolved `Version` is stored on
+`compiler.version`, propagated to the import sub-compiler (`compile_imports.go`), and frozen onto
+`Schema.version`; `validationContext.version` is seeded from it (`newValidationContext`) and from `c.version`
+for the compile-time facet sub-contexts (`check_facets.go`). The lexical gate lives in
+`internal/xsd/value.ValidateBuiltin(value, builtinLocal, version)` — `validateFloat` selects `floatRegex10`
+(no `+INF`) for 1.0; the date validators reject year `0000` for 1.0 (`yearForbiddenInXSD10`). The value
+package's comparison/canonicalization guards pass `value.Version11` (they run on already-validated values).
+relaxng pins its `ValidateBuiltin` calls to `value.Version10`. xsd threads the version into
+`validateBuiltinValue` via `vc.version`; `fixedUnionActiveMember` takes a `version Version` param threaded
+from every caller (`fixedUnionMatches`/`crossMemberValueEqual(Depth)`/`fixedValueMatches`/`fixedListMatches`
+carry it, runtime callers pass `vc.version`, and the compile-time restriction-derivation chain in
+`restriction_particle.go` passes `c.version`), so the throwaway context it builds applies the schema's real
+version — a 1.1-only lexical form (e.g. `+INF`) inside a union fixed-value or enumeration literal is accepted
+in 1.1 mode. `vc.typeAcceptsValue` (`validate_idc.go`, IDC field active-member) threads the live validation
+context (version + schema) into `validateValue`, so IDC active-member probing honors 1.1 lexical forms and
+schema-aware union selection. The standalone `TypeDef.Validate` helper remains on the `Version10`/nil-schema
+default — a documented Phase-1 gap for standalone validation only. The 1.1 built-in datatypes
+(xs:dateTimeStamp, xs:dayTimeDuration, xs:yearMonthDuration, xs:anyAtomicType, xs:error) are registered only
+in 1.1 mode by `registerBuiltinTypes11` (`compile.go`), with `BaseType` linked to their primitives;
+`Compare`/`CanonicalKey` route dateTimeStamp→dateTime and the durations→duration. **UPA weakening** is
+implemented: `entriesOverlap` (`check_upa.go`) takes the automaton's `schema.version` and, in 1.1, treats an
+element-vs-wildcard pair as non-overlapping (the element wins), so such a content model compiles;
+element-vs-element and wildcard-vs-wildcard are unchanged. Element-over-wildcard precedence is ENFORCED at
+validation for the CHOICE case (`validate_elem.go` `matchChoice`'s `matchAt`/`matchOnce` and
+`tryMatchChoice`'s `scanOnce`, both gated on `vc.version == Version11`): a branch that consumes the current
+child via an element leaf AS ITS FIRST CONSUMING TERM is tried before any branch that would consume it via a
+wildcard, regardless of declaration order or nesting, so a `skip`/`lax` wildcard declared BEFORE a typed
+element does not steal the element's child (which would false-accept an invalid value like `<a>not-int</a>`
+against `xs:int`). The selection is COMMIT-NO-FALLBACK: if ANY branch is element-first for the current child,
+the choice MUST use an element-first branch and MUST NOT fall back to a wildcard branch — even when the chosen
+element branch then fails structurally (a later required term is absent, e.g. `choice(sequence(a:int, b:int),
+any skip)` with only `<a>`) or by content. `matchOnce` first tries each element-first branch via `matchAt`; if
+none matches fully it commits to the first element-first branch and surfaces its real `matchParticle` failure
+(recording the genuine content/missing-element error) instead of entering the wildcard pass, and
+`tryMatchChoice`'s `scanOnce` mirrors this — once an element-first branch exists for the child it returns that
+branch's success/failure and never falls back — so lookahead and real passes agree. Only when NO branch is
+element-first for the child may the wildcard pass run. This stays bounded (the commit is to the first
+element-first branch in declaration order; no backtracking). The classifier `particleConsumesViaElement`
+delegates to `particleFirstConsumerKind`/`groupFirstConsumerKind` (consumerKind = element/wildcard/none),
+which is PATH-AWARE: it walks sequence members in order respecting occurrences and emptiable prefixes (reusing
+`restriction_particle.go`'s `particleEmptiable`), so a LEADING wildcard inside a sequence — e.g. `sequence(any
+skip, element a)` — is classified wildcard-first and does NOT win element precedence even though a later
+element leaf in the same group also matches the child; choice/all are element-first iff some member is. This
+is bounded first-consumer determination, not full backtracking. XSD 1.0 keeps pure declaration-order matching
+(byte-identical path). The SEQUENCE case is also enforced
+(`matchSequence`/`tryMatchSequenceOnce`/`tryMatchSequence` via `sequenceElementReservedLimit`,
+Version11-gated): before matching each particle, the children a LATER element particle in the same sequence is
+element-first-consumer for are reserved (the particle sees a truncated `children[:limit]`), so a leading
+minOccurs=0 wildcard (direct or nested as a sub-sequence's first term, e.g. `sequence( any{0,unbounded} lax,
+state, currency, zip )` from extending a wildcard-only base) cannot greedily consume the required named
+elements. The reservation fires ONLY when the current particle would consume the child via a wildcard, not an
+element leaf (element-vs-element stays in declaration order), AND only for a later element REACHABLE from the
+current position — every intervening particle is emptiable (`particleEmptiable`), so a required element
+between the wildcard and a trailing optional element keeps its child (no over-rejection); bounded lookahead,
+no backtracking, no-op for all-element sequences and XSD 1.0. The cos-nonambig position automaton carries a
+per-position ORIGIN tag (`firstSetEntry.origin`, `positionAutomaton.nextOrigin`): `applyOccurs` RESETS the
+counter before each occurrence copy it walks, so all occurrence-copies of ONE textual element leaf (any
+nesting depth, e.g. `(a{1,2}){1,2}`) share an origin while two DISTINCT textual leaves get distinct origins
+even when same-named and even sharing an `*ElementDecl` via a group ref; in 1.1 `entriesOverlap` treats
+same-name/same-origin positions as one particle (never a UPA violation) and same-name/DIFFERENT-origin as a
+violation (`choice(a,a)`, `choice(ref g, ref g)`). Element-vs-element competition is VERSION-INDEPENDENT:
+occurrence-copies of ONE textual leaf share an origin (reset by `applyOccurs` before each copy) and do NOT
+compete (e.g. `sequence maxOccurs="100"(a maxOccurs="unbounded")`), while two DISTINCT same-named leaves do.
+Only the element-vs-wildcard case is version-specific (1.1 weak wildcards: the element wins). **Assertions
+(xs:assert on complex types)** are implemented (`assert.go`): `parseAssert` reads `@test` from `<xs:assert>`
+children of complexType/restriction/extension (1.1 only), captures the in-scope namespaces
+(`collectNSContext`), and pre-compiles via `xpath3.NewCompiler().Compile` (a missing/malformed test is a fatal
+schema error, mirroring IDC); the result is stored on `TypeDef.Assertions` (the `Assertion` struct mirrors
+`IDConstraint`). `validateElementContent` extracts the content switch into `validateContentByType` and, after
+attributes+content validate, calls `checkAssertions`, which walks the type's base chain and evaluates each
+test with the element as context node via `xpath3.NewEvaluator(...).Namespaces(a.Namespaces).Evaluate(ctx,
+expr, elem)` then `xpath3.EBV` — false → validity error. StrictPrefixes is intentionally NOT set so xs:/fn:
+keep default bindings. `parseAssert` also handles `<xs:assert>` inside a simpleContent extension/restriction
+(`parseSimpleContentChildren`). `$value` is bound (via `Evaluator.Variables`) to the element's TYPED simple
+value for a simpleContent type (`assertValueSequence`→`buildValueSequence`; empty sequence for complex
+content). For an EMPTY element `assertValueSequence` substitutes the declaration's fixed/default effective
+value (from `edecl`, threaded through `checkAssertions`) before typing — mirroring `validateSimpleContent` —
+so `$value` is the schema-normalized value, not the empty sequence. A QName/NOTATION fixed/default value
+substituted into an empty element resolves its prefix against the DECLARATION's namespace context
+(`ElementDecl.FixedNS`/`DefaultNS`, selected by `effectiveValueNS`), not the instance's, for both content
+validation (1.1 branch) and `$value`; XSD 1.0 keeps instance-context resolution. A materialized QName/NOTATION
+DEFAULT/FIXED ATTRIBUTE value is prepared by `materializeQNameAttrValue` (1.1 only): it whitespace-COLLAPSES
+the value before extracting the prefix/local (so `default=" p:x "` still binds `p`), resolves the ACTIVE type
+— for a UNION attribute type it calls `fixedUnionActiveMember(ctx, collapsed, declNS, …, vc.schema,
+vc.version)` so a `memberTypes="xs:QName xs:string"` default active in its QName member is materialized too —
+declares the value's prefix (from `AttrUse.FixedNS`/`DefaultNS`) on the element, minting a fresh non-colliding
+prefix and rewriting the value (with the collapsed local) if the instance already binds that prefix to a
+different URI, so an xs:assert/IDC atomizing the attribute resolves it in the schema value space. The whole
+materialization block is gated on `vc.version == Version11`, so XSD 1.0 inserts the default/fixed value
+exactly as authored with no namespace-declaration rewrite — byte-identical serialization (no golden exercises
+this case, so the gate is the only guard). **XDM context isolation** (`isolatedAssertTree`): the test is
+evaluated against a deep copy (`helium.CopyNode`) of the element rooted in NO document and with comment/PI
+nodes removed (`stripCommentsAndPIs`), so an absolute path `/`/`//` raises XPDY0050 (root is not a document
+node) — the assertion cannot navigate outside the element subtree — while the element's in-scope namespaces —
+INCLUDING an inherited default namespace (prefix "", when not already on the copy), so
+`namespace-uri-for-prefix('', .)` and unprefixed resolution survive isolation — are re-declared on the copy
+root and the PSVI type annotations are carried onto DESCENDANT elements and ALL attributes
+(`mapAssertAnnotations`, fed to `Evaluator.TypeAnnotations`) so a typed attribute (e.g. `@length eq
+count(...)`) atomizes in its value space and node-scope QName resolution works. The assertion-tree ROOT
+element is deliberately left UNannotated (an xs:assert is part of determining the element's own validity, so
+its type is not yet assigned — `data(.)` on the root is untyped, matching Saxon/the conformance tests). The
+PSVI annotations come from `validationContext.assertAnnotations`, an always-on map (1.1 only) populated by
+`annotateElement`/`annotateAttrUse`. A single-schema `xpath3.SchemaDeclarations` adapter (`schema_decls.go`,
+`schemaDecls`, via `vc.assertSchemaDecls()`, carrying `vc.version`) is passed to the evaluator so a node
+annotated with a NAMED user simple type atomizes through its builtin base (e.g. `data(@x) instance of
+xs:integer`) and instance-of/schema-element tests see the type hierarchy. The assert/assertion-facet
+evaluators also set `Evaluator.QNameValueNoDefaultNamespace()` (xpath3) so an UNPREFIXED xs:QName/xs:NOTATION
+VALUE atomizes to NO namespace — XSD value-space semantics (a QName value, unlike a name, does not pick up the
+in-scope default namespace; a prefixed value still resolves). The option is off by default, so general
+XPath/XQuery and XSLT atomization keep resolving an unprefixed QName value against the default namespace. Its
+`ValidateCast`/`ValidateCastWithNS` run `validateValue` with a `validationContext{schema, version,
+NilErrorHandler}` (NOT `TypeDef.Validate`, which hardcodes the 1.0 default), so a user-defined
+`cast`/`castable` inside a 1.1 assertion accepts 1.1-only lexical forms (e.g. year `0000`). BOTH the
+`castable` AND `cast` evaluation paths (`xpath3/eval_types.go` `evalCastableExpr`/`evalCastExpr`) are
+namespace-aware for QName/NOTATION-derived USER types: when context-free `CastAtomic` fails and
+SchemaDeclarations resolve the type's builtin base to `xs:QName`/`xs:NOTATION`, `cast` validates via
+`ValidateCastWithNS` and returns the namespace-RESOLVED QName/NOTATION value (`castToQName`) carrying the user
+type annotation — additive, so existing xpath3 cast behavior (no SchemaDeclarations) is unchanged. A
+self-referential cast (`cast`/`castable as t:T` inside t:T's own assertion) is bounded by a per-validation
+`(type, value)` cast stack carried in the context (`castGuardKey`, lazily created on the first `validateCast`,
+self-clearing as the recursion unwinds): a repeat fails closed (treated as not castable / a cast failure)
+instead of recursing `validateCast → validateValue → checkSimpleTypeAssertions → Evaluate → validateCast …` to
+a stack overflow. `xpathDefaultNamespace` on `<xs:assert>`/`<xs:assertion>`/root `<xs:schema>` is honored
+(`resolveXPathDefaultNS`/`assertionNamespaces`): the raw value (element-local OR schema-level) is
+whitespace-COLLAPSED (schema-for-schemas whiteSpace="collapse") before the empty check and the sentinel
+switch, so `" ##targetNamespace "` resolves as the sentinel, its surrounding space gone before anything could
+read it as a URI literal; the default element namespace is governed SOLELY by it (the bare `xmlns=""` default
+is dropped), with `##targetNamespace`/`##defaultNamespace`/`##local` resolved and tracked across chameleon
+includes (`compile_imports.go` saves/restores `compiler.schemaXPathDefaultNS`) AND carried into the IMPORT
+sub-compiler (`impC.schemaXPathDefaultNS = getAttr(impRoot, attrXPathDefaultNamespace)` before
+`parseSchemaChildren`), so an imported schema's assertions resolve their own root default namespace.
+**xs:assertion simple-type facet** (`assertion_facet.go`): `parseFacets` reads `<xs:assertion>` into
+`FacetSet.Assertions`; `validateValue` (after lexical+facet validation, factored as `validateValueByVariety`)
+calls `checkSimpleTypeAssertions`, which binds `$value` to the typed value
+(`buildValueSequence`/`typedAtomic`/`atomicForType`: a sequence for a list with each item typed by its active
+member, a NAMED user-defined type's identity PRESERVED (`atomicForType` stamps the user type name as
+`TypeName`, builtin cast type as `BaseType`, via `builtinAtomicForType`, mirroring `AtomizeItem`/`data()`) so
+`$value instance of t:T` holds, a union resolved to its active member via SCHEMA-AWARE probing in
+`buildValueSequence` (so a union whose ACTIVE member is a LIST — e.g. `memberTypes="IntList xs:string"` with
+value `1 2` — yields the list-item sequence, not a single untypedAtomic) — `typedAtomic`/`buildValueSequence`
+thread `vc.schema` into `fixedUnionActiveMember` so a member whose own assertion needs `castable as t:T` is
+selectable, matching the real validation path — a QName/NOTATION lexical resolved against in-scope namespaces
+into an `xpath3.QNameValue`) and evaluates each assertion along the restriction chain (ANDed) with NO context
+item — so `.`/`position()`/`last()` raise a dynamic error → unsatisfied; the SchemaDeclarations adapter is
+passed here too. Because `validateValue` evaluates these facets, the COMPILE-TIME throwaway contexts that
+reach it are built with `schema: c.schema`: the attribute default/fixed constraint check
+(`checkAttrUseConstraints`, `link_refs.go`) and the facet value-against-base / enumeration-member /
+union-member checks (`check_facets.go`). Without it, a schema-aware cast in a facet assertion (`castable as
+t:T`) would fail closed and reject a VALID schema at compile time. (Standalone `TypeDef.Validate` stays on the
+Version10/nil-schema default — the documented Phase-1 gap.) XSD 1.1 **attribute inheritance**
+(`finalizeEffectiveAttrs`, run in `resolveRefs`, gated to 1.1): EVERY derived complex type (extension OR
+restriction) inherits each base attribute use it does not redeclare. This is mandatory, not optional —
+`checkRestrictionAttrs` does not report a non-redeclared required base attribute as "missing" in 1.1, so the
+merge is what actually keeps that inherited requirement enforced (without it an instance omitting the
+attribute would wrongly validate). The merge is TOPOLOGICAL across BOTH derivation kinds: the base is
+finalized FIRST (memoized recursion with `merged`/`visiting` sets, following the base pointer regardless of
+derivation kind), THEN the derivation attribute check runs against td's OWN declarations and the finalized
+base (`checkRestrictionAttrs` for a restriction, `checkExtensionAttrDuplicates` for an extension — both run in
+the finalizer in 1.1 so they read a complete base set), THEN td inherits the non-redeclared base uses (a
+restriction inherits the base wildcard when it declares none; an extension also unions its own wildcard with
+the base's). Because both the extension and restriction passes DEFER all attribute work to this finalizer in
+1.1, an extension-of-restriction or restriction-of-extension at any depth inherits correctly regardless of
+source order. The passes keep their content-model merge and `checkRestrictionParticles`. XSD 1.0 folds base
+attributes into extension types in-loop (so `checkRestrictionAttrs` on a restriction-of-extension still sees
+historically merged extension bases) and then finalizes effective attribute USES topologically across BOTH
+extension and restriction via `finalizeAttrUses10` (folds non-redeclared base uses into restriction types,
+re-folds uses a restriction base gained onto extensions that copied a stale snapshot, and re-runs
+`checkExtensionAttrDuplicates` against the FINALIZED base — with the extension's OWN uses snapshotted in
+`extOwnAttrUses` before the in-loop fold, and `extAttrDupReported` suppressing a second report of a collision
+the in-loop check already emitted — so an extension redeclaring an attribute its base merely INHERITS is a
+ct-props-correct.4 duplicate in 1.0 as in 1.1; `checkRestrictionAttrs` is NOT repeated there; the in-loop fold
+builds a FRESH slice via `concatAttrUses` — `append(base.Attributes, own...)` would park the derived type's
+own uses in the base slice's spare capacity, where a sibling derivation's fold or `finalizeAttrUses10`'s
+inheriting append silently overwrites them; the base {attribute wildcard} is NOT inherited on restriction — a
+1.0 restriction's wildcard is computed solely from its own content), so an extension of a restriction inherits
+undeclared grandbase attributes and an inherited attribute on an instance validates (W3C
+ctF013/ctG001/ctG013/particlesZ002/sunData combined 009) while an empty restriction of a wildcard-bearing base
+still admits no wildcard-matched attribute (sunData combined 008). **simpleContent content-type narrowing**
+(`TypeDef.ContentSimpleType`, built by `parseSimpleContentRestrictionType`): a simpleContent
+`<xs:restriction>` narrows the base content type via a nested `<xs:simpleType>` AND/OR its direct facets —
+`parseSimpleContentRestrictionType` composes BOTH (a restriction of the inline type carrying the sibling
+facets when both are present), so sibling facets are not dropped when an inline type is also given. Each
+synthetic restriction it returns is recorded in `typeDefSources` so `checkFacetConsistency` runs facet
+applicability / value-against-base checks on it — an inapplicable sibling facet (e.g. `xs:minInclusive` on an
+`xs:string` base) is a compile error, so it can never be silently ignored. The EFFECTIVE content simple type
+is composed across the WHOLE simpleContent derivation chain by `effectiveContentSimpleType`, which recurses
+through simpleContent complex types (marked `TypeDef.IsSimpleContent`, set in `parseSimpleContent`) and stops
+at the underlying simpleType/builtin (which IS its own content type). It terminates via a VISITED-SET cycle
+guard (tracking `*TypeDef` pointers), NOT a depth cap, so an arbitrarily deep finite acyclic chain is walked
+fully and a narrowing facet far down the chain (which lives on `ContentSimpleType`, not `Facets`) is never
+silently skipped; a facet-only narrowing (the synthetic `ContentSimpleType` whose `BaseType` is the owning
+complex type) is re-based on the effective base content type so ancestor and derived facets compose.
+`validateSimpleContent` (1.1) validates the text against the composed type whenever
+`simpleContentNeedsValidation` reports it constrains the value (list/union variety, a non-string builtin, or
+any facet/assertion along its chain); `assertValueSequence` types `$value` from the same composed type. A
+NESTED `<xs:simpleType>` content type carries its OWN declared base chain (it is returned by
+`effectiveContentSimpleType` as-is, NOT re-based onto the base content), so the base complex type's inherited
+content facets would otherwise be bypassed; `validateSimpleContent` therefore walks the simpleContent base
+chain and ALSO validates the value against each ancestor `effectiveContentSimpleType(cur.BaseType)` where
+`cur.ContentSimpleType.BaseType != cur` (nested-type and inline-type-plus-sibling-facets cases — re-based
+facet-only synthetic excluded), so inline narrowing AND inherited base facets apply through later derivation
+hops (XSD §3.4.2.2: a nested simpleType RESTRICTS, it does not REPLACE, the base content type — e.g. a
+`maxLength` on the base still rejects an over-long value the nested type alone would accept). So a
+simpleContent EXTENSION of a named faceted/asserted simple type enforces that base type's facets/assertions,
+and a narrowed content type (e.g. an ancestor enumeration) is inherited through a further restriction OR
+extension. In XSD 1.0 `validateSimpleContent` validates against the declared type `td` (not the composed
+`ContentSimpleType`), but its gate is likewise `simpleContentNeedsValidation(td)` (a facet ANYWHERE along td's
+base chain), so a simpleContent EXTENSION of a named faceted type enforces the base's facets in 1.0 too; a
+direct facet on a simpleContent RESTRICTION lives on `ContentSimpleType` (built in both versions and recorded
+in `typeDefSources`), so it is compile-checked by `checkFacetConsistency` in 1.0 but not yet instance-enforced
+there. `resolveWhiteSpace` treats `xs:anySimpleType` as whiteSpace="preserve" (both versions), so a fixed
+value on an `xs:anySimpleType` element keeps surrounding whitespace significant. The
+complexContent-extension-over-simple-base check (cos-ct-extends-1-1) also flags the empty/attribute-only case
+in 1.1. **Conditional type assignment (xs:alternative)** is implemented (`alternative.go`):
+`parseTypeAlternatives` reads the `<xs:alternative>` children of an xs:element (1.1 only) in order — each
+carries an optional `@test` (absent = unconditional default) pre-compiled via xpath3 and a `@type` reference
+registered on `compiler.altTypeRefs` and resolved by `resolveAltTypeRefs` in `resolveRefs`; results are stored
+on `ElementDecl.Alternatives` (the `TypeAlternative` struct). At validation `applyTypeAlternatives` runs at
+every type-selection site (root `validateRootElement`, and
+`matchAll`/`matchElementParticle`/`matchWildcardParticle`/`validateWildcardChild` plus the
+xs:anyType/lax-descendant path in `validate_elem.go`) between `effectiveDeclType` and `resolveXsiType`: when
+no xsi:type is present (`elementHasXsiType`) it returns the type of the first alternative whose `@test` EBV is
+true (or the testless default), else the declared type — so xsi:type still wins; a failing alternative test is
+treated as not-matched. At the wildcard/anyType sites CTA selects the governing type FIRST, then the
+cvc-elt.4.3 derivation-block check and the idc lax-assessment/ID-pass (`assessLaxElement`, `assessed=true`)
+run against the SELECTED type. An `<xs:alternative>` may carry an INLINE anonymous
+`<xs:complexType>`/`<xs:simpleType>` (`parseTypeAlternative`; a present-but-empty `@type` is itself a
+governing-type source, so `@type=""` plus an inline type is a conflict and a bare `@type=""` is an invalid
+QName), `type="xs:error"` (a selected xs:error invalidates the element even through the xsi:nil nilled path),
+and `@xpathDefaultNamespace` (`effectiveXPathDefaultNS`: local value resolved against the alternative else
+inherited from the schema-level default; affects only unprefixed element name tests). The @test runs against a
+DETACHED single-node CTA context (`inherited_attrs.go` `ctaContextNode`: an orphan element bearing the
+element's own attributes PLUS inheritable attributes from ancestors (`inheritedAttributes`, decl
+`inheritable="true"`), in-scope namespaces, position()=last()=1, an `emptyCollectionResolver`, schema base
+URI, no children/parent — so @test cannot navigate to ancestors/siblings). A non-default `@type`/inline
+alternative must be VALIDLY SUBSTITUTABLE for the declared type (`checkAltSubstitutability`, compile time):
+`strictBuiltinAwareDerivedFrom` (`builtin_hierarchy.go`) accepts a genuine `isDerivedFrom` derivation (user
+types), the built-in simple-type hierarchy via the `builtinSimpleBase` table (the 1.0 built-ins are NOT
+BaseType-linked), or the anySimpleType simple-content rule; a union declared type also admits any of its
+base-chain-resolved member types (`resolveVariety`/`resolveUnionMembers`); there is NO permissive
+simple-vs-simple fallback. The block check is built-in-aware (`isDerivationBlocked`). Per-document
+xpathDefaultNamespace/base-URI and the `altTypeRefs`/`ctaElems` worklists are saved/restored across
+include/redefine and seeded onto import sub-compilers. The xs:alternative @test is statically restricted
+(`alternative.go` `checkCTATestStaticContext`, via the new `xpath3.Expression.StaticReferences(namespaces)`,
+which resolves every type/function name to a namespace URI — uniform across prefixed, unprefixed, and
+braced-URI `Q{uri}local` forms — so the check is a pure URI allowlist): a FREE variable reference
+(cta9002err), a non-built-in type named in cast/castable/instance of/treat as / element()/attribute() kind
+tests / path-step node tests — verified against the XPath/XDM type hierarchy `xpath3.IsKnownXSDType` so
+XDM-only names (xs:untyped/xs:untypedAtomic/xs:anyType) are accepted but an unknown xs: name (xs:noSuchType,
+XPST0008) is rejected (cta9003err, ibm typeAlternatives s3_12ii06) — or an unknown/wrong-arity function
+call/`#arity` ref/arrow target — verified against the STANDARD registry
+`xpath3.StandardFunctionAcceptsArity(uri,local,arity)`, which holds the F&O 3.1 fn/math/map/array functions
+AND the xs: type constructors but EXCLUDES helium extension functions (fn:flatten/array:flat-map), so
+user-namespace functions, user-type CONSTRUCTOR calls, unknown functions, extension functions, and wrong-arity
+calls (XPST0017) all reject (arrow arity counts the prepended left operand; an inline-function literal call
+references no named function and is in-context) — OR a schema-element()/schema-attribute() node test (which
+references a GLOBAL declaration absent from the CTA static context, §F.2) — is a schema error; a testless
+(no-`@test`) alternative that is NOT the LAST in document order is rejected (`parseTypeAlternatives`,
+cta9001err). The inherited schema-level `@xpathDefaultNamespace` is resolved against the HOST alternative
+element, not the schema root: `effectiveXPathDefaultNS` re-resolves the RAW token
+(`compiler.schemaXPathDefaultNSToken`, per-document like `xpathDefaultNSSet`) at `elem`, so
+`##defaultNamespace` uses the alternative's own `xmlns` redeclaration (cta0005) per the {xpath default
+namespace} mapping (host in-scope namespaces); `##targetNamespace`/`##local`/URI resolve identically either
+way. `ctaContextNode` carries the INSTANCE document's URI onto the synthetic document so `fn:base-uri(.)` in
+@test resolves to the instance (cta0021; `fn:static-base-uri()` stays the schema URI). Two element
+declarations sharing an expanded name in one content model must have EQUIVALENT {type table}s (Element
+Declarations Consistent extended to type tables, cta9009err/cta9010err), and an element restriction's {type
+table} must be both-absent or both-present-and-EQUIVALENT to the base's (`restriction_particle.go`
+`elementRestrictsElement`, Particle Valid (Restriction) clause 4.6, cta0043) — equivalence is the conservative
+structural comparison (`alternative.go` `typeTablesEquivalent`: same length, identical `@test`s, same {type
+definition}s via `elementTypesConsistent`). **Open content (xs:openContent + xs:defaultOpenContent)** is
+implemented (`opencontent.go`): `parseOpenContent` reads `<xs:openContent>` (mode interleave/suffix/none; the
+`<xs:any>` child becomes the wildcard and must NOT carry minOccurs/maxOccurs — `parseOpenContentWildcard`;
+mode="none" must not carry a wildcard; at most one annotation) on complexType/restriction/extension into
+`TypeDef.OpenContent`, setting `TypeDef.openContentExplicit`. The schema-level **`<xs:defaultOpenContent>`**
+(`readDefaultOpenContent`) is PER-DOCUMENT — saved/reset/restored across
+xs:include/xs:redefine/xs:override/import like the form defaults (an xs:override/xs:redefine REPLACEMENT child
+uses the OVERRIDDEN/redefining document's default per §4.2.5, threaded back via `overrideLoadTarget`'s
+returned `*OpenContent`) — must precede component declarations, and carries mode interleave|suffix (NOT none)
+plus `appliesToEmpty` (default false). It is captured onto each complex type lacking an explicit openContent
+as `TypeDef.pendingDefaultOpenContent`. `resolveOpenContent`/`computeEffectiveOpenContent` (in `resolveRefs`,
+after content models/types are finalized, BASE-FIRST) computes each complex type's EFFECTIVE open content: the
+explicit one (mode="none" → absent, suppresses the default) else the per-document default (applied unless the
+content type is empty and appliesToEmpty=false — `contentTypeEmptyForOpenContent`); an EXTENSION
+inherits/merges the base's (§3.4.2.2 — base interleave mode wins, wildcards union; an extension may not relax
+a base interleave to suffix — §3.4.6.2) and a RESTRICTION's validity is checked (§3.4.6.4
+`checkOpenContentRestriction` — may not add open content to a closed base, subset wildcard, ≥ processContents,
+mode compatible; all WAIVED when the restriction content model is empty). `validateContentByType` routes the
+element-only/mixed/empty path through `validateContentModelOpen` when present: **suffix** matches the declared
+model (`matchContentModelSuffix` — for an `xs:all` it uses the lenient `matchAll11` that stops at the first
+non-member instead of erroring) then requires every trailing child to match the wildcard (a trailing
+declared-named child is "not expected"); **interleave** partitions children — those whose expanded name is NOT
+in `collectModelElementNames(mg)` and which match the wildcard are the open set, the rest must satisfy the
+declared model — then `refineInterleavePartition` moves a declared-named child the model cannot place (and
+which matches the wildcard) into the open set (§3.4.4.3.2 existential partition, via a `suppressDepth`-guarded
+trial match), so open content and declared content may match the same names. Open children are validated via
+`matchWildcardParticle` (lax/strict/skip). `<xs:complexContent>`/@mixed is honored and must agree with
+`<xs:complexType>`/@mixed, and an extension and its base must both be mixed or both element-only (§3.4.6.2
+cos-ct-extends) — both version-INDEPENDENT (enforced in XSD 1.0 and 1.1). The complexType
+schema-representation grammar (the `(annotation?, (restriction|extension))` wrapper via
+`parseDerivationWrapper`, the restriction/extension derivation-body order/cardinality via
+`parseComplexContentDerivationBody`/`parseSimpleContentChildren`, the direct-complexType
+annotation-first/at-most-one rule, and the global `<xs:complexType>`/@name `xs:NCName` check) is likewise
+enforced in both versions; only the 1.1-construct cases (openContent/assert) and the direct-complexType
+stray-child default stay Version11-gated. KNOWN GAPS (skipped): whitespace in a genuinely-empty
+(`<xs:sequence/>`) element-only content type is tolerated (open012.n3); schema-component `@id`
+uniqueness/NCName validity IS enforced (`check_ids.go`, a version-independent XSD rule run in BOTH 1.0 and
+1.1: a per-document DOM walk validating each XSD-namespace element's `id` as a valid xs:ID — NCName after
+whitespace-collapse — and unique within the schema document; run on the entry document AND every nested
+document loaded by xs:include/xs:redefine/xs:import/xs:override with a fresh per-document `seen` set after
+conditional-inclusion pruning, so a duplicate/invalid @id in an included/imported/overridden document is
+caught while the same value may recur across documents; the walk skips xs:appinfo/xs:documentation payload (an
+xs:annotation's own @id still counts); fixes open038/open039). **xs:all relaxations (XSD 1.1)** are
+implemented (Saxon `All.testSet` 61/62; all gated on `Version11`, 1.0 byte-identical). (0) The all group's OWN
+maxOccurs may be 0 or 1 in 1.1 (`validateAllOccurs` accepts `{0,1}`; 1.0 requires exactly 1 — mgO001/mgO018).
+(1) Element members may carry `minOccurs`/`maxOccurs>1`/`unbounded`: `checkAllElementParticleOccurs`
+(`check_elements.go`) skips the all-specific 0/1 rule in 1.1 (the generic lexical / min≤max checks still
+apply). (2) `xs:all` may contain element WILDCARDS, and an `xs:group ref` resolving to an all group may be
+nested directly inside another `xs:all` with occurrence exactly 1/1 (flattened into the parent);
+`checkAllGroupRef` (`link_refs.go`, via `groupRefSource.parentCompositor`) allows this in 1.1 and rejects a
+referenced sequence/choice group, an occurrence ≠ 1/1, or any nested all-group ref in 1.0; an INLINE
+`<xs:all>` directly inside an `<xs:all>` is rejected too (cos-all-limited — `read_particles.go`,
+Version11-gated, so it never reaches the flatteners). (3) `matchAll`/`tryMatchAll` (`validate_elem.go`)
+DISPATCH by version: XSD 1.0 uses the legacy boolean-`seen[]` matcher (`matchAll10`/`tryMatchAll10`),
+BYTE-IDENTICAL to the pre-1.1 path — a wildcard particle the parser tolerates inside a 1.0 xs:all is never
+matched and a required one is reported missing (a wildcard particle is not tracked in the 1.0 required-member
+bookkeeping, guarded by `TestAll10WildcardOnlyRegression`). The per-child content validator
+`validateAllMatchedChild` (shared by both matchers) rejects a child that resolves to an ABSTRACT element
+declaration matched directly (`msgAbstractElement`, cvc-elt.2) in BOTH versions — the 1.0 matcher maps an
+element member's own name directly, so an abstract head used in the instance instead of a concrete
+substitution member reaches here and is caught (the 1.1 `allMemberForChild` already filters it via
+`elemMatchesDeclOrSubst`). XSD 1.1 uses a FLAT member list (`flattenAllMembers` — elements, wildcards, and
+members of a flattened nested 1/1 all) with PER-MEMBER occurrence COUNTING (`matchAll11`/`tryMatchAll11`),
+matched ORDER-INDEPENDENTLY against each member's min/max; an element member is matched only when the child is
+ADMISSIBLY substitutable for it (`allMemberForChild`→`elemMatchesDeclOrSubst`, honoring
+block="substitution"/derivation-block and rejecting abstract heads AND abstract substitution members), and
+weak-wildcard precedence holds (a declared element with remaining budget wins over a wildcard). (4)
+Restriction subsumption of a base `xs:all` is occurrence-COUNTING per BASE MEMBER (`all_subsumption.go`
+`allRestrictsByCounting`/`memberContributions`, routed from `groupRestrictsGroup` for Version11 no-wildcard
+all:all / sequence:all / choice:all): `memberContributions` computes, per BASE-MEMBER INDEX, the (min,max) the
+derived side can emit (summing across a sequence/all, merging a choice's branches by per-base-member min/max
+so alternative branches CORRELATE on the base member, and distinct derived names are not summed, scaling by
+group occurrence); a non-emitting particle (prohibited wildcard / empty group) contributes nothing (checked
+before rejecting a wildcard term); a derived element maps to a base member by name or substitution group via
+the shared `admissibleSubstitutionMember` predicate (concrete member, head allows substitution, member's
+EFFECTIVE type substitutable for the head's — `findBaseAllMember`); the contribution per base member must lie
+within that member's range and every unmapped base member must be emptiable. Several derived particles (e.g.
+substitution-group members) may thus collectively restrict ONE base member with maxOccurs>1. The wildcard
+cases route to `allRestrictsWithWildcards`, which FLATTENS nested 1/1 all-groups on both sides
+(`flattenAllParticles`) and SUMS concrete derived elements per base element before accounting remaining
+concrete/wildcard contributions against the base wildcards' cardinality; a nested NON-all derived group
+(sequence/choice) that survives flattening is NOT decomposed/accounted and is rejected (fail-closed), so it
+cannot smuggle an out-of-namespace element past a base wildcard. When the syntactic Particle Valid
+(Restriction) check FAILS in 1.1, a SOUND fallback (`restriction_subsume.go` `particleLanguageSubset`) PROVES
+`L(derived) ⊆ L(base)` by product simulation of the two content-model automata over the finite alphabet of
+names the derived model can emit (element leaves expanded to instance-admissible substitution members; a base
+wildcard matches every admitted name via `wildcardAllowsName`; per-element type/nillable/fixed checked by
+`elementRestrictsElement`). It is FAIL-CLOSED — a DERIVED wildcard, an xs:all group, or an over-large
+occurrence unroll (`subsumeNFAStateCap`/`subsumePairStateCap`/`subsumeUnrollCap`) returns "not proven" (keep
+the rejection) — and runs only as a fallback that ACCEPTS, so it never rejects more
+(particlesHa161/Hb008/Hb011/Z001/Z028). XSD 1.0 keeps the syntactic verdict, byte-identical. Circular
+attribute group definitions are also permitted in 1.1 (W3C bug 15795 / attgC010-D015): the direct
+self-reference (`read_particles.go`) and indirect cycle (`link_refs.go` `checkCircularAttrGroupRefs`) are
+dropped/cut without a diagnostic (the back-edge is still CUT so the walks terminate); 1.0 rejects both
+(src-attribute_group.3), byte-identical. (5) An `xs:all` may be EXTENDED by another `xs:all`: the extension
+content-merge loop (`link_refs.go`) merges the two member sets into a SINGLE all group — both content models
+must be all groups with the SAME minOccurs; a sequence/choice extending an all, an all extending a
+sequence/choice, or a minOccurs mismatch is rejected; an open-content `interleave` base may not be extended to
+`suffix` mode. (6) UPA over all members (`check_upa.go` `walkAllBody`) is fed by MULTI-HEAD substitution
+groups (`substitutionGroup="a b"` registers the member under every head — `read_elements.go` parses the list
+into `ElementDecl.SubstitutionGroups`, `buildSubstGroups` registers each), so an element substitutable for two
+distinct all members is a cos-nonambig violation. UPA competition is by DECLARATION membership: an ABSTRACT
+substitution member STILL competes (XSD 1.1 §3.8.6.4 / bug 4337, W3C wgData/sg/upa.xsd) even though it can
+never appear in an instance, so `walkTerm` does NOT skip abstract members. Substitution-group membership is
+resolved through a TRANSITIVE cycle-guarded closure (`substitutableMembersForUncached`, `subst_closure.go`)
+that SEPARATES traversal from inclusion: an edge is traversed unless block/derivation-blocked
+(`substTypeDerivationBlocked`, abstract ALLOWED) so a concrete descendant behind an abstract intermediate
+(`h<-abstract m1<-concrete m2`) is reached, while `block="substitution"`/derivation-block prune. The two
+variants differ only in INCLUSION: `instanceSubstMembers` includes a reached member only when CONCRETE
+(abstract excluded) for runtime matching (`elemMatchesDeclOrSubst`) and subsumption (`findBaseAllMember`);
+`substitutableMembersFor` includes abstract members (DECLARATION membership) for UPA (`walkTerm`) and the
+byte-identical 1.0 matcher (`matchAll10`/`tryMatchAll10`/`resolveSubstDecl`). Both walk the full chain
+(`h<-m1<-m2`) — a direct `substGroups[head]` lookup misses multi-level members — and the
+abstract-included-vs-excluded split keeps UPA competition distinct from instance admissibility. The closure of
+every global head is precomputed once, at the end of `compileSchema`, into `Schema.substClosures`
+(`subst_closure.go` `buildSubstClosures`); `substitutableMembersFor`/`instanceSubstMembers`/`substMemberFor`
+resolve through `lookupSubstClosure`, and every compile-time caller above still runs the uncached walk
+directly since `substClosures` is nil until `compileSchema` returns. (7) A nilled element (`xsi:nil`) with
+whitespace-only character content is rejected in 1.1 (`validateNilledElement`, cvc-elt.3.2.1; 1.0 still
+tolerates it); a nilled element whose declaration carries a fixed {value constraint} (`ElementDecl.Fixed !=
+nil`) is rejected in BOTH versions (`validateNilledElement`, cvc-elt.3.2.2 — a fixed value and xsi:nil are
+contradictory; the declaration may still legally carry the fixed value, only the actual xsi:nil="true"
+instance is invalid). KNOWN GAP: `all308` (an empty mixed `xs:all` base extended by an all — Saxon bug 6202,
+where Saxon itself treats the schema as a valid extension) is accepted, not rejected. **Wildcard Element
+Declarations Consistent (EDC)** is implemented (Version11-gated). The STATIC type-table check
+(`check_element_consistent.go`
+`checkWildcardElementConsistent`/`collectModelGroupParticles`/`typeTablesConsistent`/`anyWildcardAllows`, run
+from `checkElementConsistent` over every complex type AND named group) rejects a content model whose LOCAL
+element declaration particle and a same-named GLOBAL element declaration reachable through a lax/strict
+(non-skip) wildcard have inconsistent {type table}s (conditional type assignment). Only the type TABLE is
+compared, NOT the type DEFINITION (a wildcard admits differently-typed elements, so a type-def difference is
+permitted — e.g. a local union(date,time) element plus a wildcard matching an xs:duration global of the same
+name is valid); the asymmetric empty-vs-present case is flagged (under-strict, never false-rejecting two
+distinct-but-present tables). The DYNAMIC check (`validate_elem.go` `validateWildcardElementConsistent` +
+`edcLocalDecls`) walks the matched type's BASE chain via `vc.edcType` (set/restored by `validateContentByType`
+in `validate.go`) in addition to the current content model: a restriction that drops a base's local element
+declaration but admits the name through a wildcard must have its wildcard governing type validly substitutable
+for the base's local type, else the instance is invalid. **Skip-wildcard IDC selector scoping** is
+implemented: `annotateSkipChildren` (`validate.go`) records every element inside a `processContents="skip"`
+subtree in `vc.skipContentNodes`, and `evaluateIDC` (`validate_idc.go`) drops those un-assessed nodes from the
+selector node-set, so an ancestor `xs:key`/`xs:unique`/`xs:keyref` does not constrain them (the pass-3
+ID/IDREF datatype pass already excluded skip content; this fixes the pass-2 selector). 1.1 only —
+`skipContentNodes` is nil/empty in 1.0, byte-identical.
 
-XSD 1.1 QName references (`@type`, `@base`, `@ref`, `@itemType`, and similar paths through `resolveQName` in `link_refs.go`) reject `lexicon.NamespaceXSDDatatypes` (`http://www.w3.org/2001/XMLSchema-datatypes`), the deprecated XML Schema datatypes namespace. Relax NG still uses that namespace through its own validation pipeline.
+XSD 1.1 QName references (`@type`, `@base`, `@ref`, `@itemType`, and similar paths through `resolveQName` in
+`link_refs.go`) reject `lexicon.NamespaceXSDDatatypes` (`http://www.w3.org/2001/XMLSchema-datatypes`), the
+deprecated XML Schema datatypes namespace. Relax NG still uses that namespace through its own validation
+pipeline.
 
 ### Compile: Document → Schema
 
 1. **Parse root** — must be `xs:schema`; extract targetNamespace, form defaults, block/final defaults
 2. **Register built-in types** — 46 XSD primitives
-2a. **Conditional inclusion pre-pass** (`conditional_inclusion.go`, `applyConditionalInclusion`) — run AFTER built-in registration (it consults the registry for type availability) and BEFORE the first collect pass, in BOTH 1.0 and 1.1 mode, on the top-level root AND every included/imported/redefined document (`loadInclude`/`loadRedefine`/`loadImport`). **Caller-document safety:** the pre-pass `helium.UnlinkNode`s excluded elements, which would mutate the caller's parsed `*helium.Document` and make `Compile` non-idempotent (compiling the same doc under 1.0 then 1.1 would lose the 1.1 branch). So `compileSchema` first runs a cheap `documentHasVCDirective(root)` scan and, ONLY when a vc attribute is actually present, compiles against a `helium.CopyDoc(doc)` clone (URL preserved via `SetURL`, so include/import/redefine `schemaLocation` resolution is unchanged) and prunes the CLONE; a vc-free schema keeps the fast no-copy path (no perf regression). Nested include/import/redefine documents are parsed fresh on every `Compile`, so the pre-pass prunes those in place. It walks the schema element tree and `helium.UnlinkNode`s (collected first, unlinked after — never mid-iteration) any element — with its whole subtree — excluded by its version-control (`vc:`, ns `lexicon.NamespaceXSDVersioning`) attributes for the active `c.version`. Prune rules: `vc:minVersion`/`vc:maxVersion` (xs:decimal) keep iff `minVersion <= processorVersion < maxVersion`, compared EXACTLY via `value.CompareDecimal` (math/big.Rat) against the processor version as the exact string "1.0"/"1.1" — NOT float64, so a high-precision bound (`1.1000…001`, kept) is not mis-rounded and a many-digit valid bound does not float-overflow into a spurious "malformed" error; `vc:typeAvailable`/`vc:facetAvailable` keep iff EVERY listed QName is available; `vc:typeUnavailable`/`vc:facetUnavailable` keep iff at least one listed QName is UNavailable (empty `*Unavailable` = unconditional exclude; empty `*Available` = no-op — both fall out of the "all available" formulation). "Available" is a fixed PROCESSOR-CAPABILITY check, NOT "is it declared somewhere": an XSD-namespace built-in TYPE name is matched against the IMMUTABLE per-version set (`builtinTypeAvailable` over `builtinTypeSet10` + the `builtinType11Bases` 1.1-only names — both the single source `registerBuiltinTypes`/`registerBuiltinTypes11` register from), NOT `c.schema.types` (which can already hold user/included declarations — a 1.0 schema literally declaring `{XSD}error` must not make `vc:typeAvailable="xs:error"` true); an XSD-namespace FACET name is matched against `xsdFacetNames`/`xsdFacetNames11` (`assertion`/`explicitTimezone` are 1.1-only). xs:error and the other 1.1 types are available only in 1.1; a non-XSD QName is unavailable. A vc-excluded ROOT `<xs:schema>` drops all its children (empty schema); `applyConditionalInclusion` returns that root-excluded flag so each caller SHORT-CIRCUITS to an empty contribution BEFORE interpreting/validating the root's other (non-preserved) attributes — at top level `compileSchema` skips blockDefault/finalDefault validation (an excluded root must not fail on, e.g., a bogus `blockDefault` it would never use; `registerBuiltinTypes` is moved ahead of that validation so the pre-pass has the type registry), but if the pre-pass already reported a malformed-vc error (`errorCount > 0`) it returns `ErrCompilationFailed`, so the empty-schema return cannot swallow it. For a NESTED document the pre-pass runs right after the root is confirmed `<xs:schema>` and BEFORE the targetNamespace-compatibility / src-import check (`loadInclude`/`loadRedefine`/`loadImport`), so a vc-excluded nested root with an incompatible TNS is an empty contribution, not a TNS error. A vc-excluded `loadInclude` root returns `nil` (nothing to merge), but a vc-excluded `loadRedefine` root does NOT short-circuit: it contributes an EMPTY Phase-A set and still runs `processRedefineOverrides` against it, so an `<xs:redefine>` override targeting a (now-absent) component is REJECTED per XSD redefine semantics. **src-redefine.5** (version-independent, `compile_imports.go` `checkRedefineSelfDerivation`, called from the `processRedefineOverrides` complexType/simpleType cases): a `<simpleType>`/`<complexType>` child of `<xs:redefine>` must have a `<restriction>` (or, for a complexType, `<extension>`) whose resolved `base` equals the redefined type's own name — self-derivation is present iff `c.typeRefs[newType] == qn`. A different base, a same-local base in another namespace, or no derivation at all is a schema error (the self-reference patch is then skipped). For `loadImport` the sub-compiler's diagnostics are flushed to the parent on EVERY exit path after the sub-collector is installed via an idempotent `propagateImpErrors` (a `propagated` guard) that is `defer`red right after install — so a 1.1 malformed-vc value recorded during the pre-pass is propagated (and fails the compile) even when a later early return fires, e.g. the `parseSchemaChildren`-error or fatal nested-load path; the explicit calls that remain only fix ordering (forward while the parent is still error-free, before a TNS error is reported, and skip the declaration merge on failure). Malformed `vc:` values — a non-`xs:decimal`-lexical version (`isValidXSDDecimal`: sign/digits/one-dot form only, magnitude-agnostic; the value is trimmed of ASCII XML whitespace only — `" \t\r\n"`, NOT `strings.TrimSpace`, so a NBSP-padded version stays malformed) or an invalid/unbound-prefix QName in a list (`xmlchar.IsValidQName`+`lookupNS`) — are fatal schema errors ONLY under 1.1; under 1.0 they are tolerated and the condition skipped (so a schema with a bad `vc:minVersion` is valid under 1.0, invalid under 1.1, matching W3C VC vc902/vc903). Only the six exact attribute local names are consulted; a misspelt versioning-namespace attribute (e.g. `vc:minversion`) is an inert foreign attribute. Empirically calibrated against the W3C saxonData/VC + ibmData conditionalInclusion suites (note: the spec's "Unavailable" quantifier is the surprising one — vc011 single-known prunes, vc013 mixed keeps, vc014 xs:error single-known prunes).
+2a. **Conditional inclusion pre-pass** (`conditional_inclusion.go`, `applyConditionalInclusion`) — run AFTER
+    built-in registration (it consults the registry for type availability) and BEFORE the first collect pass,
+    in BOTH 1.0 and 1.1 mode, on the top-level root AND every included/imported/redefined document
+    (`loadInclude`/`loadRedefine`/`loadImport`). **Caller-document safety:** the pre-pass `helium.UnlinkNode`s
+    excluded elements, which would mutate the caller's parsed `*helium.Document` and make `Compile`
+    non-idempotent (compiling the same doc under 1.0 then 1.1 would lose the 1.1 branch). So `compileSchema`
+    first runs a cheap `documentHasVCDirective(root)` scan and, ONLY when a vc attribute is actually present,
+    compiles against a `helium.CopyDoc(doc)` clone (URL preserved via `SetURL`, so include/import/redefine
+    `schemaLocation` resolution is unchanged) and prunes the CLONE; a vc-free schema keeps the fast no-copy
+    path (no perf regression). Nested include/import/redefine documents are parsed fresh on every `Compile`,
+    so the pre-pass prunes those in place. It walks the schema element tree and `helium.UnlinkNode`s
+    (collected first, unlinked after — never mid-iteration) any element — with its whole subtree — excluded by
+    its version-control (`vc:`, ns `lexicon.NamespaceXSDVersioning`) attributes for the active `c.version`.
+    Prune rules: `vc:minVersion`/`vc:maxVersion` (xs:decimal) keep iff `minVersion <= processorVersion <
+    maxVersion`, compared EXACTLY via `value.CompareDecimal` (math/big.Rat) against the processor version as
+    the exact string "1.0"/"1.1" — NOT float64, so a high-precision bound (`1.1000…001`, kept) is not
+    mis-rounded and a many-digit valid bound does not float-overflow into a spurious "malformed" error;
+    `vc:typeAvailable`/`vc:facetAvailable` keep iff EVERY listed QName is available;
+    `vc:typeUnavailable`/`vc:facetUnavailable` keep iff at least one listed QName is UNavailable (empty
+    `*Unavailable` = unconditional exclude; empty `*Available` = no-op — both fall out of the "all available"
+    formulation). "Available" is a fixed PROCESSOR-CAPABILITY check, NOT "is it declared somewhere": an
+    XSD-namespace built-in TYPE name is matched against the IMMUTABLE per-version set (`builtinTypeAvailable`
+    over `builtinTypeSet10` + the `builtinType11Bases` 1.1-only names — both the single source
+    `registerBuiltinTypes`/`registerBuiltinTypes11` register from), NOT `c.schema.types` (which can already
+    hold user/included declarations — a 1.0 schema literally declaring `{XSD}error` must not make
+    `vc:typeAvailable="xs:error"` true); an XSD-namespace FACET name is matched against
+    `xsdFacetNames`/`xsdFacetNames11` (`assertion`/`explicitTimezone` are 1.1-only). xs:error and the other
+    1.1 types are available only in 1.1; a non-XSD QName is unavailable. A vc-excluded ROOT `<xs:schema>`
+    drops all its children (empty schema); `applyConditionalInclusion` returns that root-excluded flag so each
+    caller SHORT-CIRCUITS to an empty contribution BEFORE interpreting/validating the root's other
+    (non-preserved) attributes — at top level `compileSchema` skips blockDefault/finalDefault validation (an
+    excluded root must not fail on, e.g., a bogus `blockDefault` it would never use; `registerBuiltinTypes` is
+    moved ahead of that validation so the pre-pass has the type registry), but if the pre-pass already
+    reported a malformed-vc error (`errorCount > 0`) it returns `ErrCompilationFailed`, so the empty-schema
+    return cannot swallow it. For a NESTED document the pre-pass runs right after the root is confirmed
+    `<xs:schema>` and BEFORE the targetNamespace-compatibility / src-import check
+    (`loadInclude`/`loadRedefine`/`loadImport`), so a vc-excluded nested root with an incompatible TNS is an
+    empty contribution, not a TNS error. A vc-excluded `loadInclude` root returns `nil` (nothing to merge),
+    but a vc-excluded `loadRedefine` root does NOT short-circuit: it contributes an EMPTY Phase-A set and
+    still runs `processRedefineOverrides` against it, so an `<xs:redefine>` override targeting a (now-absent)
+    component is REJECTED per XSD redefine semantics. **src-redefine.5** (version-independent,
+    `compile_imports.go` `checkRedefineSelfDerivation`, called from the `processRedefineOverrides`
+    complexType/simpleType cases): a `<simpleType>`/`<complexType>` child of `<xs:redefine>` must have a
+    `<restriction>` (or, for a complexType, `<extension>`) whose resolved `base` equals the redefined type's
+    own name — self-derivation is present iff `c.typeRefs[newType] == qn`. A different base, a same-local base
+    in another namespace, or no derivation at all is a schema error (the self-reference patch is then
+    skipped). For `loadImport` the sub-compiler's diagnostics are flushed to the parent on EVERY exit path
+    after the sub-collector is installed via an idempotent `propagateImpErrors` (a `propagated` guard) that is
+    `defer`red right after install — so a 1.1 malformed-vc value recorded during the pre-pass is propagated
+    (and fails the compile) even when a later early return fires, e.g. the `parseSchemaChildren`-error or
+    fatal nested-load path; the explicit calls that remain only fix ordering (forward while the parent is
+    still error-free, before a TNS error is reported, and skip the declaration merge on failure). Malformed
+    `vc:` values — a non-`xs:decimal`-lexical version (`isValidXSDDecimal`: sign/digits/one-dot form only,
+    magnitude-agnostic; the value is trimmed of ASCII XML whitespace only — `" \t\r\n"`, NOT
+    `strings.TrimSpace`, so a NBSP-padded version stays malformed) or an invalid/unbound-prefix QName in a
+    list (`xmlchar.IsValidQName`+`lookupNS`) — are fatal schema errors ONLY under 1.1; under 1.0 they are
+    tolerated and the condition skipped (so a schema with a bad `vc:minVersion` is valid under 1.0, invalid
+    under 1.1, matching W3C VC vc902/vc903). Only the six exact attribute local names are consulted; a
+    misspelt versioning-namespace attribute (e.g. `vc:minversion`) is an inert foreign attribute. Empirically
+    calibrated against the W3C saxonData/VC + ibmData conditionalInclusion suites (note: the spec's
+    "Unavailable" quantifier is the surprising one — vc011 single-known prunes, vc013 mixed keeps, vc014
+    xs:error single-known prunes).
 3. **First pass: collect** — walk children, populate maps:
    - `schema.elements` (global element decls)
    - `schema.types` (named complex/simple types)
    - `schema.groups` (model groups)
    - `schema.attrGroups` (attribute groups)
    - `schema.globalAttrs` (global attributes)
-4. **Process includes/imports** — load `xs:include`/`xs:import`/`xs:redefine`, merge declarations. Nested-schema document loads go through `compiler.readNestedSchema(path)` (FS `Open` preferred, falling back to `fs.ReadFile` for a `ReadFileFS`-only FS whose `Open` errors, both under a `maxNestedSchemaSize` 10 MiB byte cap via `internal/iolimit`, so an endless source cannot exhaust memory), reading from `compileConfig.fsys`, an injectable `fs.FS` set via `Compiler.FS(...)`; it **defaults to `iofs.DenyAll`** (opens nothing — secure by default, mirroring `helium.NewParser`) so an untrusted schema cannot disclose local files or exhaust resources via a hostile `schemaLocation` — opt into host access via `Compiler.FS(helium.PermissiveFS())` or a confined FS — and is propagated to sub-compilers. **Circular-import termination:** a shared (pointer-passed to every sub-compiler) `importActive` set tracks resolved fs paths currently ON the active import ancestry (the load stack, keyed by path → expected namespace, seeded with the root's `rootKey` and targetNamespace). `loadImport` short-circuits (returns nil, skipping only the RELOAD) an import whose target path is already on that stack — a mutual (A ↔ B) or self import is mid-parse in an ancestor, so re-loading would recurse forever and can add no new components — but FIRST validates the back-edge's requested `namespace` against the recorded expected namespace and emits the src-import diagnostic on mismatch (so a cyclic back-edge with a wrong/absent namespace is caught, not hidden). Entries are pushed before descending and popped on unwind, so a DIAMOND import of the same document on two disjoint branches still loads independently (deduped by the "if not exists" merge guards). A legal circular import (W3C particlesDa001/Db001) thus compiles cleanly, and the `maxImportDepth` ceiling remains a defensive net for a genuinely deep non-cyclic chain. An over-cap read returns `errSchemaTooLarge`, classified fatal by `IsFatalSchemaLoad`. `xslt3` injects a resolver-backed `fs.FS` (`schemaResolverFS`) so nested includes inside a resolver-loaded schema obey the same default-deny `URIResolver` policy as the top-level load. `schemaResolverFS.Open` is the xslt3→xsd BOUNDARY: it TRANSLATES the xslt3 loader's classification into XSD's `fs.FS` vocabulary so `readNestedSchema` demotes/keeps-fatal consistently — a CONFIRMED resolution miss (`isDemotableSchemaMiss`, e.g. a resolver returning a bare `errors.New("not found")` that does NOT itself satisfy `fs.ErrNotExist`) is re-expressed as a `*fs.PathError{Op:"open", Err: fs.ErrNotExist}` (via `schemaMissNotExistError`, which reports `fs.ErrNotExist` through `Is` while preserving the original chain) so the OPTIONAL nested include WARNS-and-skips instead of being over-rejected; everything else (a post-open read failure, a permission denial, a resource-cap breach, a policy denial, or any other/ambiguous error) is wrapped `fatalSchemaLoadError` so `IsFatalSchemaLoad`/`notDemotable` keeps it FATAL regardless of the inner errno (the chain is preserved so `errors.Is(fs.ErrPermission)`/`ErrResourceTooLarge` still hold). Schema-location resolution is **URI-aware** and lives in a **single canonical helper**, `xsd.ResolveSchemaURI(ref, base) (string, error)` (`xsd/resolve_uri.go`), shared by both the xsd nested-include path and `xslt3`'s schema loader so the two layers cannot drift. `validateSchemaPath` is a thin wrapper over it. It keys off whether `ref`/`base` carries a URI scheme (`xsd.URIScheme`, the **one** scheme-detector for both packages — multi-char scheme required so Windows drive letters and bare OS paths stay local): an **absolute-URI** `schemaLocation` (e.g. a cross-host `https://cdn.example.com/part.xsd`) is passed through **unchanged** — never `filepath.Join`ed, which would collapse `//` and drop the host (and when that verbatim non-file-scheme URI reaches the direct filesystem loader `iofs.PermissiveRoot.Open`, it is NOT `os.Open`ed — a network URI is not a local path, so `os.Open` would fail with a platform-DEPENDENT errno, ENOENT on Linux, EINVAL on macOS/Windows; instead `PermissiveRoot` returns a `*fs.PathError{Op:"open", Err: fs.ErrNotExist}` via `uripath.URIScheme`, so an OPTIONAL absolute-URI include/import hint the local FS cannot serve is classified as a resolution MISS and demoted to a warning-and-skip CONSISTENTLY across platforms; a `file:` URI IS a local resource, so `PermissiveRoot` CONVERTS it to a filesystem path first (`FileURIToPath` — percent-decode, `file:///abs` → `/abs`, Windows `file:///C:/x` → `C:\x`) so a valid `file:///` include LOADS and a missing one yields `os.Open`'s own ENOENT (a demotable miss), a malformed/UNC/non-local file URI being returned as a NON-`fs.ErrNotExist` PathError (fatal); while a genuinely-local path — no scheme, or a drive-letter path — still reaches `os.Open` and keeps its real errno so a malformed local path stays fatal. This `PermissiveRoot` mapping is a convenience for that FS; `readNestedSchema`'s own scheme-based non-file-URI demotion (above) is the FS-INDEPENDENT guarantee that also covers `os.DirFS`); a **relative** location against a **URI base** resolves via `net/url` `ResolveReference` (RFC 3986), keeping authority intact **and re-applying the base's `OmitHost` flag** when the base had no authority (so `mem:/schemas/main.xsd` + `part.xsd` → `mem:/schemas/part.xsd`, never `mem:///schemas/part.xsd`, while canonical `file:///...` bases keep their `///`); a genuine **local** base/location keeps the historical `filepath.Join` + `..`-escape guard (the only branch that can return an error). The import sub-compiler's `baseDir` is `schemaBaseDir(path)` (the full URI for URI bases, `filepath.Dir` for local). Because resolution happens while base and raw `schemaLocation` are still separate, the name reaching the FS is the **canonical** nested URI, so `schemaResolverFS.Open` forwards it verbatim (no string repair of a collapsed name). `xslt3`'s `resolveSchemaURI` delegates the absolute-URI and URI-base cases to `xsd.ResolveSchemaURI` and only handles its own local **file**-base case (xslt3's base is a full file URI/path, not a directory); it seeds the xsd `BaseDir` via `schemaCompileBaseDir(uri)` (full URI when scheme present, `filepath.Dir` otherwise). **targetNamespace match (src-import / src-include):** `loadImport` rejects the located schema when its `targetNamespace` differs from the `namespace` declared on `<xs:import>` — a present `namespace` requires that exact TNS, an absent `namespace` requires the imported schema to have no TNS (so a schema imported as one namespace cannot silently contribute another's declarations). `loadInclude`/`loadRedefine` enforce the analogous include rule (included TNS must equal the including schema's, modulo chameleon includes with no TNS). Both raise a fatal `Schemas parser error` and stop merging that document. **Nested-load classification — PHASE-AWARE, FAIL-CLOSED, three-way (src-include.1 / src-import):** the fatal-vs-warning decision for an `xs:include`/`xs:import`/`xs:redefine` target is not fetch-vs-content but a THREE-way taxonomy keyed on WHERE the failure occurs, and it is FAIL-CLOSED (fatal by default). The demotable decision is a SINGLE POSITIVE TAG applied at ONE place: `readNestedSchema(path)` itself classifies each fetch outcome PHASE-AWARELY and wraps ONLY a benign RESOLUTION miss in `errSchemaFetchMiss`; `nestedLoadFailureFatal(err)` is `!nestedFetchMiss(err)` and `nestedFetchMiss(err)` is `errors.Is(err, errSchemaFetchMiss) && !IsFatalSchemaLoad(err)` — so the ONLY demotable outcome is a tagged benign miss. `processImport` and the `xs:override` subsystem route through the SAME classifier so the include/redefine/import/override cells cannot diverge. The `xs:override` subsystem (`override.go`) applies the IDENTICAL taxonomy: `overrideLoadTarget` fetches its target through the shared `readNestedSchema` (so a missing target is tagged `errSchemaFetchMiss`, its parse/non-schema-root errors `errSchemaContentInvalid`), the top-level `loadOverride` call in `processIncludes` demotes a fetch-miss via `nestedLoadFailureFatal`, and the target's OWN nested `xs:include`/`xs:override`/`xs:redefine` children route through the shared `demoteNestedOverrideLoad` (same `nestedLoadFailureFatal` + `reportSchemaLoadWarning`), so a missing override target — or a missing include/redefine target nested inside an overridden document — WARNS-and-skips while content/policy stays fatal. A MISSING (absent) `@schemaLocation` on `xs:include`/`xs:redefine`/`xs:override` is a distinct fatal representation error (`reportMissingSchemaLocation`, src-include.1 / src-redefine.1 / §4.2.4), enforced in BOTH `processIncludes` and `overrideProcessNested`. (1) **Fetch/resolution miss → WARNING:** a demotable miss must POSITIVELY signal the resource is ABSENT. `readNestedSchema` demotes ONLY: a FAILED `Open` whose errno is `fs.ErrNotExist` (`isBenignResolutionMiss` — `fs.ErrNotExist` ONLY, since only it positively signals not-found; a bare `fs.ErrInvalid` / permission / other errno on a genuinely-LOCAL path is NOT a confirmed absence and stays FATAL); a non-file-scheme ABSOLUTE URI `schemaLocation` (http://, urn:, …), which is not a local resource, so a filesystem FS reports an FS-DEPENDENT benign errno — `fs.ErrNotExist` (os.Open / `iofs.PermissiveRoot`'s URI mapping) or `fs.ErrInvalid` (`os.DirFS`, which rejects a non-`fs.ValidPath` name), and readNestedSchema demotes it FS-INDEPENDENTLY by scheme (`uriScheme(path)` non-file) unless `notDemotable`; or, for a `ReadFileFS`-only FS whose `Open` is unsupported (`isOpenMissOrUnsupported`: `fs.ErrNotExist`/`fs.ErrInvalid`), an atomic `fs.ReadFile` fallback reporting a CANONICAL "file not found" (`isDirectNotExist`: the bare `fs.ErrNotExist` sentinel or a `*fs.PathError{Op:"open"}` whose cause satisfies `fs.ErrNotExist`). It wraps the miss in `errSchemaFetchMiss` and demotes to the non-fatal I/O warning pair (`reportSchemaLoadWarning`, "Failed to locate a schema ... Skipping the include./import./redefine."), so a valid schema carrying unresolvable location hints still compiles (libxml2 parity; W3C anyURI_a001/schB8/schD8/schE5/schE6/schE10). (2) **Content failure → FATAL:** the target was fetched but is not well-formed XML (a `parse` error) or its root is not `<xs:schema>` — tagged `errSchemaContentInvalid` by all three loaders; and — the key phase-awareness — a POST-OPEN read failure (the location RESOLVED and OPENED, then the stream `Read` failed) is wrapped in `errNestedSchemaReadAfterOpen` (fatal, recognized by `IsFatalSchemaLoad`), and ANY error AFTER the fetch phase (declaration parsing, redefine overrides, a nested include/import inside the fetched document, e.g. a top-level `xs:complexType` missing its `@name`) is UNTAGGED and therefore fatal by the fail-closed default, so a fetched-but-invalid schema is never silently downgraded to a warning. (3) **Policy/security denial → FATAL:** BOTH demotion predicates (`isBenignResolutionMiss`, `isDirectNotExist`) consult ONE shared veto `notDemotable(err)` FIRST — `containsMultiError(err) || errors.Is(err, fs.ErrPermission) || IsFatalSchemaLoad(err)` — so a MULTI-ERROR (`errors.Join` / any `Unwrap() []error`, which defeats `errors.Is` first-match selection so a benign sibling could mask a fatal one), a PERMISSION denial (`fs.ErrPermission`, e.g. an outside-root policy error), or an `IsFatalSchemaLoad` condition (`errImportDepthExceeded`/`errIncludeDepthExceeded`/`errSchemaPathEscape`/`errSchemaTooLarge`/`errNestedSchemaReadAfterOpen`, plus any chain satisfying the exported `xsd.FatalSchemaLoader` interface) is NEVER tagged and stays fatal even when it ALSO wraps a benign errno. `readNestedSchema` also returns UNTAGGED — fatal — an error from the default `iofs.DenyAll` FS (which returns `fs.ErrNotExist` for EVERY Open, indistinguishable by errno from a genuine miss, so the FS TYPE — not the errno — decides; an untrusted schema's on-disk include is thus not silently swallowed — `TestDefaultFSDeniesUntrustedInclude`). The imported-schema nested path propagates `impC.processIncludes`'s error UNCONDITIONALLY — that sub-call has already demoted its own benign nested misses internally and returns non-nil only for a fatal condition, so a content-invalid nested include inside an imported schema stays fatal. `xslt3` marks TWO of its loader errors so `IsFatalSchemaLoad` recognizes them across the boundary: an over-cap read (`ErrResourceTooLarge`) and the default-deny POLICY denial (`errSchemaResolverDenied` — "no URIResolver configured", filesystem access is opt-in), both wrapped in a `FatalSchemaLoader` marker by `schemaResolverFS.Open` that `Unwrap`s to the original so `errors.Is` still holds and the "no URIResolver configured" message survives; the marker distinguishes a POLICY denial from a resolver fetch MISS (a configured resolver simply lacking the target, which stays demotable). The `xslt3` TOP-LEVEL `xsl:import-schema` schema-location path (`compile_schema.go` `compileImportSchema`) applies the SAME three-way fetch-miss / content / denial taxonomy to its precompiled-schema fallback (`findImportSchema` by namespace, from `Compiler.ImportSchemas`): `compileSchemaFromURI` is PHASE-AWARE — the fetch phase (`loadSchemaBytes`) returns its errors UNTAGGED (a genuine fetch miss the fallback may use), while EVERY post-fetch return (a malformed-XML `parseExternalXML` error, or an invalid-XSD `Compile` / `ErrCompilationFailed` / XTSE0220) is tagged `errSchemaContentInvalid`. Classification is POSITIVE-TAG, mirroring the xsd nested classifier: the xslt3 loaders tag a CONFIRMED benign resolution miss with `errSchemaResolutionMiss` (the sole demotable outcome) at exactly the resolution-phase points — `loadSchemaBytes`/`fetchViaResolver` when the resolver's `Resolve`/`ResolveURI` error POSITIVELY signals not-found (`errors.Is(err, fs.ErrNotExist)` — an OPAQUE resolver error like a bare "HTTP 403" is NOT tagged and is therefore FATAL; a URIResolver must return an `fs.ErrNotExist`-satisfying error to signal a demotable absent optional schema), and `fetchHTTPBytes` on an HTTP 404/410 — and `isDemotableSchemaMiss(err)` is `errors.Is(err, errSchemaResolutionMiss) && !isFatalSchemaLoadError(err)`. Together `isDemotableSchemaMiss` and `isFatalSchemaLoadError` PARTITION the space: the precompiled fallback fires ONLY when `isDemotableSchemaMiss`, so EVERYTHING else fails closed with an `xsl:import-schema: cannot compile` error — a POST-OPEN read failure (reader obtained then Read fails, untagged), an HTTP 401/403/5xx/other-non-2xx (untagged), a FATAL load (`isFatalSchemaLoadError` — denial/cap/path-escape/depth, a PERMISSION denial `fs.ErrPermission`, or a MULTI-ERROR), a CONTENT error (`errSchemaContentInvalid`), or any untagged/ambiguous error — never masked by a matching precompiled `ImportSchemas` entry. A schema that WAS fetched but whose `targetNamespace` does not match the declared `namespace` is a fatal XTSE0220 with NO precompiled fallback (the fetched schema is authoritative — falling back would silently mask an authoritative-but-wrong location). The runtime source-document schema loader (`source_schema.go` `loadSchemasFromSchemaLocation`, from a source document's `xsi:schemaLocation`/`xsi:noNamespaceSchemaLocation`) has NO precompiled fallback but applies the SAME fetch/content/denial taxonomy at its CALLER (`execute_transform.go`) under lax/default validation as under strict — it does NOT demote content or policy errors just because validation is lax. It PHASE-TAGS each error so the caller can classify it: a malformed schema-location reference (`resolveSchemaURI`), malformed XML (`Parse`), or invalid XSD (`Compile`) is tagged `errSchemaContentInvalid`; a default-deny POLICY denial (no URIResolver/HTTPClient configured for the hint, detected via `execContext.schemaFetchAvailable`) is tagged `errSchemaResolverDenied`; a resource-cap breach (`ErrResourceTooLarge`) survives in the chain. The caller returns fatal when validation is strict OR the error is NOT a positively-tagged demotable miss (`!isDemotableSchemaMiss`); ONLY a CONFIRMED benign resolution miss (`errSchemaResolutionMiss` — a resolver lacking the target / HTTP 404) is best-effort skipped under lax/default (schemaLocation is only a hint, the source is left unvalidated), while a post-open read failure, an HTTP 401/403/5xx, a content error, or a policy/cap/permission denial stays fatal even under lax. So a broken or policy-denied source-schema hint is fatal even under lax, never silently masked. The multi-entry loop over the resolved `xsi:schemaLocation`/`xsi:noNamespaceSchemaLocation` paths AGGREGATES across the whole list: a POLICY denial (`errSchemaResolverDenied`), a POLICY/CAP fatal (`isFatalSchemaLoadError`), or a CONTENT error (`errSchemaContentInvalid` from parse/compile) returns EAGERLY (fatal), preserving the schemas loaded so far; a genuine untagged FETCH MISS is recorded (only the FIRST) and the loop CONTINUES, returning `(schemas, firstMiss)` at the end. So a demotable miss on an earlier entry does NOT hide a later entry's content/policy error (which stays fatal under lax) or prevent a later VALID entry from loading best-effort — mirroring the accumulate-then-break shape of the xsd `processIncludes`/`overrideProcessNested` loops. The taxonomy is pinned by `nested_load_taxonomy_test.go` (fetch miss warns; malformed/non-schema/missing-@name content is fatal for include/import/redefine AND for a nested include inside an imported schema; deny-all denial is fatal — and the same three cells for an `xs:override` target and for an `xs:redefine` nested inside an overridden document). **Transitive includes:** after parsing an included/redefined schema's declarations, `loadInclude`/`loadRedefine` recurse via `processNestedIncludes` (switching `baseDir`/`filename` to the included schema) so that schema's OWN `xs:include`/`xs:import`/`xs:redefine` resolve — a chain `main → inc1 → inc2(defines T)` where `main` uses `T` compiles. Recursion is bounded by `includeVisited` (a per-compiler loaded-set keyed on resolved fs path, so each document loads at most once and circular includes terminate) plus a `maxIncludeDepth` cap (`errIncludeDepthExceeded`). `includeVisited` only records documents pulled in via `loadInclude`/`loadRedefine`, so `CompileFile` seeds it with the TOP-LEVEL schema's own resolved key (`compileConfig.rootKey`, computed via `ResolveSchemaURI(filepath.Base(path), baseDir)` in the same canonical form a nested include would use): a cycle that points back at the root (`main → inc → main`) then treats the root as already-loaded instead of re-parsing it and emitting spurious duplicate-component errors. **Repeated `xs:redefine` of the same document:** XSD permits multiple `xs:redefine` targeting one document (redefining disjoint components, or a no-op repeat), so a redefine whose target is already in `includeVisited` is NOT rejected for the path repeating. When a document is first loaded (via `loadInclude` or `loadRedefine`), the set of redefinable component names it contributes (the `(afterKeys − beforeKeys)` delta, split by kind via `computeRedefinableKeys`) is cached per resolved path in `loadedRedefinable`; a later `xs:redefine` of that already-loaded document skips Phase A and processes its override children (`processRedefineOverrides`) against the cached Phase-A set. A shared `consumed` set per document tracks which components have already been redefined across every `xs:redefine` of it, so a component redefined twice (`g` in two redefines) is reported as a duplicate (`… does already exist.`) while disjoint redefinitions and an empty/no-op repeat compile clean. **`xs:override` (XSD 1.1, `override.go`, gated to `Version11`):** processed in `processIncludes` alongside include/import/redefine. Unlike redefine (restriction/extension of the SAME component), override is WHOLESALE REPLACEMENT of any top-level component (element/attribute/simpleType/complexType/group/attributeGroup/notation) in the referenced document matched by an override child of the same (expanded-name, symbol space — simpleType and complexType share ONE type symbol space). `loadOverride` collects the override children, then `overrideLoadTarget` loads the target (like include: TNS/chameleon/form-default handling, and the SAME three-way fetch-miss/content/denial nested-load taxonomy via `readNestedSchema` + `nestedLoadFailureFatal`), parses its SURVIVING components via `overrideParseTargetChildren` (a matched component is SUPPRESSED and recorded), and recurses into the target's own include/override via `overrideProcessNested` — the transform is TRANSITIVE, a nested `xs:include` is treated as an `xs:override` carrying the cascaded set and a nested `xs:override` merges its children (OUTER override wins on collision). The active override set is BRANCH-LOCAL: a nested `xs:override` derives a FRESH map (inherited ∪ its own children, outer-precedence, `activeFromEntries`) so its children cannot leak into a later SIBLING include/override target's suppression set; `overrideLoadTarget` RETURNS the matched subset and each `xs:override` REGISTERS its own matched children IMMEDIATELY (`registerMatchedChildren`/`registerOverrideChild`), while the DECLARING document's context (form/block/final defaults, xpathDefaultNamespace, base URI, includeFile) is still active — never deferred to an outer context. An override child that matched nothing is DROPPED, so a reference to it is a dangling-ref error (conformance-verified against over026 — registering unmatched children makes over026 the only failing case; NOT the literal §4.2.5 "add all children" reading). Termination uses a SEPARATE `overrideVisited` set (distinct from plain-include `includeVisited`) keyed by `path + overrideActiveFingerprint(active)` (sorted symbol/name/replacement-element identity) plus the document's `rootKey`: a re-reach under the SAME active set or a back-edge to the root terminates without re-loading (permissible circular override), but the SAME document reached with a DIFFERENT active set is a DISTINCT transformed document and is loaded again — keying by path alone would over-terminate and silently drop a sibling override's replacements, while loading distinct lets a genuine collision surface via the duplicate-component check. A disallowed cycle surfaces as a dangling reference. A document pulled in by BOTH a plain `xs:include`/`xs:redefine` AND an `xs:override` is a FATAL conflict (`reportOverrideIncludeConflict`, enforced in `overrideLoadTarget` and symmetrically in `loadInclude`/`loadRedefine`) — not a silent no-op, since the override yields a distinct constituent whose components collide with the included originals. Per-document override-target sets in `processIncludes`/`overrideProcessNested` reject overriding the same document twice; duplicate override children of one `xs:override` are rejected. `xs:import` inside a target is handled by the SHARED `processImport` helper (NOT transformed) so it emits the same already-imported / load-failure warnings as a top-level import; override children may reference components imported only by the overriding schema. Override+redefine interplay is unexercised by the suite and processes redefine without cascade — a documented gap.5. **Resolve references** — resolve all QName refs (types, base types, groups, attr groups, union members), detect circular substitution. **Circular model-group references** are detected and CUT by `checkCircularGroupRefs` (`link_refs.go`) BEFORE the group-ref resolution loop shares group content slices: a named `xs:group` that references itself (directly or transitively) would otherwise make the resolved content-model tree cyclic and stack-overflow the downstream Glushkov (UPA)/element-consistency/open-content walks. A DFS over the named-group reference graph (built from each group's UNRESOLVED definition) reports each back-edge as a `Circular reference to the model group definition '...' defined.` schema error and leaves the back-edge placeholder an empty model group so resolution stays acyclic. This is forbidden in BOTH XSD 1.0 and 1.1 (a model group must not contain itself), so it is reported in both versions (unlike circular ATTRIBUTE groups, which 1.1 permits). `check_upa.go`'s `positionAutomaton` also carries a defensive recursion-stack guard (`walking`, a `map[*ModelGroup]struct{}`) that terminates the Glushkov walk on any self-referential model group that ever slips through — never fired by a valid schema, since an acyclic model never has a group as its own ancestor. The substitution-group membership map itself is built by `buildSubstGroups` just BEFORE this step (global element `@substitutionGroup` affiliations are fixed at read/include time; XSD 1.1 list-valued attributes register the member under every listed head), so the UPA (`checkUPA`) check run WITHIN `resolveRefs` can expand a content model's substitution-group head leaves to their transitive members. `buildSubstGroups` only populates and sorts the direct-affiliation map and emits no diagnostics, so the circular/final/element-consistency checks keep their original error ordering. For an untyped member, `inheritedTypeFromFirstSubstitutionHead` follows only the FIRST QName in the actual `@substitutionGroup` value at each step to find the inherited declared type; the full list remains for membership and affiliation checks. After refs resolve, `checkSubstGroupAffiliations()` rejects any member whose effective declared type is not validly derived from each affiliated head's effective declared type. After attribute type refs resolve, `checkAttrUseConstraints()` validates each attribute use's `default`/`fixed` constraint value against the attribute's declared simple type, so a retained-but-invalid constraint (e.g. `default=""` on an `xs:integer` attribute) is reported as a schema parser error, so it can never be injected into the instance at validation time. **au-props-correct.3** is enforced during attr-ref resolution (`checkAttrRefFixedConflict`): when an `<xs:attribute ref>` use carries its OWN value constraint AND the referenced global declaration has a `fixed`, the use's constraint must ALSO be `fixed` and value-equal (compared under the global's type via `fixedConstraintRestricts`) — a local `default`, or a `fixed` with a different value, is a schema error. This is enforced for EVERY referencing use, not only inside a restriction (the derivation-ok-restriction check covers only the derived-vs-base relationship), so a plain complexType with `<xs:attribute ref="t:a" default="2"/>` against a `fixed` t:a is rejected. **XSD 1.1 only**, `checkElementDeclConstraints()` (`link_refs.go`) does the same for ELEMENT declarations: an EXPLICIT `default`/`fixed` is validated against the element's EFFECTIVE declared type (`effectiveDeclType`, so a no-type substitution-group member is checked against its inherited head type; element-only/mixed complex content is skipped) through the SHARED `validateSimpleContentValue` — the same path the instance value uses, covering the effective content simple type (`effectiveContentSimpleType`) PLUS inherited simpleContent base-content facets (`validateNestedSimpleContentBases`) — on the version-/schema-aware `validateValue`, so an invalid list/union/builtin default, or one violating an inherited base-content facet, is a fatal schema error (W3C idIDREF s3_3_4si07/si08). Sources are recorded (`elemDeclConstraintSources`) only under Version11 and merged from import sub-compilers (a `ref=""` element inheriting the global's value is covered by the global's own entry), so XSD 1.0 stays byte-identical. Presence-based schema checks (`check_elements.go`) use `hasAttr`, and both `hasAttr`/`getAttr` require an **unqualified** attribute (`URI()==""`) so a foreign-namespaced `other:fixed` is not mistaken for the XSD `fixed`. When validation inserts an absent qualified attribute's default/fixed value, it is inserted **namespace-aware** (`SetAttributeNS`, reusing the in-scope prefix) so a later `xs:key` field like `@t:a` matches it. The insertion loop skips `Required` **and** `Prohibited` uses: a prohibited use must never materialize a default/fixed value (the absent attribute is accepted, and a present one is rejected), so it would otherwise mutate a valid document by inserting a forbidden attribute. The compile-time `default`-requires-`use="optional"` check (`checkAttributeUse`, `check_elements.go`) is applied to **ref** attribute declarations as well as named ones, so `<xs:attribute ref="t:a" use="prohibited" default="x"/>` is rejected at compile time, matching xmllint. `checkAttributeUse` also enforces the **`use` attribute's representation** (version-INDEPENDENT — both XSD 1.0 and 1.1): `use` is not permitted on a **global** (top-level) attribute declaration (`isGlobalAttributeDecl` — the schema-for-schemas `topLevelAttribute` type omits it), and on a local attribute use its value must be one of `{optional, prohibited, required}` (any other value, including the empty string, is a schema error). The **`form` attribute's representation** is enforced the same way (version-INDEPENDENT): `form` is not permitted on a **global** attribute declaration (`topLevelAttribute` also omits it), and on a local declaration its value must be one of the `formChoice` enumeration `{qualified, unqualified}` (any other value, including the empty string, is a schema error). The SAME **`@name` NCName** rule applies to `<xs:element>` declarations (version-INDEPENDENT — both XSD 1.0 and 1.1): `checkGlobalElement`/`checkLocalElement` (`check_elements.go`) reject a global or local named element whose `@name` is present but not a valid `xs:NCName` (`xmlchar.IsValidNCName`) per §3.3.2; a global element's empty/missing name is still reported as `name` required, and the NCName error does not double-fire. It also enforces the **`@name` NCName** (version-INDEPENDENT): a non-`ref` `<xs:attribute>` whose `@name` is present but not a valid `xs:NCName` (`xmlchar.IsValidNCName` — empty, a non-name start such as a leading digit, or a colon-bearing QName like `a:b`) is a schema-representation error (XSD Structures §3.2.2; the dedicated `xmlns` reserved-name check takes precedence, `xmlns` itself being a valid NCName). **Unbound QName prefix (src-resolve):** the shared QName-resolution helper `resolveQName` (`link_refs.go`), used for every QName-valued schema attribute (`@type`, `@ref`, `@base`, `@itemType`, `@substitutionGroup`, union `@memberTypes`), reports a fatal schema error via `reportUnboundQNamePrefix` when a **prefixed** ref's prefix is not bound in scope (`lookupNS` returns ""), instead of silently mapping it to the empty namespace. An **absent** prefix still maps to the in-scope default namespace (else the target namespace), and the predeclared `xml` prefix is never flagged (`lookupNS` returns the XML namespace for it).
-   After refs resolve, `checkEnumQNameAndNotation()` (`xsd/check_facets.go`) runs two QName/NOTATION compile-time checks: (a) every `enumeration` literal of a QName/NOTATION-restricted type is resolved against its captured `FacetSet.EnumerationNS` bindings — an unbound prefix makes the literal an invalid QName and is reported as a schema error, so it cannot compile into an unsatisfiable enumeration. This is **variety-aware** (`enumLiteralHasUnboundQName`): an atomic literal is checked directly, a **list** literal item-by-item against the item type, and a **union** literal against whichever member type accepts it under its bindings (a literal that only a QName/NOTATION member could carry, with an unbound prefix, is flagged). (b) A simpleType whose base is directly `xs:NOTATION` with no `enumeration` facet is rejected. `checkNotationOnDeclarations()` extends (b) to **declarations**: an element or attribute whose effective type is the built-in `xs:NOTATION` (or NOTATION-derived) without an effective enumeration facet (`hasEffectiveEnumeration` walks the base chain) is rejected — this catches `type="xs:NOTATION"` placed directly on `<xs:element>`/`<xs:attribute>`, which bypasses the simpleType-level rule. Every attribute use records its source line in `attrUseSources` (merged from import sub-compilers) so the attribute case can report with the right location. (c) **XSD 1.1 only**: an `xs:NOTATION` atomic restriction's `enumeration` values must each name a notation declared in the schema. `parseSchemaChildren` collects every top-level `<xs:notation name="...">` into `compiler.notations` (keyed `QName{name, targetNamespace}`, merged from import sub-compilers); `checkEnumQNameAndNotation` resolves each enumeration value of a NOTATION-carrier type via `resolveLexicalQName`+`EnumerationNS` and reports a schema error when the resolved QName is not in `notations`. Gated on Version11 so XSD 1.0 stays byte-identical (the historical "declaration-table matching deferred" behavior). Full list/union-nested NOTATION declaration-table matching beyond the direct atomic case remains deferred. `checkAnyAtomicTypeUsage()` (`xsd/check_facets.go`, Version11) additionally rejects a user-defined simple type that names `xs:anyAtomicType` as its restriction base, list item type, or union member type (W3C bug 11103); it is the abstract base of all atomic types and must not appear in a user derivation (`xs:anyAtomicType` IS valid as an element/attribute/xsi:type type). `checkAnySimpleTypeUsage()` (`xsd/check_facets.go`, Version11) does the analogous check for the simple ur-type `xs:anySimpleType` (note in XML Schema Part 2 §2.4.1 / W3C bug 14559): it must not be RESTRICTED — as a simpleType restriction base, list item type, or union member type, nor as a simpleContent complexType RESTRICTION whose effective content simple type (`effectiveContentSimpleType`) is left as `xs:anySimpleType` (an empty or non-narrowing restriction of a base whose content type is the ur-type derives a content simple type that restricts the ur-type). It stays valid as an element/attribute/xsi:type type and as the base of a simpleContent EXTENSION (e.g. a substitution-group head). `checkFacetConsistency()` additionally runs `checkFacetValueAgainstBase()` (`xsd/check_facets.go`): each value-bearing range facet (`min`/`maxInclusive`, `min`/`maxExclusive`) is validated as an instance of the restricted base type's value space via `validateValue` with a silenced `validationContext`; a bound that is not a valid instance (e.g. `<xs:minInclusive value="abc"/>` on an `xs:int` base, or a numerically out-of-range bound) is a fatal schema error. Falling through `compareForRangeFacet`'s "can't compare" path would turn the constraint into a no-op at validation time. The length-family and digit facet {value}s are lexically validated at PARSE time (`parseFacets`/`validateNumericFacetValue`, `xsd/read_types.go`): `length`/`minLength`/`maxLength`/`fractionDigits` must be a valid `xs:nonNegativeInteger` and `totalDigits` a valid `xs:positiveInteger` (whitespace-collapsed first, via `validateBuiltinValue`), so `<xs:maxLength value="1e2"/>`, a negative/non-numeric/empty value, or `totalDigits="0"` is a fatal schema error instead of being silently collapsed to `0` by `parseOccurs` (which would drop the constraint). This is an XSD 1.0 rule enforced in BOTH the default (1.0) and Version11 mode (goldens are byte-identical — no libxml2-compat golden uses an out-of-space length/digit facet value). `checkFacetConsistency()` likewise runs `checkEnumValueAgainstBase()` (`xsd/check_facets.go`): each `enumeration` value is validated against the base type's value space via `validateValue` with a silenced `validationContext` and its captured `FacetSet.EnumerationNS[i]` bindings; an invalid member (e.g. `<xs:enumeration value="+NaN"/>` on an `xs:float`/`xs:double` base — signed NaN is not in their lexical space) is a fatal schema error at compile time, so it never becomes an unsatisfiable enumeration that fails only at instance validation. This is **variety-aware** — atomic literals against the base value space, **list** literals item-by-item against the item type, **union** literals against whichever member type accepts them — matching `validateValue`. Suppression is **per literal, narrow**: only a literal that `enumLiteralHasUnboundQName` flags (a QName/NOTATION carrier, at any nesting depth, with an unbound prefix, which `checkEnumQNameAndNotation` already diagnoses) is skipped, to avoid a duplicate diagnostic. It is **not** a blanket skip of QName/NOTATION-carrying types: every other enumeration literal of such a type is still checked against the base value space, so e.g. a QName base restricted with `xs:length value="2"` still rejects an out-of-space `<xs:enumeration value="abc"/>`.
-   **Attribute-group reference expansion** (`link_refs.go`): a named attribute group's effective {attribute uses} is the union over the group's own `<xs:attribute>` children (`schema.attrGroups[qn]`) and, transitively, every `<xs:attributeGroup ref>` child (`attrGroupRefChildren[qn]`). `parseNamedAttributeGroup` records nested refs and `expandAttrGroupUses` (cycle-guarded) flattens them into each referencing type so a required/defaulted attribute declared in a nested group is not dropped. Three grammar rules apply: (a) **`use="prohibited"` declared directly inside an `<xs:attributeGroup>` is pointless** — libxml2 warns (`Skipping attribute use prohibition, since it is pointless inside an <attributeGroup>.`) and SKIPS it, so it is never propagated as a blocking use and a referencing `xs:anyAttribute` wildcard still admits the attribute (`parseNamedAttributeGroup` / the redefine-override loop in `compile_imports.go` both warn-and-skip). (b) A **circular** reference is a schema error (src-attribute_group.3) outside `<xs:redefine>`. A DIRECT self-reference (`<xs:attributeGroup ref>` resolving to the group being defined) is caught at parse time (`reportCircularAttrGroupRef`) and dropped; an INDIRECT cycle (e.g. `h -> i -> h`, or the 3-node `a -> b -> c -> a`) is caught in `resolveRefs` by `checkCircularAttrGroupRefs`, a deterministic DFS over `attrGroupRefChildren` run BEFORE flattening that reports each back-edge (`reportCircularAttrGroupRefQName`: `Circular reference to the attribute group 'x' defined.`) and CUTS it so the flatten/expand walks terminate without a diagnostic-less truncation and without a duplicate-attribute false positive. The indirect-cycle diagnostic is attributed to the BACK-EDGE `<xs:attributeGroup ref>` element's own line/file (recorded PER edge in `attrGroupRefSources[qn]`, index-aligned with `attrGroupRefChildren[qn]`, populated in `parseNamedAttributeGroup` and the redefine-override loop and merged across imports), NOT the owning group's declaration line — matching the direct-self-reference path and pointing at the right file when the cycle spans included/redefined schemas. The legitimate self-reference inside `<xs:redefine>` is handled by the override path, not `parseNamedAttributeGroup`. (c) The duplicate-attribute-use detection (`flattenAttrGroupRefDuplicates`, ag-props-correct.2) uses `visited` as a **recursion stack** (add on entry, `defer delete` on exit), not a global "seen ever" set — so two SIBLING refs to the same group are each expanded and a name contributed via both (e.g. `g -> h, h` with `h` carrying `x`) surfaces as a duplicate, while true reference cycles are still cut. (d) A **ref that does not resolve** to a globally-declared attribute group is a schema error (src-resolve), version-INDEPENDENT: `checkAttrGroupRefsResolve` (run in `resolveRefs` before `checkCircularAttrGroupRefs`) walks both `attrGroupRefs` (complex-type / derivation-body refs) and `attrGroupRefChildren` (nested refs), and for each ref QName absent from `schema.attrGroups` — a name in the wrong symbol space (a complexType or a global attribute), a name declared nowhere, or an empty/absent `ref=""` (now recorded via `hasAttr` at the four ref-recording sites) — reports `does not resolve to a(n) attribute group definition`. An unprefixed ref resolving to the targetNamespace falls back to the empty-namespace lookup so a NO-namespace imported group still resolves; a permitted 1.1 circular ref points at an existing group and is unaffected. All these schema diagnostics route through `c.diagSource()` / a per-record `source` so an included/imported schema is cited correctly.
-**Schema default attributes** (read/resolve phase, XSD 1.1 only): `xs:schema/@defaultAttributes` is read per schema document (including includes/redefines/imports with save/restore around nested documents) and resolved as a QName. Lexically invalid QNames, unbound prefixes, and deprecated XSD-datatypes namespace refs are reported but not recorded for the later unresolved-attribute-group pass, avoiding duplicate follow-on diagnostics. `xs:complexType/@defaultAttributesApply` defaults true in 1.1; when true and a schema default is present, the complex type records an implicit attribute-group reference to that default group, so the existing attribute-group expansion path handles required/default/fixed uses, duplicate detection, wildcards, and source diagnostics. Attribute uses contributed by the implicit default group are tracked separately (`defaultAttrUses`): extension duplicate checking suppresses only the case where the derived type re-applies the same schema default use component already inherited from its base; explicit attribute/attributeGroup redeclarations and same-name uses from different schema default groups still report duplicate attribute uses. **`xs:override` governance** (§4.2.5): an override replacement complex type is copied into the TRANSFORMED TARGET document, so the TARGET (overridden) document's `@defaultAttributes` — not the overriding document's — governs it. `overrideLoadTarget` resolves the target root's `@defaultAttributes` (via the side-effect-free `resolveSchemaDefaultAttributes`, shared with the normal read path's `readSchemaDefaultAttributes`), applies it as the active schema default for the duration of the target's parse (so surviving target complex types are governed correctly too — save/reset/restore alongside form/block/final defaults), and RETURNS that `schemaDefaultAttrsState`; the owner level (`loadOverride` / `overrideProcessNested`) reapplies it around `registerMatchedChildren` so the replacement records the implicit ref (or none) of the target document. Without this, an override target lacking its own `@defaultAttributes` would inherit the overriding schema's default group (W3C ibmMeta/defaultAttributesApply s3_4_2_4ii08). A replacement matched in a DEEPER nested include of the target is registered under the DIRECT target's state — a documented edge not exercised by the conformance suite. XSD 1.0 schemas ignore both attributes.
+4. **Process includes/imports** — load `xs:include`/`xs:import`/`xs:redefine`, merge declarations.
+   Nested-schema document loads go through `compiler.readNestedSchema(path)` (FS `Open` preferred, falling
+   back to `fs.ReadFile` for a `ReadFileFS`-only FS whose `Open` errors, both under a `maxNestedSchemaSize` 10
+   MiB byte cap via `internal/iolimit`, so an endless source cannot exhaust memory), reading from
+   `compileConfig.fsys`, an injectable `fs.FS` set via `Compiler.FS(...)`; it **defaults to `iofs.DenyAll`**
+   (opens nothing — secure by default, mirroring `helium.NewParser`) so an untrusted schema cannot disclose
+   local files or exhaust resources via a hostile `schemaLocation` — opt into host access via
+   `Compiler.FS(helium.PermissiveFS())` or a confined FS — and is propagated to sub-compilers.
+   **Circular-import termination:** a shared (pointer-passed to every sub-compiler) `importActive` set tracks
+   resolved fs paths currently ON the active import ancestry (the load stack, keyed by path → expected
+   namespace, seeded with the root's `rootKey` and targetNamespace). `loadImport` short-circuits (returns nil,
+   skipping only the RELOAD) an import whose target path is already on that stack — a mutual (A ↔ B) or self
+   import is mid-parse in an ancestor, so re-loading would recurse forever and can add no new components — but
+   FIRST validates the back-edge's requested `namespace` against the recorded expected namespace and emits the
+   src-import diagnostic on mismatch (so a cyclic back-edge with a wrong/absent namespace is caught, not
+   hidden). Entries are pushed before descending and popped on unwind, so a DIAMOND import of the same
+   document on two disjoint branches still loads independently (deduped by the "if not exists" merge guards).
+   A legal circular import (W3C particlesDa001/Db001) thus compiles cleanly, and the `maxImportDepth` ceiling
+   remains a defensive net for a genuinely deep non-cyclic chain. An over-cap read returns
+   `errSchemaTooLarge`, classified fatal by `IsFatalSchemaLoad`. `xslt3` injects a resolver-backed `fs.FS`
+   (`schemaResolverFS`) so nested includes inside a resolver-loaded schema obey the same default-deny
+   `URIResolver` policy as the top-level load. `schemaResolverFS.Open` is the xslt3→xsd BOUNDARY: it
+   TRANSLATES the xslt3 loader's classification into XSD's `fs.FS` vocabulary so `readNestedSchema`
+   demotes/keeps-fatal consistently — a CONFIRMED resolution miss (`isDemotableSchemaMiss`, e.g. a resolver
+   returning a bare `errors.New("not found")` that does NOT itself satisfy `fs.ErrNotExist`) is re-expressed
+   as a `*fs.PathError{Op:"open", Err: fs.ErrNotExist}` (via `schemaMissNotExistError`, which reports
+   `fs.ErrNotExist` through `Is` while preserving the original chain) so the OPTIONAL nested include
+   WARNS-and-skips instead of being over-rejected; everything else (a post-open read failure, a permission
+   denial, a resource-cap breach, a policy denial, or any other/ambiguous error) is wrapped
+   `fatalSchemaLoadError` so `IsFatalSchemaLoad`/`notDemotable` keeps it FATAL regardless of the inner errno
+   (the chain is preserved so `errors.Is(fs.ErrPermission)`/`ErrResourceTooLarge` still hold). Schema-location
+   resolution is **URI-aware** and lives in a **single canonical helper**, `xsd.ResolveSchemaURI(ref, base)
+   (string, error)` (`xsd/resolve_uri.go`), shared by both the xsd nested-include path and `xslt3`'s schema
+   loader so the two layers cannot drift. `validateSchemaPath` is a thin wrapper over it. It keys off whether
+   `ref`/`base` carries a URI scheme (`xsd.URIScheme`, the **one** scheme-detector for both packages —
+   multi-char scheme required so Windows drive letters and bare OS paths stay local): an **absolute-URI**
+   `schemaLocation` (e.g. a cross-host `https://cdn.example.com/part.xsd`) is passed through **unchanged** —
+   never `filepath.Join`ed, which would collapse `//` and drop the host (and when that verbatim
+   non-file-scheme URI reaches the direct filesystem loader `iofs.PermissiveRoot.Open`, it is NOT `os.Open`ed
+   — a network URI is not a local path, so `os.Open` would fail with a platform-DEPENDENT errno, ENOENT on
+   Linux, EINVAL on macOS/Windows; instead `PermissiveRoot` returns a `*fs.PathError{Op:"open", Err:
+   fs.ErrNotExist}` via `uripath.URIScheme`, so an OPTIONAL absolute-URI include/import hint the local FS
+   cannot serve is classified as a resolution MISS and demoted to a warning-and-skip CONSISTENTLY across
+   platforms; a `file:` URI IS a local resource, so `PermissiveRoot` CONVERTS it to a filesystem path first
+   (`FileURIToPath` — percent-decode, `file:///abs` → `/abs`, Windows `file:///C:/x` → `C:\x`) so a valid
+   `file:///` include LOADS and a missing one yields `os.Open`'s own ENOENT (a demotable miss), a
+   malformed/UNC/non-local file URI being returned as a NON-`fs.ErrNotExist` PathError (fatal); while a
+   genuinely-local path — no scheme, or a drive-letter path — still reaches `os.Open` and keeps its real errno
+   so a malformed local path stays fatal. This `PermissiveRoot` mapping is a convenience for that FS;
+   `readNestedSchema`'s own scheme-based non-file-URI demotion (above) is the FS-INDEPENDENT guarantee that
+   also covers `os.DirFS`); a **relative** location against a **URI base** resolves via `net/url`
+   `ResolveReference` (RFC 3986), keeping authority intact **and re-applying the base's `OmitHost` flag** when
+   the base had no authority (so `mem:/schemas/main.xsd` + `part.xsd` → `mem:/schemas/part.xsd`, never
+   `mem:///schemas/part.xsd`, while canonical `file:///...` bases keep their `///`); a genuine **local**
+   base/location keeps the historical `filepath.Join` + `..`-escape guard (the only branch that can return an
+   error). The import sub-compiler's `baseDir` is `schemaBaseDir(path)` (the full URI for URI bases,
+   `filepath.Dir` for local). Because resolution happens while base and raw `schemaLocation` are still
+   separate, the name reaching the FS is the **canonical** nested URI, so `schemaResolverFS.Open` forwards it
+   verbatim (no string repair of a collapsed name). `xslt3`'s `resolveSchemaURI` delegates the absolute-URI
+   and URI-base cases to `xsd.ResolveSchemaURI` and only handles its own local **file**-base case (xslt3's
+   base is a full file URI/path, not a directory); it seeds the xsd `BaseDir` via `schemaCompileBaseDir(uri)`
+   (full URI when scheme present, `filepath.Dir` otherwise). **targetNamespace match (src-import /
+   src-include):** `loadImport` rejects the located schema when its `targetNamespace` differs from the
+   `namespace` declared on `<xs:import>` — a present `namespace` requires that exact TNS, an absent
+   `namespace` requires the imported schema to have no TNS (so a schema imported as one namespace cannot
+   silently contribute another's declarations). `loadInclude`/`loadRedefine` enforce the analogous include
+   rule (included TNS must equal the including schema's, modulo chameleon includes with no TNS). Both raise a
+   fatal `Schemas parser error` and stop merging that document. **Nested-load classification — PHASE-AWARE,
+   FAIL-CLOSED, three-way (src-include.1 / src-import):** the fatal-vs-warning decision for an
+   `xs:include`/`xs:import`/`xs:redefine` target is not fetch-vs-content but a THREE-way taxonomy keyed on
+   WHERE the failure occurs, and it is FAIL-CLOSED (fatal by default). The demotable decision is a SINGLE
+   POSITIVE TAG applied at ONE place: `readNestedSchema(path)` itself classifies each fetch outcome
+   PHASE-AWARELY and wraps ONLY a benign RESOLUTION miss in `errSchemaFetchMiss`;
+   `nestedLoadFailureFatal(err)` is `!nestedFetchMiss(err)` and `nestedFetchMiss(err)` is `errors.Is(err,
+   errSchemaFetchMiss) && !IsFatalSchemaLoad(err)` — so the ONLY demotable outcome is a tagged benign miss.
+   `processImport` and the `xs:override` subsystem route through the SAME classifier so the
+   include/redefine/import/override cells cannot diverge. The `xs:override` subsystem (`override.go`) applies
+   the IDENTICAL taxonomy: `overrideLoadTarget` fetches its target through the shared `readNestedSchema` (so a
+   missing target is tagged `errSchemaFetchMiss`, its parse/non-schema-root errors `errSchemaContentInvalid`),
+   the top-level `loadOverride` call in `processIncludes` demotes a fetch-miss via `nestedLoadFailureFatal`,
+   and the target's OWN nested `xs:include`/`xs:override`/`xs:redefine` children route through the shared
+   `demoteNestedOverrideLoad` (same `nestedLoadFailureFatal` + `reportSchemaLoadWarning`), so a missing
+   override target — or a missing include/redefine target nested inside an overridden document —
+   WARNS-and-skips while content/policy stays fatal. A MISSING (absent) `@schemaLocation` on
+   `xs:include`/`xs:redefine`/`xs:override` is a distinct fatal representation error
+   (`reportMissingSchemaLocation`, src-include.1 / src-redefine.1 / §4.2.4), enforced in BOTH
+   `processIncludes` and `overrideProcessNested`. (1) **Fetch/resolution miss → WARNING:** a demotable miss
+   must POSITIVELY signal the resource is ABSENT. `readNestedSchema` demotes ONLY: a FAILED `Open` whose errno
+   is `fs.ErrNotExist` (`isBenignResolutionMiss` — `fs.ErrNotExist` ONLY, since only it positively signals
+   not-found; a bare `fs.ErrInvalid` / permission / other errno on a genuinely-LOCAL path is NOT a confirmed
+   absence and stays FATAL); a non-file-scheme ABSOLUTE URI `schemaLocation` (http://, urn:, …), which is not
+   a local resource, so a filesystem FS reports an FS-DEPENDENT benign errno — `fs.ErrNotExist` (os.Open /
+   `iofs.PermissiveRoot`'s URI mapping) or `fs.ErrInvalid` (`os.DirFS`, which rejects a non-`fs.ValidPath`
+   name), and readNestedSchema demotes it FS-INDEPENDENTLY by scheme (`uriScheme(path)` non-file) unless
+   `notDemotable`; or, for a `ReadFileFS`-only FS whose `Open` is unsupported (`isOpenMissOrUnsupported`:
+   `fs.ErrNotExist`/`fs.ErrInvalid`), an atomic `fs.ReadFile` fallback reporting a CANONICAL "file not found"
+   (`isDirectNotExist`: the bare `fs.ErrNotExist` sentinel or a `*fs.PathError{Op:"open"}` whose cause
+   satisfies `fs.ErrNotExist`). It wraps the miss in `errSchemaFetchMiss` and demotes to the non-fatal I/O
+   warning pair (`reportSchemaLoadWarning`, "Failed to locate a schema ... Skipping the
+   include./import./redefine."), so a valid schema carrying unresolvable location hints still compiles
+   (libxml2 parity; W3C anyURI_a001/schB8/schD8/schE5/schE6/schE10). (2) **Content failure → FATAL:** the
+   target was fetched but is not well-formed XML (a `parse` error) or its root is not `<xs:schema>` — tagged
+   `errSchemaContentInvalid` by all three loaders; and — the key phase-awareness — a POST-OPEN read failure
+   (the location RESOLVED and OPENED, then the stream `Read` failed) is wrapped in
+   `errNestedSchemaReadAfterOpen` (fatal, recognized by `IsFatalSchemaLoad`), and ANY error AFTER the fetch
+   phase (declaration parsing, redefine overrides, a nested include/import inside the fetched document, e.g. a
+   top-level `xs:complexType` missing its `@name`) is UNTAGGED and therefore fatal by the fail-closed default,
+   so a fetched-but-invalid schema is never silently downgraded to a warning. (3) **Policy/security denial →
+   FATAL:** BOTH demotion predicates (`isBenignResolutionMiss`, `isDirectNotExist`) consult ONE shared veto
+   `notDemotable(err)` FIRST — `containsMultiError(err) || errors.Is(err, fs.ErrPermission) ||
+   IsFatalSchemaLoad(err)` — so a MULTI-ERROR (`errors.Join` / any `Unwrap() []error`, which defeats
+   `errors.Is` first-match selection so a benign sibling could mask a fatal one), a PERMISSION denial
+   (`fs.ErrPermission`, e.g. an outside-root policy error), or an `IsFatalSchemaLoad` condition
+   (`errImportDepthExceeded`/`errIncludeDepthExceeded`/`errSchemaPathEscape`/`errSchemaTooLarge`/`errNestedSchemaReadAfterOpen`,
+   plus any chain satisfying the exported `xsd.FatalSchemaLoader` interface) is NEVER tagged and stays fatal
+   even when it ALSO wraps a benign errno. `readNestedSchema` also returns UNTAGGED — fatal — an error from
+   the default `iofs.DenyAll` FS (which returns `fs.ErrNotExist` for EVERY Open, indistinguishable by errno
+   from a genuine miss, so the FS TYPE — not the errno — decides; an untrusted schema's on-disk include is
+   thus not silently swallowed — `TestDefaultFSDeniesUntrustedInclude`). The imported-schema nested path
+   propagates `impC.processIncludes`'s error UNCONDITIONALLY — that sub-call has already demoted its own
+   benign nested misses internally and returns non-nil only for a fatal condition, so a content-invalid nested
+   include inside an imported schema stays fatal. `xslt3` marks TWO of its loader errors so
+   `IsFatalSchemaLoad` recognizes them across the boundary: an over-cap read (`ErrResourceTooLarge`) and the
+   default-deny POLICY denial (`errSchemaResolverDenied` — "no URIResolver configured", filesystem access is
+   opt-in), both wrapped in a `FatalSchemaLoader` marker by `schemaResolverFS.Open` that `Unwrap`s to the
+   original so `errors.Is` still holds and the "no URIResolver configured" message survives; the marker
+   distinguishes a POLICY denial from a resolver fetch MISS (a configured resolver simply lacking the target,
+   which stays demotable). The `xslt3` TOP-LEVEL `xsl:import-schema` schema-location path (`compile_schema.go`
+   `compileImportSchema`) applies the SAME three-way fetch-miss / content / denial taxonomy to its
+   precompiled-schema fallback (`findImportSchema` by namespace, from `Compiler.ImportSchemas`):
+   `compileSchemaFromURI` is PHASE-AWARE — the fetch phase (`loadSchemaBytes`) returns its errors UNTAGGED (a
+   genuine fetch miss the fallback may use), while EVERY post-fetch return (a malformed-XML `parseExternalXML`
+   error, or an invalid-XSD `Compile` / `ErrCompilationFailed` / XTSE0220) is tagged
+   `errSchemaContentInvalid`. Classification is POSITIVE-TAG, mirroring the xsd nested classifier: the xslt3
+   loaders tag a CONFIRMED benign resolution miss with `errSchemaResolutionMiss` (the sole demotable outcome)
+   at exactly the resolution-phase points — `loadSchemaBytes`/`fetchViaResolver` when the resolver's
+   `Resolve`/`ResolveURI` error POSITIVELY signals not-found (`errors.Is(err, fs.ErrNotExist)` — an OPAQUE
+   resolver error like a bare "HTTP 403" is NOT tagged and is therefore FATAL; a URIResolver must return an
+   `fs.ErrNotExist`-satisfying error to signal a demotable absent optional schema), and `fetchHTTPBytes` on an
+   HTTP 404/410 — and `isDemotableSchemaMiss(err)` is `errors.Is(err, errSchemaResolutionMiss) &&
+   !isFatalSchemaLoadError(err)`. Together `isDemotableSchemaMiss` and `isFatalSchemaLoadError` PARTITION the
+   space: the precompiled fallback fires ONLY when `isDemotableSchemaMiss`, so EVERYTHING else fails closed
+   with an `xsl:import-schema: cannot compile` error — a POST-OPEN read failure (reader obtained then Read
+   fails, untagged), an HTTP 401/403/5xx/other-non-2xx (untagged), a FATAL load (`isFatalSchemaLoadError` —
+   denial/cap/path-escape/depth, a PERMISSION denial `fs.ErrPermission`, or a MULTI-ERROR), a CONTENT error
+   (`errSchemaContentInvalid`), or any untagged/ambiguous error — never masked by a matching precompiled
+   `ImportSchemas` entry. A schema that WAS fetched but whose `targetNamespace` does not match the declared
+   `namespace` is a fatal XTSE0220 with NO precompiled fallback (the fetched schema is authoritative — falling
+   back would silently mask an authoritative-but-wrong location). The runtime source-document schema loader
+   (`source_schema.go` `loadSchemasFromSchemaLocation`, from a source document's
+   `xsi:schemaLocation`/`xsi:noNamespaceSchemaLocation`) has NO precompiled fallback but applies the SAME
+   fetch/content/denial taxonomy at its CALLER (`execute_transform.go`) under lax/default validation as under
+   strict — it does NOT demote content or policy errors just because validation is lax. It PHASE-TAGS each
+   error so the caller can classify it: a malformed schema-location reference (`resolveSchemaURI`), malformed
+   XML (`Parse`), or invalid XSD (`Compile`) is tagged `errSchemaContentInvalid`; a default-deny POLICY denial
+   (no URIResolver/HTTPClient configured for the hint, detected via `execContext.schemaFetchAvailable`) is
+   tagged `errSchemaResolverDenied`; a resource-cap breach (`ErrResourceTooLarge`) survives in the chain. The
+   caller returns fatal when validation is strict OR the error is NOT a positively-tagged demotable miss
+   (`!isDemotableSchemaMiss`); ONLY a CONFIRMED benign resolution miss (`errSchemaResolutionMiss` — a resolver
+   lacking the target / HTTP 404) is best-effort skipped under lax/default (schemaLocation is only a hint, the
+   source is left unvalidated), while a post-open read failure, an HTTP 401/403/5xx, a content error, or a
+   policy/cap/permission denial stays fatal even under lax. So a broken or policy-denied source-schema hint is
+   fatal even under lax, never silently masked. The multi-entry loop over the resolved
+   `xsi:schemaLocation`/`xsi:noNamespaceSchemaLocation` paths AGGREGATES across the whole list: a POLICY
+   denial (`errSchemaResolverDenied`), a POLICY/CAP fatal (`isFatalSchemaLoadError`), or a CONTENT error
+   (`errSchemaContentInvalid` from parse/compile) returns EAGERLY (fatal), preserving the schemas loaded so
+   far; a genuine untagged FETCH MISS is recorded (only the FIRST) and the loop CONTINUES, returning
+   `(schemas, firstMiss)` at the end. So a demotable miss on an earlier entry does NOT hide a later entry's
+   content/policy error (which stays fatal under lax) or prevent a later VALID entry from loading best-effort
+   — mirroring the accumulate-then-break shape of the xsd `processIncludes`/`overrideProcessNested` loops. The
+   taxonomy is pinned by `nested_load_taxonomy_test.go` (fetch miss warns; malformed/non-schema/missing-@name
+   content is fatal for include/import/redefine AND for a nested include inside an imported schema; deny-all
+   denial is fatal — and the same three cells for an `xs:override` target and for an `xs:redefine` nested
+   inside an overridden document). **Transitive includes:** after parsing an included/redefined schema's
+   declarations, `loadInclude`/`loadRedefine` recurse via `processNestedIncludes` (switching
+   `baseDir`/`filename` to the included schema) so that schema's OWN `xs:include`/`xs:import`/`xs:redefine`
+   resolve — a chain `main → inc1 → inc2(defines T)` where `main` uses `T` compiles. Recursion is bounded by
+   `includeVisited` (a per-compiler loaded-set keyed on resolved fs path, so each document loads at most once
+   and circular includes terminate) plus a `maxIncludeDepth` cap (`errIncludeDepthExceeded`). `includeVisited`
+   only records documents pulled in via `loadInclude`/`loadRedefine`, so `CompileFile` seeds it with the
+   TOP-LEVEL schema's own resolved key (`compileConfig.rootKey`, computed via
+   `ResolveSchemaURI(filepath.Base(path), baseDir)` in the same canonical form a nested include would use): a
+   cycle that points back at the root (`main → inc → main`) then treats the root as already-loaded instead of
+   re-parsing it and emitting spurious duplicate-component errors. **Repeated `xs:redefine` of the same
+   document:** XSD permits multiple `xs:redefine` targeting one document (redefining disjoint components, or a
+   no-op repeat), so a redefine whose target is already in `includeVisited` is NOT rejected for the path
+   repeating. When a document is first loaded (via `loadInclude` or `loadRedefine`), the set of redefinable
+   component names it contributes (the `(afterKeys − beforeKeys)` delta, split by kind via
+   `computeRedefinableKeys`) is cached per resolved path in `loadedRedefinable`; a later `xs:redefine` of that
+   already-loaded document skips Phase A and processes its override children (`processRedefineOverrides`)
+   against the cached Phase-A set. A shared `consumed` set per document tracks which components have already
+   been redefined across every `xs:redefine` of it, so a component redefined twice (`g` in two redefines) is
+   reported as a duplicate (`… does already exist.`) while disjoint redefinitions and an empty/no-op repeat
+   compile clean. **`xs:override` (XSD 1.1, `override.go`, gated to `Version11`):** processed in
+   `processIncludes` alongside include/import/redefine. Unlike redefine (restriction/extension of the SAME
+   component), override is WHOLESALE REPLACEMENT of any top-level component
+   (element/attribute/simpleType/complexType/group/attributeGroup/notation) in the referenced document matched
+   by an override child of the same (expanded-name, symbol space — simpleType and complexType share ONE type
+   symbol space). `loadOverride` collects the override children, then `overrideLoadTarget` loads the target
+   (like include: TNS/chameleon/form-default handling, and the SAME three-way fetch-miss/content/denial
+   nested-load taxonomy via `readNestedSchema` + `nestedLoadFailureFatal`), parses its SURVIVING components
+   via `overrideParseTargetChildren` (a matched component is SUPPRESSED and recorded), and recurses into the
+   target's own include/override via `overrideProcessNested` — the transform is TRANSITIVE, a nested
+   `xs:include` is treated as an `xs:override` carrying the cascaded set and a nested `xs:override` merges its
+   children (OUTER override wins on collision). The active override set is BRANCH-LOCAL: a nested
+   `xs:override` derives a FRESH map (inherited ∪ its own children, outer-precedence, `activeFromEntries`) so
+   its children cannot leak into a later SIBLING include/override target's suppression set;
+   `overrideLoadTarget` RETURNS the matched subset and each `xs:override` REGISTERS its own matched children
+   IMMEDIATELY (`registerMatchedChildren`/`registerOverrideChild`), while the DECLARING document's context
+   (form/block/final defaults, xpathDefaultNamespace, base URI, includeFile) is still active — never deferred
+   to an outer context. An override child that matched nothing is DROPPED, so a reference to it is a
+   dangling-ref error (conformance-verified against over026 — registering unmatched children makes over026 the
+   only failing case; NOT the literal §4.2.5 "add all children" reading). Termination uses a SEPARATE
+   `overrideVisited` set (distinct from plain-include `includeVisited`) keyed by `path +
+   overrideActiveFingerprint(active)` (sorted symbol/name/replacement-element identity) plus the document's
+   `rootKey`: a re-reach under the SAME active set or a back-edge to the root terminates without re-loading
+   (permissible circular override), but the SAME document reached with a DIFFERENT active set is a DISTINCT
+   transformed document and is loaded again — keying by path alone would over-terminate and silently drop a
+   sibling override's replacements, while loading distinct lets a genuine collision surface via the
+   duplicate-component check. A disallowed cycle surfaces as a dangling reference. A document pulled in by
+   BOTH a plain `xs:include`/`xs:redefine` AND an `xs:override` is a FATAL conflict
+   (`reportOverrideIncludeConflict`, enforced in `overrideLoadTarget` and symmetrically in
+   `loadInclude`/`loadRedefine`) — not a silent no-op, since the override yields a distinct constituent whose
+   components collide with the included originals. Per-document override-target sets in
+   `processIncludes`/`overrideProcessNested` reject overriding the same document twice; duplicate override
+   children of one `xs:override` are rejected. `xs:import` inside a target is handled by the SHARED
+   `processImport` helper (NOT transformed) so it emits the same already-imported / load-failure warnings as a
+   top-level import; override children may reference components imported only by the overriding schema.
+   Override+redefine interplay is unexercised by the suite and processes redefine without cascade — a
+   documented gap.5. **Resolve references** — resolve all QName refs (types, base types, groups, attr groups,
+   union members), detect circular substitution. **Circular model-group references** are detected and CUT by
+   `checkCircularGroupRefs` (`link_refs.go`) BEFORE the group-ref resolution loop shares group content slices:
+   a named `xs:group` that references itself (directly or transitively) would otherwise make the resolved
+   content-model tree cyclic and stack-overflow the downstream Glushkov (UPA)/element-consistency/open-content
+   walks. A DFS over the named-group reference graph (built from each group's UNRESOLVED definition) reports
+   each back-edge as a `Circular reference to the model group definition '...' defined.` schema error and
+   leaves the back-edge placeholder an empty model group so resolution stays acyclic. This is forbidden in
+   BOTH XSD 1.0 and 1.1 (a model group must not contain itself), so it is reported in both versions (unlike
+   circular ATTRIBUTE groups, which 1.1 permits). `check_upa.go`'s `positionAutomaton` also carries a
+   defensive recursion-stack guard (`walking`, a `map[*ModelGroup]struct{}`) that terminates the Glushkov walk
+   on any self-referential model group that ever slips through — never fired by a valid schema, since an
+   acyclic model never has a group as its own ancestor. The substitution-group membership map itself is built
+   by `buildSubstGroups` just BEFORE this step (global element `@substitutionGroup` affiliations are fixed at
+   read/include time; XSD 1.1 list-valued attributes register the member under every listed head), so the UPA
+   (`checkUPA`) check run WITHIN `resolveRefs` can expand a content model's substitution-group head leaves to
+   their transitive members. `buildSubstGroups` only populates and sorts the direct-affiliation map and emits
+   no diagnostics, so the circular/final/element-consistency checks keep their original error ordering. For an
+   untyped member, `inheritedTypeFromFirstSubstitutionHead` follows only the FIRST QName in the actual
+   `@substitutionGroup` value at each step to find the inherited declared type; the full list remains for
+   membership and affiliation checks. After refs resolve, `checkSubstGroupAffiliations()` rejects any member
+   whose effective declared type is not validly derived from each affiliated head's effective declared type.
+   After attribute type refs resolve, `checkAttrUseConstraints()` validates each attribute use's
+   `default`/`fixed` constraint value against the attribute's declared simple type, so a retained-but-invalid
+   constraint (e.g. `default=""` on an `xs:integer` attribute) is reported as a schema parser error, so it can
+   never be injected into the instance at validation time. **au-props-correct.3** is enforced during attr-ref
+   resolution (`checkAttrRefFixedConflict`): when an `<xs:attribute ref>` use carries its OWN value constraint
+   AND the referenced global declaration has a `fixed`, the use's constraint must ALSO be `fixed` and
+   value-equal (compared under the global's type via `fixedConstraintRestricts`) — a local `default`, or a
+   `fixed` with a different value, is a schema error. This is enforced for EVERY referencing use, not only
+   inside a restriction (the derivation-ok-restriction check covers only the derived-vs-base relationship), so
+   a plain complexType with `<xs:attribute ref="t:a" default="2"/>` against a `fixed` t:a is rejected. **XSD
+   1.1 only**, `checkElementDeclConstraints()` (`link_refs.go`) does the same for ELEMENT declarations: an
+   EXPLICIT `default`/`fixed` is validated against the element's EFFECTIVE declared type (`effectiveDeclType`,
+   so a no-type substitution-group member is checked against its inherited head type; element-only/mixed
+   complex content is skipped) through the SHARED `validateSimpleContentValue` — the same path the instance
+   value uses, covering the effective content simple type (`effectiveContentSimpleType`) PLUS inherited
+   simpleContent base-content facets (`validateNestedSimpleContentBases`) — on the version-/schema-aware
+   `validateValue`, so an invalid list/union/builtin default, or one violating an inherited base-content
+   facet, is a fatal schema error (W3C idIDREF s3_3_4si07/si08). Sources are recorded
+   (`elemDeclConstraintSources`) only under Version11 and merged from import sub-compilers (a `ref=""` element
+   inheriting the global's value is covered by the global's own entry), so XSD 1.0 stays byte-identical.
+   Presence-based schema checks (`check_elements.go`) use `hasAttr`, and both `hasAttr`/`getAttr` require an
+   **unqualified** attribute (`URI()==""`) so a foreign-namespaced `other:fixed` is not mistaken for the XSD
+   `fixed`. When validation inserts an absent qualified attribute's default/fixed value, it is inserted
+   **namespace-aware** (`SetAttributeNS`, reusing the in-scope prefix) so a later `xs:key` field like `@t:a`
+   matches it. The insertion loop skips `Required` **and** `Prohibited` uses: a prohibited use must never
+   materialize a default/fixed value (the absent attribute is accepted, and a present one is rejected), so it
+   would otherwise mutate a valid document by inserting a forbidden attribute. The compile-time
+   `default`-requires-`use="optional"` check (`checkAttributeUse`, `check_elements.go`) is applied to **ref**
+   attribute declarations as well as named ones, so `<xs:attribute ref="t:a" use="prohibited" default="x"/>`
+   is rejected at compile time, matching xmllint. `checkAttributeUse` also enforces the **`use` attribute's
+   representation** (version-INDEPENDENT — both XSD 1.0 and 1.1): `use` is not permitted on a **global**
+   (top-level) attribute declaration (`isGlobalAttributeDecl` — the schema-for-schemas `topLevelAttribute`
+   type omits it), and on a local attribute use its value must be one of `{optional, prohibited, required}`
+   (any other value, including the empty string, is a schema error). The **`form` attribute's representation**
+   is enforced the same way (version-INDEPENDENT): `form` is not permitted on a **global** attribute
+   declaration (`topLevelAttribute` also omits it), and on a local declaration its value must be one of the
+   `formChoice` enumeration `{qualified, unqualified}` (any other value, including the empty string, is a
+   schema error). The SAME **`@name` NCName** rule applies to `<xs:element>` declarations (version-INDEPENDENT
+   — both XSD 1.0 and 1.1): `checkGlobalElement`/`checkLocalElement` (`check_elements.go`) reject a global or
+   local named element whose `@name` is present but not a valid `xs:NCName` (`xmlchar.IsValidNCName`) per
+   §3.3.2; a global element's empty/missing name is still reported as `name` required, and the NCName error
+   does not double-fire. It also enforces the **`@name` NCName** (version-INDEPENDENT): a non-`ref`
+   `<xs:attribute>` whose `@name` is present but not a valid `xs:NCName` (`xmlchar.IsValidNCName` — empty, a
+   non-name start such as a leading digit, or a colon-bearing QName like `a:b`) is a schema-representation
+   error (XSD Structures §3.2.2; the dedicated `xmlns` reserved-name check takes precedence, `xmlns` itself
+   being a valid NCName). **Unbound QName prefix (src-resolve):** the shared QName-resolution helper
+   `resolveQName` (`link_refs.go`), used for every QName-valued schema attribute (`@type`, `@ref`, `@base`,
+   `@itemType`, `@substitutionGroup`, union `@memberTypes`), reports a fatal schema error via
+   `reportUnboundQNamePrefix` when a **prefixed** ref's prefix is not bound in scope (`lookupNS` returns ""),
+   instead of silently mapping it to the empty namespace. An **absent** prefix still maps to the in-scope
+   default namespace (else the target namespace), and the predeclared `xml` prefix is never flagged
+   (`lookupNS` returns the XML namespace for it).
+   After refs resolve, `checkEnumQNameAndNotation()` (`xsd/check_facets.go`) runs two QName/NOTATION
+   compile-time checks: (a) every `enumeration` literal of a QName/NOTATION-restricted type is resolved
+   against its captured `FacetSet.EnumerationNS` bindings — an unbound prefix makes the literal an invalid
+   QName and is reported as a schema error, so it cannot compile into an unsatisfiable enumeration. This is
+   **variety-aware** (`enumLiteralHasUnboundQName`): an atomic literal is checked directly, a **list** literal
+   item-by-item against the item type, and a **union** literal against whichever member type accepts it under
+   its bindings (a literal that only a QName/NOTATION member could carry, with an unbound prefix, is flagged).
+   (b) A simpleType whose base is directly `xs:NOTATION` with no `enumeration` facet is rejected.
+   `checkNotationOnDeclarations()` extends (b) to **declarations**: an element or attribute whose effective
+   type is the built-in `xs:NOTATION` (or NOTATION-derived) without an effective enumeration facet
+   (`hasEffectiveEnumeration` walks the base chain) is rejected — this catches `type="xs:NOTATION"` placed
+   directly on `<xs:element>`/`<xs:attribute>`, which bypasses the simpleType-level rule. Every attribute use
+   records its source line in `attrUseSources` (merged from import sub-compilers) so the attribute case can
+   report with the right location. (c) **XSD 1.1 only**: an `xs:NOTATION` atomic restriction's `enumeration`
+   values must each name a notation declared in the schema. `parseSchemaChildren` collects every top-level
+   `<xs:notation name="...">` into `compiler.notations` (keyed `QName{name, targetNamespace}`, merged from
+   import sub-compilers); `checkEnumQNameAndNotation` resolves each enumeration value of a NOTATION-carrier
+   type via `resolveLexicalQName`+`EnumerationNS` and reports a schema error when the resolved QName is not in
+   `notations`. Gated on Version11 so XSD 1.0 stays byte-identical (the historical "declaration-table matching
+   deferred" behavior). Full list/union-nested NOTATION declaration-table matching beyond the direct atomic
+   case remains deferred. `checkAnyAtomicTypeUsage()` (`xsd/check_facets.go`, Version11) additionally rejects
+   a user-defined simple type that names `xs:anyAtomicType` as its restriction base, list item type, or union
+   member type (W3C bug 11103); it is the abstract base of all atomic types and must not appear in a user
+   derivation (`xs:anyAtomicType` IS valid as an element/attribute/xsi:type type). `checkAnySimpleTypeUsage()`
+   (`xsd/check_facets.go`, Version11) does the analogous check for the simple ur-type `xs:anySimpleType` (note
+   in XML Schema Part 2 §2.4.1 / W3C bug 14559): it must not be RESTRICTED — as a simpleType restriction base,
+   list item type, or union member type, nor as a simpleContent complexType RESTRICTION whose effective
+   content simple type (`effectiveContentSimpleType`) is left as `xs:anySimpleType` (an empty or non-narrowing
+   restriction of a base whose content type is the ur-type derives a content simple type that restricts the
+   ur-type). It stays valid as an element/attribute/xsi:type type and as the base of a simpleContent EXTENSION
+   (e.g. a substitution-group head). `checkFacetConsistency()` additionally runs
+   `checkFacetValueAgainstBase()` (`xsd/check_facets.go`): each value-bearing range facet
+   (`min`/`maxInclusive`, `min`/`maxExclusive`) is validated as an instance of the restricted base type's
+   value space via `validateValue` with a silenced `validationContext`; a bound that is not a valid instance
+   (e.g. `<xs:minInclusive value="abc"/>` on an `xs:int` base, or a numerically out-of-range bound) is a fatal
+   schema error. Falling through `compareForRangeFacet`'s "can't compare" path would turn the constraint into
+   a no-op at validation time. The length-family and digit facet {value}s are lexically validated at PARSE
+   time (`parseFacets`/`validateNumericFacetValue`, `xsd/read_types.go`):
+   `length`/`minLength`/`maxLength`/`fractionDigits` must be a valid `xs:nonNegativeInteger` and `totalDigits`
+   a valid `xs:positiveInteger` (whitespace-collapsed first, via `validateBuiltinValue`), so `<xs:maxLength
+   value="1e2"/>`, a negative/non-numeric/empty value, or `totalDigits="0"` is a fatal schema error instead of
+   being silently collapsed to `0` by `parseOccurs` (which would drop the constraint). This is an XSD 1.0 rule
+   enforced in BOTH the default (1.0) and Version11 mode (goldens are byte-identical — no libxml2-compat
+   golden uses an out-of-space length/digit facet value). `checkFacetConsistency()` likewise runs
+   `checkEnumValueAgainstBase()` (`xsd/check_facets.go`): each `enumeration` value is validated against the
+   base type's value space via `validateValue` with a silenced `validationContext` and its captured
+   `FacetSet.EnumerationNS[i]` bindings; an invalid member (e.g. `<xs:enumeration value="+NaN"/>` on an
+   `xs:float`/`xs:double` base — signed NaN is not in their lexical space) is a fatal schema error at compile
+   time, so it never becomes an unsatisfiable enumeration that fails only at instance validation. This is
+   **variety-aware** — atomic literals against the base value space, **list** literals item-by-item against
+   the item type, **union** literals against whichever member type accepts them — matching `validateValue`.
+   Suppression is **per literal, narrow**: only a literal that `enumLiteralHasUnboundQName` flags (a
+   QName/NOTATION carrier, at any nesting depth, with an unbound prefix, which `checkEnumQNameAndNotation`
+   already diagnoses) is skipped, to avoid a duplicate diagnostic. It is **not** a blanket skip of
+   QName/NOTATION-carrying types: every other enumeration literal of such a type is still checked against the
+   base value space, so e.g. a QName base restricted with `xs:length value="2"` still rejects an out-of-space
+   `<xs:enumeration value="abc"/>`.
+   **Attribute-group reference expansion** (`link_refs.go`): a named attribute group's effective {attribute
+   uses} is the union over the group's own `<xs:attribute>` children (`schema.attrGroups[qn]`) and,
+   transitively, every `<xs:attributeGroup ref>` child (`attrGroupRefChildren[qn]`).
+   `parseNamedAttributeGroup` records nested refs and `expandAttrGroupUses` (cycle-guarded) flattens them into
+   each referencing type so a required/defaulted attribute declared in a nested group is not dropped. Three
+   grammar rules apply: (a) **`use="prohibited"` declared directly inside an `<xs:attributeGroup>` is
+   pointless** — libxml2 warns (`Skipping attribute use prohibition, since it is pointless inside an
+   <attributeGroup>.`) and SKIPS it, so it is never propagated as a blocking use and a referencing
+   `xs:anyAttribute` wildcard still admits the attribute (`parseNamedAttributeGroup` / the redefine-override
+   loop in `compile_imports.go` both warn-and-skip). (b) A **circular** reference is a schema error
+   (src-attribute_group.3) outside `<xs:redefine>`. A DIRECT self-reference (`<xs:attributeGroup ref>`
+   resolving to the group being defined) is caught at parse time (`reportCircularAttrGroupRef`) and dropped;
+   an INDIRECT cycle (e.g. `h -> i -> h`, or the 3-node `a -> b -> c -> a`) is caught in `resolveRefs` by
+   `checkCircularAttrGroupRefs`, a deterministic DFS over `attrGroupRefChildren` run BEFORE flattening that
+   reports each back-edge (`reportCircularAttrGroupRefQName`: `Circular reference to the attribute group 'x'
+   defined.`) and CUTS it so the flatten/expand walks terminate without a diagnostic-less truncation and
+   without a duplicate-attribute false positive. The indirect-cycle diagnostic is attributed to the BACK-EDGE
+   `<xs:attributeGroup ref>` element's own line/file (recorded PER edge in `attrGroupRefSources[qn]`,
+   index-aligned with `attrGroupRefChildren[qn]`, populated in `parseNamedAttributeGroup` and the
+   redefine-override loop and merged across imports), NOT the owning group's declaration line — matching the
+   direct-self-reference path and pointing at the right file when the cycle spans included/redefined schemas.
+   The legitimate self-reference inside `<xs:redefine>` is handled by the override path, not
+   `parseNamedAttributeGroup`. (c) The duplicate-attribute-use detection (`flattenAttrGroupRefDuplicates`,
+   ag-props-correct.2) uses `visited` as a **recursion stack** (add on entry, `defer delete` on exit), not a
+   global "seen ever" set — so two SIBLING refs to the same group are each expanded and a name contributed via
+   both (e.g. `g -> h, h` with `h` carrying `x`) surfaces as a duplicate, while true reference cycles are
+   still cut. (d) A **ref that does not resolve** to a globally-declared attribute group is a schema error
+   (src-resolve), version-INDEPENDENT: `checkAttrGroupRefsResolve` (run in `resolveRefs` before
+   `checkCircularAttrGroupRefs`) walks both `attrGroupRefs` (complex-type / derivation-body refs) and
+   `attrGroupRefChildren` (nested refs), and for each ref QName absent from `schema.attrGroups` — a name in
+   the wrong symbol space (a complexType or a global attribute), a name declared nowhere, or an empty/absent
+   `ref=""` (now recorded via `hasAttr` at the four ref-recording sites) — reports `does not resolve to a(n)
+   attribute group definition`. An unprefixed ref resolving to the targetNamespace falls back to the
+   empty-namespace lookup so a NO-namespace imported group still resolves; a permitted 1.1 circular ref points
+   at an existing group and is unaffected. All these schema diagnostics route through `c.diagSource()` / a
+   per-record `source` so an included/imported schema is cited correctly.
+**Schema default attributes** (read/resolve phase, XSD 1.1 only): `xs:schema/@defaultAttributes` is read per
+schema document (including includes/redefines/imports with save/restore around nested documents) and resolved
+as a QName. Lexically invalid QNames, unbound prefixes, and deprecated XSD-datatypes namespace refs are
+reported but not recorded for the later unresolved-attribute-group pass, avoiding duplicate follow-on
+diagnostics. `xs:complexType/@defaultAttributesApply` defaults true in 1.1; when true and a schema default is
+present, the complex type records an implicit attribute-group reference to that default group, so the existing
+attribute-group expansion path handles required/default/fixed uses, duplicate detection, wildcards, and source
+diagnostics. Attribute uses contributed by the implicit default group are tracked separately
+(`defaultAttrUses`): extension duplicate checking suppresses only the case where the derived type re-applies
+the same schema default use component already inherited from its base; explicit attribute/attributeGroup
+redeclarations and same-name uses from different schema default groups still report duplicate attribute uses.
+**`xs:override` governance** (§4.2.5): an override replacement complex type is copied into the TRANSFORMED
+TARGET document, so the TARGET (overridden) document's `@defaultAttributes` — not the overriding document's —
+governs it. `overrideLoadTarget` resolves the target root's `@defaultAttributes` (via the side-effect-free
+`resolveSchemaDefaultAttributes`, shared with the normal read path's `readSchemaDefaultAttributes`), applies
+it as the active schema default for the duration of the target's parse (so surviving target complex types are
+governed correctly too — save/reset/restore alongside form/block/final defaults), and RETURNS that
+`schemaDefaultAttrsState`; the owner level (`loadOverride` / `overrideProcessNested`) reapplies it around
+`registerMatchedChildren` so the replacement records the implicit ref (or none) of the target document.
+Without this, an override target lacking its own `@defaultAttributes` would inherit the overriding schema's
+default group (W3C ibmMeta/defaultAttributesApply s3_4_2_4ii08). A replacement matched in a DEEPER nested
+include of the target is registered under the DIRECT target's state — a documented edge not exercised by the
+conformance suite. XSD 1.0 schemas ignore both attributes.
 
-**Particle occurrence validation** (read phase, `read_particles.go`/`read_elements.go`/`check_elements.go`): every particle `minOccurs`/`maxOccurs` is validated as `xs:nonNegativeInteger` (max also allows `unbounded`) with `min<=max` and the prohibited-particle (`min=0 max=0`) carve-out. Lexical-error wording matches xmllint for `minOccurs` and `maxOccurs`. `validateOccursAttrs` covers compositor/wildcard/group-ref particles; `checkLocalElement` covers `xs:element`. The `min<=max` check compares against the EFFECTIVE occurrences — both default to 1 when absent — so in `validateOccursAttrs` a `minOccurs="2"` with an ABSENT `maxOccurs` (effective 1) is rejected the same as `maxOccurs="1"` (version-independent, W3C particlesEb015/Oa004/Oa008). (`checkLocalElement` still compares only when BOTH attributes are present, so an `xs:element` with `minOccurs>1` and a defaulted `maxOccurs` is a known residual false-accept.)
+**Particle occurrence validation** (read phase, `read_particles.go`/`read_elements.go`/`check_elements.go`):
+every particle `minOccurs`/`maxOccurs` is validated as `xs:nonNegativeInteger` (max also allows `unbounded`)
+with `min<=max` and the prohibited-particle (`min=0 max=0`) carve-out. Lexical-error wording matches xmllint
+for `minOccurs` and `maxOccurs`. `validateOccursAttrs` covers compositor/wildcard/group-ref particles;
+`checkLocalElement` covers `xs:element`. The `min<=max` check compares against the EFFECTIVE occurrences —
+both default to 1 when absent — so in `validateOccursAttrs` a `minOccurs="2"` with an ABSENT `maxOccurs`
+(effective 1) is rejected the same as `maxOccurs="1"` (version-independent, W3C particlesEb015/Oa004/Oa008).
+(`checkLocalElement` still compares only when BOTH attributes are present, so an `xs:element` with
+`minOccurs>1` and a defaulted `maxOccurs` is a known residual false-accept.)
 
-**xs:all occurrence rules are versioned.** XSD 1.0 enforces cos-all-limited: the all compositor `minOccurs` is 0 or 1, its `maxOccurs` is 1, and each direct element particle has `minOccurs`/`maxOccurs` in {0,1}. XSD 1.1 keeps the compositor rule but relaxes member particles: `checkAllElementParticleOccurs` skips the direct-element 0/1 rule, `xs:all` may contain wildcard members, and `matchAll11` validates flattened all members with per-member occurrence counting. Inline nested `<xs:all>` remains rejected. An `xs:group ref` resolving to an all group may be nested directly in an XSD 1.1 all only with 1/1 occurrence, then it is flattened; XSD 1.0 rejects that nested all ref. Extension placement still rejects appending an all group to a non-empty non-all base content model. Prohibited particles (`maxOccurs=0`) are not content for these placement checks. Occurrence diagnostics use declaring-file source attribution via `c.diagSource()`/recorded `groupRefSource`.
+**xs:all occurrence rules are versioned.** XSD 1.0 enforces cos-all-limited: the all compositor `minOccurs` is
+0 or 1, its `maxOccurs` is 1, and each direct element particle has `minOccurs`/`maxOccurs` in {0,1}. XSD 1.1
+keeps the compositor rule but relaxes member particles: `checkAllElementParticleOccurs` skips the
+direct-element 0/1 rule, `xs:all` may contain wildcard members, and `matchAll11` validates flattened all
+members with per-member occurrence counting. Inline nested `<xs:all>` remains rejected. An `xs:group ref`
+resolving to an all group may be nested directly in an XSD 1.1 all only with 1/1 occurrence, then it is
+flattened; XSD 1.0 rejects that nested all ref. Extension placement still rejects appending an all group to a
+non-empty non-all base content model. Prohibited particles (`maxOccurs=0`) are not content for these placement
+checks. Occurrence diagnostics use declaring-file source attribution via `c.diagSource()`/recorded
+`groupRefSource`.
 
-**Named model group definition content model** (`read_particles.go` `parseNamedGroup`, version-INDEPENDENT — enforced in both XSD 1.0 and 1.1 per §3.7.2): a `<xs:group name="...">` must have content `(annotation?, (all | choice | sequence))` — exactly one model group child, at most one annotation which must PRECEDE the model group, and no other element children. A missing model group, a second model group, a second/misplaced annotation, or any stray child (e.g. a direct `<xs:element>`/`<xs:complexType>`/`<xs:attribute>`/`<xs:group ref>`) is a schema error. The single model group is still recorded so references resolve; the redundant missing-model-group diagnostic is suppressed when a stray/misplaced child already produced a grammar error on the group.
+**Named model group definition content model** (`read_particles.go` `parseNamedGroup`, version-INDEPENDENT —
+enforced in both XSD 1.0 and 1.1 per §3.7.2): a `<xs:group name="...">` must have content `(annotation?, (all
+| choice | sequence))` — exactly one model group child, at most one annotation which must PRECEDE the model
+group, and no other element children. A missing model group, a second model group, a second/misplaced
+annotation, or any stray child (e.g. a direct `<xs:element>`/`<xs:complexType>`/`<xs:attribute>`/`<xs:group
+ref>`) is a schema error. The single model group is still recorded so references resolve; the redundant
+missing-model-group diagnostic is suppressed when a stray/misplaced child already produced a grammar error on
+the group.
 
-**XSD 1.1 local element targetNamespace:** `parseLocalElement` uses explicit local `@targetNamespace` when `Version11`; otherwise it derives namespace from `@form`/`elementFormDefault`. Presence matters: `targetNamespace=""` means absent namespace. `checkLocalElement` rejects `@targetNamespace` on `@ref`, requires `@name` when `@targetNamespace` is present, rejects `@targetNamespace` with `@form`, and requires local `@targetNamespace` values that differ from the effective ancestor schema target namespace, or appear when the effective ancestor schema has no target namespace, to be inside a non-`xs:anyType` complex-content restriction before the nearest `xs:complexType`; chameleon includes/redefines inherit the including schema's target namespace for this check.
+**XSD 1.1 local element targetNamespace:** `parseLocalElement` uses explicit local `@targetNamespace` when
+`Version11`; otherwise it derives namespace from `@form`/`elementFormDefault`. Presence matters:
+`targetNamespace=""` means absent namespace. `checkLocalElement` rejects `@targetNamespace` on `@ref`,
+requires `@name` when `@targetNamespace` is present, rejects `@targetNamespace` with `@form`, and requires
+local `@targetNamespace` values that differ from the effective ancestor schema target namespace, or appear
+when the effective ancestor schema has no target namespace, to be inside a non-`xs:anyType` complex-content
+restriction before the nearest `xs:complexType`; chameleon includes/redefines inherit the including schema's
+target namespace for this check.
 
-**Complex-type child ordering** (read phase, `read_types.go`, XSD 3.4.2): `parseComplexType`, `parseRestriction`, `parseExtension`, and `parseSimpleContentChildren` enforce the fixed child order as an ordered state machine — an OPTIONAL leading model-group particle (`sequence`/`choice`/`all`/`group` ref), at most one, THEN attribute/attributeGroup uses, THEN an OPTIONAL final `anyAttribute`. A model-group particle that appears AFTER any attribute/attributeGroup/anyAttribute is out of order and rejected (`The content model particle '…' must appear before the attribute declaration '…'.`), so it cannot overwrite the content model. A second model group (`more than one content model particle`) and mixing a particle with a `simpleContent`/`complexContent` wrapper are also rejected. The `anyAttribute` wildcard must be the optional FINAL child: an `attribute`/`attributeGroup` use appearing after it is rejected (`The attribute declaration '…' must appear before the attribute wildcard 'anyAttribute'.`), and a second wildcard is rejected (`A complex type definition must not have more than one attribute wildcard …`) via an `anyAttributeSeen` flag tracked in each of the four parse paths, so `td.AnyAttribute` is never silently overwritten. **simpleContent extension prohibited attrs:** `parseSimpleContentChildren` takes the derivation kind; on an EXTENSION a `use="prohibited"` attribute is pointless and is warned+skipped (`Skipping attribute use prohibition, since it is pointless when extending a type.`) exactly like `parseExtension` (complexContent), so it does not propagate as a blocking use and a base attribute wildcard still admits the attribute; on a RESTRICTION the prohibition is kept. **Unresolved type/element ref source attribution:** `reportUnresolvedTypeRef` reports via `c.diagSourceOrRecorded(typeDefSource.source)` and the owner type's actual element kind (`typeDefSource.elemKind`, recorded at parse time — `complexType` vs `simpleType`), not a hard-coded `c.filename`/`"simpleType"`; `elemRefSource` likewise carries the declaring `source` so an unresolved element/ref in an included/imported schema cites the declaring file.
+**Complex-type child ordering** (read phase, `read_types.go`, XSD 3.4.2): `parseComplexType`,
+`parseRestriction`, `parseExtension`, and `parseSimpleContentChildren` enforce the fixed child order as an
+ordered state machine — an OPTIONAL leading model-group particle (`sequence`/`choice`/`all`/`group` ref), at
+most one, THEN attribute/attributeGroup uses, THEN an OPTIONAL final `anyAttribute`. A model-group particle
+that appears AFTER any attribute/attributeGroup/anyAttribute is out of order and rejected (`The content model
+particle '…' must appear before the attribute declaration '…'.`), so it cannot overwrite the content model. A
+second model group (`more than one content model particle`) and mixing a particle with a
+`simpleContent`/`complexContent` wrapper are also rejected. The `anyAttribute` wildcard must be the optional
+FINAL child: an `attribute`/`attributeGroup` use appearing after it is rejected (`The attribute declaration
+'…' must appear before the attribute wildcard 'anyAttribute'.`), and a second wildcard is rejected (`A complex
+type definition must not have more than one attribute wildcard …`) via an `anyAttributeSeen` flag tracked in
+each of the four parse paths, so `td.AnyAttribute` is never silently overwritten. **simpleContent extension
+prohibited attrs:** `parseSimpleContentChildren` takes the derivation kind; on an EXTENSION a
+`use="prohibited"` attribute is pointless and is warned+skipped (`Skipping attribute use prohibition, since it
+is pointless when extending a type.`) exactly like `parseExtension` (complexContent), so it does not propagate
+as a blocking use and a base attribute wildcard still admits the attribute; on a RESTRICTION the prohibition
+is kept. **Unresolved type/element ref source attribution:** `reportUnresolvedTypeRef` reports via
+`c.diagSourceOrRecorded(typeDefSource.source)` and the owner type's actual element kind
+(`typeDefSource.elemKind`, recorded at parse time — `complexType` vs `simpleType`), not a hard-coded
+`c.filename`/`"simpleType"`; `elemRefSource` likewise carries the declaring `source` so an unresolved
+element/ref in an included/imported schema cites the declaring file.
 
-**Simple-type child grammar** (read phase, `read_types.go`, XSD §3.14.2/§3.15.2/§3.16.2, version-INDEPENDENT — runs in BOTH XSD 1.0 and 1.1): `parseSimpleType` enforces the `xs:simpleType` content model `(annotation?, (restriction | list | union))` — at most one annotation and it must be first, exactly one of restriction/list/union, and no other XSD-namespace child (a missing derivation, a second derivation, a mis-ordered/duplicate annotation, or a stray XSD element is a schema error, report-and-continue so a valid derivation still parses). `checkSimpleTypeDerivationBody` enforces each derivation body: **restriction** `(annotation?, (simpleType?, facet*))` — annotation first/at-most-one, at most one simpleType which must precede the facets, `base` attribute XOR nested simpleType, a `base` or a simpleType child required, and a stray XSD element that is not a recognized facet (`isSimpleTypeFacetElement`) / simpleType / annotation is rejected (so a non-existent facet like `<xs:whitespace>`/`<xs:duration>`/`<xs:period>` or an `<xs:attribute>`/`<xs:attributeGroup>`/`<xs:anyAttribute>` inside a simpleType restriction is an error); **list** `(annotation?, simpleType?)` — `itemType` attribute XOR nested simpleType, a non-empty `itemType` or a simpleType child required (an empty `itemType=""` is rejected), no other element children; **union** `(annotation?, simpleType*)` — a `memberTypes` attribute and/or at least one simpleType child required, annotation first/at-most-one, no other element children. Type-resolution failures (base/itemType/memberType naming a complexType, a list itemType naming a list, restriction of `xs:anyType`) and the `@name` NCName / local-simpleType-name rules are separate checks, not this grammar.
+**Simple-type child grammar** (read phase, `read_types.go`, XSD §3.14.2/§3.15.2/§3.16.2, version-INDEPENDENT —
+runs in BOTH XSD 1.0 and 1.1): `parseSimpleType` enforces the `xs:simpleType` content model `(annotation?,
+(restriction | list | union))` — at most one annotation and it must be first, exactly one of
+restriction/list/union, and no other XSD-namespace child (a missing derivation, a second derivation, a
+mis-ordered/duplicate annotation, or a stray XSD element is a schema error, report-and-continue so a valid
+derivation still parses). `checkSimpleTypeDerivationBody` enforces each derivation body: **restriction**
+`(annotation?, (simpleType?, facet*))` — annotation first/at-most-one, at most one simpleType which must
+precede the facets, `base` attribute XOR nested simpleType, a `base` or a simpleType child required, and a
+stray XSD element that is not a recognized facet (`isSimpleTypeFacetElement`) / simpleType / annotation is
+rejected (so a non-existent facet like `<xs:whitespace>`/`<xs:duration>`/`<xs:period>` or an
+`<xs:attribute>`/`<xs:attributeGroup>`/`<xs:anyAttribute>` inside a simpleType restriction is an error);
+**list** `(annotation?, simpleType?)` — `itemType` attribute XOR nested simpleType, a non-empty `itemType` or
+a simpleType child required (an empty `itemType=""` is rejected), no other element children; **union**
+`(annotation?, simpleType*)` — a `memberTypes` attribute and/or at least one simpleType child required,
+annotation first/at-most-one, no other element children. Type-resolution failures (base/itemType/memberType
+naming a complexType, a list itemType naming a list, restriction of `xs:anyType`) and the `@name` NCName /
+local-simpleType-name rules are separate checks, not this grammar.
 
 6. **Constraint checks** (when errorCount == 0):
-   - `checkFinalOnTypes()` — final attribute enforcement. In **Version11**, `finalDefault="extension"` also reaches a simple type's `{final}` (the simpleType final-default mask in `read_types.go` includes `FinalExtension`; spec bug 2074), so a simpleContent extension of an extension-final simple type is rejected. XSD 1.0 masks `extension` out of a simple type's `{final}`, byte-identical.
+   - `checkFinalOnTypes()` — final attribute enforcement. In **Version11**, `finalDefault="extension"` also
+     reaches a simple type's `{final}` (the simpleType final-default mask in `read_types.go` includes
+     `FinalExtension`; spec bug 2074), so a simpleContent extension of an extension-final simple type is
+     rejected. XSD 1.0 masks `extension` out of a simple type's `{final}`, byte-identical.
    - `checkFinalOnSubstGroups()` — substitution group final
-   - `checkUPA()` (`check_upa.go`) — Unique Particle Attribution / cos-nonambig (content model determinism). Builds a **position automaton** (Glushkov construction) over the content-model particle tree: each element/wildcard leaf particle becomes a numbered position, and the walk yields nullable/firstpos/lastpos/followpos. Occurrence (`minOccurs`/`maxOccurs`) is folded in by `applyOccurs` **once per particle** — a particle wrapping a model group is NOT re-counted, since the parser stores the same range on both the particle and the group (`walkParticle` defers a group term to `walkModelGroup`, which applies the group's own range). `applyOccurs` distinguishes two cases: a **non-nullable body** expands its required copies (`minOccurs`) into a strict chain of distinct positions and attaches at most ONE optional remainder copy (looping only if it can repeat) — this keeps counted models like `a{2}, a` deterministic, and the single optional copy avoids falsely flagging interchangeable repeats like `<any maxOccurs="5"/>`; a **nullable body** collapses to a single loop copy (expanding it is unsound because a skipped occurrence would make later copies compete with earlier ones, e.g. `(a?, b?){1,3}`). The Glushkov sequence concatenation keys lastpos on the CURRENT particle's nullability (`last(rs) = last(s) ∪ last(r)` only when `s` is nullable), so an optional prefix before a required element does not linger in lastpos (`(a?, b), b` stays deterministic). Substitution-group members of an element term each get their own position (any member can match where the head is expected) — so a choice/sequence that lets a member match both via a `ref="head"` leaf and an explicit `ref="member"` leaf is correctly flagged. This head→member expansion depends on `schema.substGroups` being populated by `buildSubstGroups` BEFORE `resolveRefs` (and thus before this check, which runs within `resolveRefs`). A model is ambiguous if, from any single state — the start state firstpos(root), or followpos(p) for any position p — two distinct positions reachable on the same element name (or via overlapping wildcards, by `entriesOverlap`/`wildcardsOverlap`) compete. This catches non-adjacent ambiguity such as `a?, b?, a` (skipping the optional first `a` re-introduces it as a competitor of the final `a`). `xs:all` is walked as an order-independent group by `walkAllBody` (NOT as a sequence): every member's firstpos competes from the start state, and after any member is consumed every OTHER member is still reachable (mutual-reachability followpos — each member's lastpos may be followed by every other member's firstpos). This faithfully models all's order-independence and is what catches a duplicate same-name member (two members with the same element name overlap in the union of firstpos). The wildcard-vs-wildcard overlap test (`wildcardsOverlap`) is namespace-constraint-aware: two wildcards overlap (and so are a UPA conflict) ONLY if their namespace sets INTERSECT. A finite-set vs finite-set pair overlaps iff they share a member; two negation constraints (`##any`/`##other`/`##not-absent`) always intersect; a negation vs a finite set reuses `wildcardMatchesNS` per member (so `##other`, which here = not(targetNS) and not(absent), is DISJOINT from `##targetNamespace` and from `##local`). A disjoint pair such as `##other?, ##targetNamespace` is therefore accepted, not falsely rejected. The diagnostic message is `The content model is not determinist.`
-   - `checkElementConsistent()` (`check_element_consistent.go`) — cos-element-consistent (Element Declarations Consistent): two element declarations with the same expanded name reachable in one effective content model (after group-ref expansion and across nested model groups) must have the same {type definition}. Runs in `compileSchema` AFTER substitution groups are built (NOT inside `resolveRefs`), gated on `errorCount==0` — it consults `schema.substGroups`, so it must run once that map exists. Coverage: (a) complex-type content models (iterated in source line/ordinal order); (b) for each element TERM, the term's substitution-group MEMBERS (`schema.substGroups[term.Name]`) are folded in as implicitly-containable declarations under each member's own name (a head's particle stands in for its members), so a `ref="head"` colliding by name with a different-typed same-named local element is rejected — untyped members' declared types resolve through the first substitution-group head via `resolveDeclaredType`; (c) standalone named `xs:group` definitions (over `schema.groups`, in stable source order via `groupSources` recorded at parse time and merged from import sub-compilers), so a named group no complex type references is still checked. Type identity is by `*TypeDef` pointer (helium shares one pointer per named type and copies the global's type onto a `ref`), with a same-expanded-QName fallback for import-merged duplicates; distinct anonymous inline types are different components and therefore inconsistent. The check is only ever under-strict (a missed violation is safe; it never false-rejects a valid schema). libxml2 does NOT implement this constraint (it is an "URGENT TODO" in `xmlschemas.c`), so the diagnostic uses the existing component-error style, with no libxml2 wording to mirror, and no golden schema trips it.
+   - `checkUPA()` (`check_upa.go`) — Unique Particle Attribution / cos-nonambig (content model determinism).
+     Builds a **position automaton** (Glushkov construction) over the content-model particle tree: each
+     element/wildcard leaf particle becomes a numbered position, and the walk yields
+     nullable/firstpos/lastpos/followpos. Occurrence (`minOccurs`/`maxOccurs`) is folded in by `applyOccurs`
+     **once per particle** — a particle wrapping a model group is NOT re-counted, since the parser stores the
+     same range on both the particle and the group (`walkParticle` defers a group term to `walkModelGroup`,
+     which applies the group's own range). `applyOccurs` distinguishes two cases: a **non-nullable body**
+     expands its required copies (`minOccurs`) into a strict chain of distinct positions and attaches at most
+     ONE optional remainder copy (looping only if it can repeat) — this keeps counted models like `a{2}, a`
+     deterministic, and the single optional copy avoids falsely flagging interchangeable repeats like `<any
+     maxOccurs="5"/>`; a **nullable body** collapses to a single loop copy (expanding it is unsound because a
+     skipped occurrence would make later copies compete with earlier ones, e.g. `(a?, b?){1,3}`). The Glushkov
+     sequence concatenation keys lastpos on the CURRENT particle's nullability (`last(rs) = last(s) ∪ last(r)`
+     only when `s` is nullable), so an optional prefix before a required element does not linger in lastpos
+     (`(a?, b), b` stays deterministic). Substitution-group members of an element term each get their own
+     position (any member can match where the head is expected) — so a choice/sequence that lets a member
+     match both via a `ref="head"` leaf and an explicit `ref="member"` leaf is correctly flagged. This
+     head→member expansion depends on `schema.substGroups` being populated by `buildSubstGroups` BEFORE
+     `resolveRefs` (and thus before this check, which runs within `resolveRefs`). A model is ambiguous if,
+     from any single state — the start state firstpos(root), or followpos(p) for any position p — two distinct
+     positions reachable on the same element name (or via overlapping wildcards, by
+     `entriesOverlap`/`wildcardsOverlap`) compete. This catches non-adjacent ambiguity such as `a?, b?, a`
+     (skipping the optional first `a` re-introduces it as a competitor of the final `a`). `xs:all` is walked
+     as an order-independent group by `walkAllBody` (NOT as a sequence): every member's firstpos competes from
+     the start state, and after any member is consumed every OTHER member is still reachable
+     (mutual-reachability followpos — each member's lastpos may be followed by every other member's firstpos).
+     This faithfully models all's order-independence and is what catches a duplicate same-name member (two
+     members with the same element name overlap in the union of firstpos). The wildcard-vs-wildcard overlap
+     test (`wildcardsOverlap`) is namespace-constraint-aware: two wildcards overlap (and so are a UPA
+     conflict) ONLY if their namespace sets INTERSECT. A finite-set vs finite-set pair overlaps iff they share
+     a member; two negation constraints (`##any`/`##other`/`##not-absent`) always intersect; a negation vs a
+     finite set reuses `wildcardMatchesNS` per member (so `##other`, which here = not(targetNS) and
+     not(absent), is DISJOINT from `##targetNamespace` and from `##local`). A disjoint pair such as `##other?,
+     ##targetNamespace` is therefore accepted, not falsely rejected. The diagnostic message is `The content
+     model is not determinist.`
+   - `checkElementConsistent()` (`check_element_consistent.go`) — cos-element-consistent (Element Declarations
+     Consistent): two element declarations with the same expanded name reachable in one effective content
+     model (after group-ref expansion and across nested model groups) must have the same {type definition}.
+     Runs in `compileSchema` AFTER substitution groups are built (NOT inside `resolveRefs`), gated on
+     `errorCount==0` — it consults `schema.substGroups`, so it must run once that map exists. Coverage: (a)
+     complex-type content models (iterated in source line/ordinal order); (b) for each element TERM, the
+     term's substitution-group MEMBERS (`schema.substGroups[term.Name]`) are folded in as
+     implicitly-containable declarations under each member's own name (a head's particle stands in for its
+     members), so a `ref="head"` colliding by name with a different-typed same-named local element is rejected
+     — untyped members' declared types resolve through the first substitution-group head via
+     `resolveDeclaredType`; (c) standalone named `xs:group` definitions (over `schema.groups`, in stable
+     source order via `groupSources` recorded at parse time and merged from import sub-compilers), so a named
+     group no complex type references is still checked. Type identity is by `*TypeDef` pointer (helium shares
+     one pointer per named type and copies the global's type onto a `ref`), with a same-expanded-QName
+     fallback for import-merged duplicates; distinct anonymous inline types are different components and
+     therefore inconsistent. The check is only ever under-strict (a missed violation is safe; it never
+     false-rejects a valid schema). libxml2 does NOT implement this constraint (it is an "URGENT TODO" in
+     `xmlschemas.c`), so the diagnostic uses the existing component-error style, with no libxml2 wording to
+     mirror, and no golden schema trips it.
    - Wildcard overlap detection
-   - **Restriction derivation checks** (`link_refs.go`, run per `DerivationRestriction` complex type in source-line order): `checkRestrictionAttrs` enforces derivation-ok-restriction for ATTRIBUTE uses (optional cannot restrict required, every derived attribute must have a matching base use/wildcard, every required base attribute must be matched, and the attribute wildcard NSSubset/processContents rules). For a redeclared same-QName attribute it additionally enforces derivation-ok-restriction.2.1.2/2.1.3: the derived attribute's type must be the same as, or derived by restriction from, the base attribute's type (`simpleTypeValidlyRestricts` — the `*TypeDef` pointer chain via `isDerivedFrom`, with a builtin-hierarchy fallback `builtinDerivesFrom`/`builtinRestrictionParent` for the builtin-to-builtin narrowing case like xs:integer→xs:int that the pointer chain cannot see because builtins carry no `BaseType` links). An ABSENT attribute type is `xs:anySimpleType` (XSD §3.2.2.1, via `attrUseEffectiveTypeDef`), so an UNTYPED derived attribute restricting a narrower base (e.g. xs:int) is the simple ur-type WIDENING the base and is REJECTED. The builtin fallback applies ONLY when the BASE is an ACTUAL XSD builtin (`base.Name.NS == NamespaceXSD`): walking the DERIVED side to its builtin ancestor is sound, but treating a user simple type that RESTRICTS a builtin (e.g. xs:int with `maxInclusive="10"`) as that builtin would WIDEN the base and wrongly accept a derived type that drops the user-added facets — so a user-restricted base must be derived from through the pointer chain. Two exceptions are handled BEFORE the builtin-base early return, because `builtinBaseLocal` is empty for a union and for a directly-declared list, so the early return would otherwise accept ANY derived type unconditionally (a false-accept). (a) A user-defined UNION base (`resolveVariety(base)==Union`): per cos-st-derived-ok (§3.14.6, the XSD 1.0 Type Derivation OK Simple rule) a type validly derived from (at least) ONE of the union's (transitively-walked) member types is a valid derivation. So a base `@a` of `IntOrString` (memberTypes="xs:int xs:string") restricted to derived `@a` xs:int is ACCEPTED, while xs:date (derived from NEITHER member) is REJECTED. This holds REGARDLESS of facets the base union carries: XSD 1.0 has NO "facets empty" condition on a union base, so a FACETED union base (e.g. `IntOrString` further restricted by an `enumeration`) — and likewise a no-facet restriction ALIAS over a faceted union — STILL admits a derived member type and is ACCEPTED. (The "facets empty" condition is XSD 1.1-only, §3.16.6.3 Type Derivation OK Simple; this package targets XSD 1.0 / libxml2 parity, so it is intentionally NOT enforced.) Intervening MEMBER unions are walked through `simpleTypeValidlyRestricts`' recursion. (b) A LIST base: a type that did NOT pass the pointer chain (`isDerivedFrom`, which a real `<xs:restriction base="theList">` satisfies via the `BaseType` pointer) is NOT a valid restriction of the list and is REJECTED. This covers (i) a user-defined list base (`resolveVariety(base)==List`) — both an unrelated list (e.g. base `IntList`=list(xs:int) redeclared as `StringList`=list(xs:string)) AND xs:anySimpleType (the simple ur-type is a SUPERTYPE; restricting a list "down to" it would WIDEN to accept non-list values, so it is NOT a valid restriction) are rejected — and (ii) the builtin LIST types (xs:IDREFS/xs:ENTITIES/xs:NMTOKENS), which are registered as bare atomic-variety names with no list marker so `resolveVariety` reports Atomic and clause (i) does not catch them: `base.Name` ∈ {IDREFS,ENTITIES,NMTOKENS} (in the XSD namespace) is rejected whenever the pointer chain failed, so an xs:IDREFS base "restricted" by an unrelated user list (xs:list itemType="xs:string") — which reaches the `db==""` shortcut and would otherwise be accepted — or by an atomic xs:string is REJECTED. Both branches run BEFORE the builtin db/bb fallback (`builtinBaseLocal` is empty for a directly-declared list, so the early db/bb return would otherwise accept ANY derived type unconditionally). `builtinRestrictionParent` covers EVERY atomic builtin primitive (string/decimal families plus boolean, float, double, the date/time/g* family, duration, hexBinary, base64Binary, anyURI, QName, NOTATION — all rooted at anySimpleType), so a cross-family pair (e.g. base xs:int restricted by derived xs:boolean) is decided and REJECTED, so no cross-family pair survives as "unknown" and accepted. `builtinDerivesFrom` (via `builtinListItem`) still DECIDES a builtin list on the DERIVED side (a list type is the same only as itself and validly derives only from xs:anySimpleType per cos-st-derived-ok.2.2.3, otherwise UNRELATED to every atomic type and to the other two list types); the base-side builtin-list case is short-circuited to REJECT in `simpleTypeValidlyRestricts` (above) to close the `db==""` user-list false-accept. (c) A CONSTRUCTED derived list or union (`resolveVariety(derived)` is List/Union) that reaches the end having FAILED both the pointer chain (`isDerivedFrom`) and the union-member shortcut can only be validly derived from `xs:anySimpleType` (the simple ur-type) or through a real base-type chain, so it is ACCEPTED only when the base IS the actual `xs:anySimpleType` and otherwise REJECTED — closing the `db==""` "unknown ⇒ valid" fallback that would wrongly accept an ATOMIC base (e.g. xs:string) redeclared as a user `xs:union` or `xs:list`. A base `fixed` value constraint forces the derived attribute to carry a value-space-equal `fixed` value (`fixedConstraintRestricts`): each lexical is compared under ITS OWN simple type (a same-type fast path via `fixedValueMatches`, else the cross-type `crossMemberValueEqual`), so base `fixed="1"` accepts derived `fixed="01"` for xs:int, base xs:decimal `fixed="1.0"` accepts a narrowing derived xs:int `fixed="1"`, but a dropped or `fixed="2"` constraint is rejected. It is CONSERVATIVE — it accepts whenever derivation cannot be decided (unresolved types, or a builtin pair the tables do not cover), so it never false-rejects a legitimate restriction; base `@a` xs:int restricted to derived `@a` xs:string is rejected. Every `checkRestrictionAttrs` diagnostic is attributed via `source := c.diagSourceOrRecorded(src.source)` (paired with the type's recorded `src.line`) so an invalid attribute restriction in an included/imported schema cites the DECLARING file, not the top-level `c.filename`; the processContents 4.3 case, which deliberately reports at the BASE type's line/component, likewise uses `c.diagSourceOrRecorded(baseSrc.source)` so its filename follows that base line. `checkRestrictionParticles` (`restriction_particle.go`) complements it with a CONSERVATIVE subset of derivation-ok-restriction for the CONTENT MODEL (§3.9.6 Particle Valid (Restriction)): the derived type's effective content model must be a valid restriction of the base's, via `particleValidRestriction` — element→element NameAndTypeOK (same expanded name, occurrence subset, type `isDerivedFrom` base type — **in Version11, when the base element's type is a UNION the derived type may instead be validly derived from one of the union's (transitive) members via `isXsiTypeDerivedFromDeclared`, union member substitutability**, no nillable-widening, and a base `fixed` value forces the derived element to carry a VALUE-SPACE-equal fixed value — compared via `fixedValueMatches` in the element's simple-type value space, NOT raw lexical string equality, so base `fixed="1"` accepts derived `fixed="01"` for xs:integer while `fixed="2"` is rejected), occurrence-range subset (`occurrenceValidRestriction`: rMin>=bMin, rMax<=bMax with -1 = unbounded), order-preserving Recurse for sequence→sequence and choice→choice (`recurseOrdered`: each base particle either restricts the next derived particle or must be emptiable; every derived particle must be consumed), all→all distinct-mapping Recurse (`recurseAll`), wildcard NSSubset (any→any) and element→wildcard NSCompat (`wildcardAllowsName`), **Recurse-As-If-Group** (derived ELEMENT R vs base MODEL GROUP, `elementRestrictsGroup`: R is mapped as a SINGLETON group through the base group's children — for sequence/all it must restrict exactly one base child with every OTHER base child emptiable, for choice it must restrict SOME alternative. The OUTER occurrence check is the singleton wrapper's `{1,1}` against the base group's occurrence — `occurrenceValidRestriction(1, 1, base.Min, base.Max)`, NOT R's own occurrence; R's full occurrence and type are enforced by the inner per-member/branch `particleValidRestriction`, which carries R unchanged, so an element whose occurrence differs from `{1,1}` — e.g. `a?{0,1}` restricting `seq(a?){1,1}`, or `c1{1,2}`/`c1{3,30}` restricting a `{1,1}` base branch — is not false-rejected, W3C particlesHa022/Hb010/L003/M003), **NSRecurseCheckCardinality** (derived MODEL GROUP vs base WILDCARD, `groupRestrictsWildcard`/`groupLeavesWithinWildcard`: the group particle's range must be within the base wildcard particle's range, and every element/wildcard LEAF inside the derived group — with its effective occurrence folded through the enclosing group ranges via `mulOccurs` — must be admitted by the base wildcard's namespace constraint and within its cardinality; a nested wildcard leaf must also be a namespace subset with at-least-as-strong processContents; a base whose model group is a §3.9.6-POINTLESS wrapper — a `{1,1}` sequence/choice with EXACTLY ONE particle, recursively — that folds down to a lone WILDCARD is reduced to that wildcard particle by `baseWildcardFromPointlessGroup` and routed here in `groupRestrictsGroup`, so a derived `sequence(e,e,any)` restricting a base `sequence(any{2,3})` is checked by NSRecurseCheckCardinality instead of the element-by-element positional recurse that would wrongly map `e{1,1}` against the wildcard `{2,3}` — W3C particlesHa080 valid / particlesHa081 invalid; only `{1,1}` single-particle wrappers fold so a hole-hiding occurrence multiply like `seq{0,1}(any{2,unbounded})`→`any{0,unbounded}` is never taken; version-INDEPENDENT), and emptiable handling (`particleEmptiable`). **Prohibited particles (`maxOccurs=0`) emit nothing:** `particleEmitsNothing` (max element-emission == 0 via `particleElementRange`) treats a prohibited leaf/group as contributing (0,0) — such a derived particle is dropped before the order-preserving mapping (`nonEmittingFiltered` in `recurseOrdered`) and skipped in `recurseAll`/`recurseChoiceUnordered`/the map-and-sum loop/`groupLeavesRestrictElement`/`groupLeavesWithinWildcard` (it needs no base counterpart and admits no content), and a prohibited BASE particle never requires a derived counterpart — so a derived restriction that omits or prohibits a maxOccurs=0 leaf is not false-rejected. It catches the CLEAR violations — reordered, added, or renamed particles, widened occurrence, an element that drops a required base group child or matches no base alternative, and a group leaf outside the base wildcard's namespace/cardinality — and emits `The content model is not a valid restriction of the content model of the base complex type definition '{ns}name'.`. Map-and-sum (derived SEQUENCE restricting a base CHOICE, in `groupRestrictsGroup`) compares the derived sequence's TOTAL element-emission range (`particleElementRange`, folding each group's own occurrence range times its children's emission and recursing through nesting) against the base choice particle's range, then requires every emitting derived member to restrict SOME base branch; group-vs-element (derived MODEL GROUP restricting a base single ELEMENT) is VERSION-SPLIT: XSD 1.0 (`pointlessReduce`) accepts only a genuinely §3.9.6-POINTLESS derived group — it folds to a single element via HOLE-FREE occurrence hoisting (the member occurs at most once, OR the group occurs at most once AND is a `{1,1}` wrapper or its member's `minOccurs`<=1 — so the folded range `[gmin*mmin, gmax*mmax]` has no unreachable count), then restricts that element against the base element; a group whose fold would leave an unreachable occurrence count is rejected: a repeating group `sequence maxOccurs="2"(e1 maxOccurs="2")` (W3C particlesHb011), OR an emptiable group over a multi-occur member — `sequence{0,1}(e1{2,2})` emits `e1` in {0,2} with a HOLE at 1, so it is NOT equivalent to a single `e1{0,2}` and does NOT fold. XSD 1.1 keeps the broader emission-range leniency (`groupRestrictsElement`/`groupLeavesRestrictElement`, backed by the `particleLanguageSubset` fallback). The mixed-compositor group:group pairs with NO §3.9.6 derivation rule — derived choice:sequence, choice:all, all:sequence, all:choice — are REJECTED in `groupRestrictsGroup`'s default branch, but only after `reduceSingletonGroup` first folds away any "pointless" single-emitting-child wrapper on either side and re-dispatches (so e.g. choice(a) restricting sequence(a) reduces to element→element and stays valid); derived sequence:all is **RecurseUnordered** (`recurseAll`, after a group-occurrence subset check): each derived sequence particle must map to a DISTINCT base all particle it validly restricts (order is irrelevant in the base all) and every unmatched base particle must be emptiable, so a derived sequence that adds/renames a particle or drops a required base all member is rejected. By design it NEVER false-rejects: any sub-case the recursion cannot decide with confidence (unresolved types, restriction off xs:anyType) returns "valid". A restriction off a base with no model group (an EMPTY attribute-only content type, or a SIMPLE `<xs:simpleContent>` content type — both carry no particle) is valid iff the base is NOT simple-content AND the derived model group emits NO content (`base.ContentType != ContentTypeSimple && !modelGroupHasContent` — an empty `<xs:sequence/>` restricts an EMPTY (or mixed-emptiable) base's empty content to empty content, a subset). It is rejected when the derived model adds emitting particles, OR when the base is a SIMPLE-content type — a simple (character) content type cannot be restricted down to empty element content (cos-ct-restricts §3.4.6.4 forbids simple→empty). This is version-INDEPENDENT (MS DataTypes int_max/minInclusive/Exclusive narrow an attribute under an empty-content complexContent restriction). No golden schema trips it. The restriction diagnostic is attributed via `c.diagSourceOrRecorded(src.source)` so an invalid restriction in an included/imported schema cites the declaring file. **Deferred sub-cases:** substitution-group containment is accepted unconditionally, with no full verification.
+   - **Restriction derivation checks** (`link_refs.go`, run per `DerivationRestriction` complex type in
+     source-line order): `checkRestrictionAttrs` enforces derivation-ok-restriction for ATTRIBUTE uses
+     (optional cannot restrict required, every derived attribute must have a matching base use/wildcard, every
+     required base attribute must be matched, and the attribute wildcard NSSubset/processContents rules). For
+     a redeclared same-QName attribute it additionally enforces derivation-ok-restriction.2.1.2/2.1.3: the
+     derived attribute's type must be the same as, or derived by restriction from, the base attribute's type
+     (`simpleTypeValidlyRestricts` — the `*TypeDef` pointer chain via `isDerivedFrom`, with a
+     builtin-hierarchy fallback `builtinDerivesFrom`/`builtinRestrictionParent` for the builtin-to-builtin
+     narrowing case like xs:integer→xs:int that the pointer chain cannot see because builtins carry no
+     `BaseType` links). An ABSENT attribute type is `xs:anySimpleType` (XSD §3.2.2.1, via
+     `attrUseEffectiveTypeDef`), so an UNTYPED derived attribute restricting a narrower base (e.g. xs:int) is
+     the simple ur-type WIDENING the base and is REJECTED. The builtin fallback applies ONLY when the BASE is
+     an ACTUAL XSD builtin (`base.Name.NS == NamespaceXSD`): walking the DERIVED side to its builtin ancestor
+     is sound, but treating a user simple type that RESTRICTS a builtin (e.g. xs:int with `maxInclusive="10"`)
+     as that builtin would WIDEN the base and wrongly accept a derived type that drops the user-added facets —
+     so a user-restricted base must be derived from through the pointer chain. Two exceptions are handled
+     BEFORE the builtin-base early return, because `builtinBaseLocal` is empty for a union and for a
+     directly-declared list, so the early return would otherwise accept ANY derived type unconditionally (a
+     false-accept). (a) A user-defined UNION base (`resolveVariety(base)==Union`): per cos-st-derived-ok
+     (§3.14.6, the XSD 1.0 Type Derivation OK Simple rule) a type validly derived from (at least) ONE of the
+     union's (transitively-walked) member types is a valid derivation. So a base `@a` of `IntOrString`
+     (memberTypes="xs:int xs:string") restricted to derived `@a` xs:int is ACCEPTED, while xs:date (derived
+     from NEITHER member) is REJECTED. This holds REGARDLESS of facets the base union carries: XSD 1.0 has NO
+     "facets empty" condition on a union base, so a FACETED union base (e.g. `IntOrString` further restricted
+     by an `enumeration`) — and likewise a no-facet restriction ALIAS over a faceted union — STILL admits a
+     derived member type and is ACCEPTED. (The "facets empty" condition is XSD 1.1-only, §3.16.6.3 Type
+     Derivation OK Simple; this package targets XSD 1.0 / libxml2 parity, so it is intentionally NOT
+     enforced.) Intervening MEMBER unions are walked through `simpleTypeValidlyRestricts`' recursion. (b) A
+     LIST base: a type that did NOT pass the pointer chain (`isDerivedFrom`, which a real `<xs:restriction
+     base="theList">` satisfies via the `BaseType` pointer) is NOT a valid restriction of the list and is
+     REJECTED. This covers (i) a user-defined list base (`resolveVariety(base)==List`) — both an unrelated
+     list (e.g. base `IntList`=list(xs:int) redeclared as `StringList`=list(xs:string)) AND xs:anySimpleType
+     (the simple ur-type is a SUPERTYPE; restricting a list "down to" it would WIDEN to accept non-list
+     values, so it is NOT a valid restriction) are rejected — and (ii) the builtin LIST types
+     (xs:IDREFS/xs:ENTITIES/xs:NMTOKENS), which are registered as bare atomic-variety names with no list
+     marker so `resolveVariety` reports Atomic and clause (i) does not catch them: `base.Name` ∈
+     {IDREFS,ENTITIES,NMTOKENS} (in the XSD namespace) is rejected whenever the pointer chain failed, so an
+     xs:IDREFS base "restricted" by an unrelated user list (xs:list itemType="xs:string") — which reaches the
+     `db==""` shortcut and would otherwise be accepted — or by an atomic xs:string is REJECTED. Both branches
+     run BEFORE the builtin db/bb fallback (`builtinBaseLocal` is empty for a directly-declared list, so the
+     early db/bb return would otherwise accept ANY derived type unconditionally). `builtinRestrictionParent`
+     covers EVERY atomic builtin primitive (string/decimal families plus boolean, float, double, the
+     date/time/g* family, duration, hexBinary, base64Binary, anyURI, QName, NOTATION — all rooted at
+     anySimpleType), so a cross-family pair (e.g. base xs:int restricted by derived xs:boolean) is decided and
+     REJECTED, so no cross-family pair survives as "unknown" and accepted. `builtinDerivesFrom` (via
+     `builtinListItem`) still DECIDES a builtin list on the DERIVED side (a list type is the same only as
+     itself and validly derives only from xs:anySimpleType per cos-st-derived-ok.2.2.3, otherwise UNRELATED to
+     every atomic type and to the other two list types); the base-side builtin-list case is short-circuited to
+     REJECT in `simpleTypeValidlyRestricts` (above) to close the `db==""` user-list false-accept. (c) A
+     CONSTRUCTED derived list or union (`resolveVariety(derived)` is List/Union) that reaches the end having
+     FAILED both the pointer chain (`isDerivedFrom`) and the union-member shortcut can only be validly derived
+     from `xs:anySimpleType` (the simple ur-type) or through a real base-type chain, so it is ACCEPTED only
+     when the base IS the actual `xs:anySimpleType` and otherwise REJECTED — closing the `db==""` "unknown ⇒
+     valid" fallback that would wrongly accept an ATOMIC base (e.g. xs:string) redeclared as a user `xs:union`
+     or `xs:list`. A base `fixed` value constraint forces the derived attribute to carry a value-space-equal
+     `fixed` value (`fixedConstraintRestricts`): each lexical is compared under ITS OWN simple type (a
+     same-type fast path via `fixedValueMatches`, else the cross-type `crossMemberValueEqual`), so base
+     `fixed="1"` accepts derived `fixed="01"` for xs:int, base xs:decimal `fixed="1.0"` accepts a narrowing
+     derived xs:int `fixed="1"`, but a dropped or `fixed="2"` constraint is rejected. It is CONSERVATIVE — it
+     accepts whenever derivation cannot be decided (unresolved types, or a builtin pair the tables do not
+     cover), so it never false-rejects a legitimate restriction; base `@a` xs:int restricted to derived `@a`
+     xs:string is rejected. Every `checkRestrictionAttrs` diagnostic is attributed via `source :=
+     c.diagSourceOrRecorded(src.source)` (paired with the type's recorded `src.line`) so an invalid attribute
+     restriction in an included/imported schema cites the DECLARING file, not the top-level `c.filename`; the
+     processContents 4.3 case, which deliberately reports at the BASE type's line/component, likewise uses
+     `c.diagSourceOrRecorded(baseSrc.source)` so its filename follows that base line.
+     `checkRestrictionParticles` (`restriction_particle.go`) complements it with a CONSERVATIVE subset of
+     derivation-ok-restriction for the CONTENT MODEL (§3.9.6 Particle Valid (Restriction)): the derived type's
+     effective content model must be a valid restriction of the base's, via `particleValidRestriction` —
+     element→element NameAndTypeOK (same expanded name, occurrence subset, type `isDerivedFrom` base type —
+     **in Version11, when the base element's type is a UNION the derived type may instead be validly derived
+     from one of the union's (transitive) members via `isXsiTypeDerivedFromDeclared`, union member
+     substitutability**, no nillable-widening, and a base `fixed` value forces the derived element to carry a
+     VALUE-SPACE-equal fixed value — compared via `fixedValueMatches` in the element's simple-type value
+     space, NOT raw lexical string equality, so base `fixed="1"` accepts derived `fixed="01"` for xs:integer
+     while `fixed="2"` is rejected), occurrence-range subset (`occurrenceValidRestriction`: rMin>=bMin,
+     rMax<=bMax with -1 = unbounded), order-preserving Recurse for sequence→sequence and choice→choice
+     (`recurseOrdered`: each base particle either restricts the next derived particle or must be emptiable;
+     every derived particle must be consumed), all→all distinct-mapping Recurse (`recurseAll`), wildcard
+     NSSubset (any→any) and element→wildcard NSCompat (`wildcardAllowsName`), **Recurse-As-If-Group** (derived
+     ELEMENT R vs base MODEL GROUP, `elementRestrictsGroup`: R is mapped as a SINGLETON group through the base
+     group's children — for sequence/all it must restrict exactly one base child with every OTHER base child
+     emptiable, for choice it must restrict SOME alternative. The OUTER occurrence check is the singleton
+     wrapper's `{1,1}` against the base group's occurrence — `occurrenceValidRestriction(1, 1, base.Min,
+     base.Max)`, NOT R's own occurrence; R's full occurrence and type are enforced by the inner
+     per-member/branch `particleValidRestriction`, which carries R unchanged, so an element whose occurrence
+     differs from `{1,1}` — e.g. `a?{0,1}` restricting `seq(a?){1,1}`, or `c1{1,2}`/`c1{3,30}` restricting a
+     `{1,1}` base branch — is not false-rejected, W3C particlesHa022/Hb010/L003/M003),
+     **NSRecurseCheckCardinality** (derived MODEL GROUP vs base WILDCARD,
+     `groupRestrictsWildcard`/`groupLeavesWithinWildcard`: the group particle's range must be within the base
+     wildcard particle's range, and every element/wildcard LEAF inside the derived group — with its effective
+     occurrence folded through the enclosing group ranges via `mulOccurs` — must be admitted by the base
+     wildcard's namespace constraint and within its cardinality; a nested wildcard leaf must also be a
+     namespace subset with at-least-as-strong processContents; a base whose model group is a §3.9.6-POINTLESS
+     wrapper — a `{1,1}` sequence/choice with EXACTLY ONE particle, recursively — that folds down to a lone
+     WILDCARD is reduced to that wildcard particle by `baseWildcardFromPointlessGroup` and routed here in
+     `groupRestrictsGroup`, so a derived `sequence(e,e,any)` restricting a base `sequence(any{2,3})` is
+     checked by NSRecurseCheckCardinality instead of the element-by-element positional recurse that would
+     wrongly map `e{1,1}` against the wildcard `{2,3}` — W3C particlesHa080 valid / particlesHa081 invalid;
+     only `{1,1}` single-particle wrappers fold so a hole-hiding occurrence multiply like
+     `seq{0,1}(any{2,unbounded})`→`any{0,unbounded}` is never taken; version-INDEPENDENT), and emptiable
+     handling (`particleEmptiable`). **Prohibited particles (`maxOccurs=0`) emit nothing:**
+     `particleEmitsNothing` (max element-emission == 0 via `particleElementRange`) treats a prohibited
+     leaf/group as contributing (0,0) — such a derived particle is dropped before the order-preserving mapping
+     (`nonEmittingFiltered` in `recurseOrdered`) and skipped in `recurseAll`/`recurseChoiceUnordered`/the
+     map-and-sum loop/`groupLeavesRestrictElement`/`groupLeavesWithinWildcard` (it needs no base counterpart
+     and admits no content), and a prohibited BASE particle never requires a derived counterpart — so a
+     derived restriction that omits or prohibits a maxOccurs=0 leaf is not false-rejected. It catches the
+     CLEAR violations — reordered, added, or renamed particles, widened occurrence, an element that drops a
+     required base group child or matches no base alternative, and a group leaf outside the base wildcard's
+     namespace/cardinality — and emits `The content model is not a valid restriction of the content model of
+     the base complex type definition '{ns}name'.`. Map-and-sum (derived SEQUENCE restricting a base CHOICE,
+     in `groupRestrictsGroup`) compares the derived sequence's TOTAL element-emission range
+     (`particleElementRange`, folding each group's own occurrence range times its children's emission and
+     recursing through nesting) against the base choice particle's range, then requires every emitting derived
+     member to restrict SOME base branch; group-vs-element (derived MODEL GROUP restricting a base single
+     ELEMENT) is VERSION-SPLIT: XSD 1.0 (`pointlessReduce`) accepts only a genuinely §3.9.6-POINTLESS derived
+     group — it folds to a single element via HOLE-FREE occurrence hoisting (the member occurs at most once,
+     OR the group occurs at most once AND is a `{1,1}` wrapper or its member's `minOccurs`<=1 — so the folded
+     range `[gmin*mmin, gmax*mmax]` has no unreachable count), then restricts that element against the base
+     element; a group whose fold would leave an unreachable occurrence count is rejected: a repeating group
+     `sequence maxOccurs="2"(e1 maxOccurs="2")` (W3C particlesHb011), OR an emptiable group over a multi-occur
+     member — `sequence{0,1}(e1{2,2})` emits `e1` in {0,2} with a HOLE at 1, so it is NOT equivalent to a
+     single `e1{0,2}` and does NOT fold. XSD 1.1 keeps the broader emission-range leniency
+     (`groupRestrictsElement`/`groupLeavesRestrictElement`, backed by the `particleLanguageSubset` fallback).
+     The mixed-compositor group:group pairs with NO §3.9.6 derivation rule — derived choice:sequence,
+     choice:all, all:sequence, all:choice — are REJECTED in `groupRestrictsGroup`'s default branch, but only
+     after `reduceSingletonGroup` first folds away any "pointless" single-emitting-child wrapper on either
+     side and re-dispatches (so e.g. choice(a) restricting sequence(a) reduces to element→element and stays
+     valid); derived sequence:all is **RecurseUnordered** (`recurseAll`, after a group-occurrence subset
+     check): each derived sequence particle must map to a DISTINCT base all particle it validly restricts
+     (order is irrelevant in the base all) and every unmatched base particle must be emptiable, so a derived
+     sequence that adds/renames a particle or drops a required base all member is rejected. By design it NEVER
+     false-rejects: any sub-case the recursion cannot decide with confidence (unresolved types, restriction
+     off xs:anyType) returns "valid". A restriction off a base with no model group (an EMPTY attribute-only
+     content type, or a SIMPLE `<xs:simpleContent>` content type — both carry no particle) is valid iff the
+     base is NOT simple-content AND the derived model group emits NO content (`base.ContentType !=
+     ContentTypeSimple && !modelGroupHasContent` — an empty `<xs:sequence/>` restricts an EMPTY (or
+     mixed-emptiable) base's empty content to empty content, a subset). It is rejected when the derived model
+     adds emitting particles, OR when the base is a SIMPLE-content type — a simple (character) content type
+     cannot be restricted down to empty element content (cos-ct-restricts §3.4.6.4 forbids simple→empty). This
+     is version-INDEPENDENT (MS DataTypes int_max/minInclusive/Exclusive narrow an attribute under an
+     empty-content complexContent restriction). No golden schema trips it. The restriction diagnostic is
+     attributed via `c.diagSourceOrRecorded(src.source)` so an invalid restriction in an included/imported
+     schema cites the declaring file. **Deferred sub-cases:** substitution-group containment is accepted
+     unconditionally, with no full verification.
 
-7. **Compile result gate:** after linking/checks, `compileSchema` returns `(nil, ErrCompilationFailed)` if `c.errorCount > 0` (fatal diagnostics already delivered to the `ErrorHandler`), otherwise `(schema, nil)`. Sub-compiler `errorCount` is merged into the parent (`compile_imports.go`), so an import/include/redefine fatal also fails the top-level `Compile`. `xslt3` schema-awareness (`compile_schema.go`) maps `ErrCompilationFailed` to `XTSE0220`.
+7. **Compile result gate:** after linking/checks, `compileSchema` returns `(nil, ErrCompilationFailed)` if
+   `c.errorCount > 0` (fatal diagnostics already delivered to the `ErrorHandler`), otherwise `(schema, nil)`.
+   Sub-compiler `errorCount` is merged into the parent (`compile_imports.go`), so an import/include/redefine
+   fatal also fails the top-level `Compile`. `xslt3` schema-awareness (`compile_schema.go`) maps
+   `ErrCompilationFailed` to `XTSE0220`.
 
 ### Validate: Document + Schema → Errors
 
@@ -276,7 +1452,40 @@ XPath flavor `xpath3` shares (`fn:matches`/`tokenize`/`replace`) legitimately
 permits reluctant quantifiers and `(?:…)`. Stray-hyphen character-class ranges
 (`[^a-d-b-c]`) are a known remaining false-accept, deferred.
 
-**Compile-time IDC checks:** a malformed `xs:selector`/`xs:field` `@xpath` is a fatal schema parser error (`parseIDConstraint` → `reportIDCXPathError`). A silently-dropped `xpath1.Compile` failure would disable the whole constraint. A structurally malformed IDC declaration is likewise fatal (`parseIDConstraint` → `reportIDCStructureError`, src-identity-constraint): a missing required `@name` (`The attribute 'name' is required but missing.`, drops the constraint), a missing `<selector>` child (`A child element is missing.`, short-circuits the field check like libxml2), or a `<selector>` present with zero `<field>` children (`The content is not valid. Expected is (annotation?, (selector, field+)).`). The `(annotation?, (selector, field+))` content model is enforced as an ordered scan (ORDER + CARDINALITY): an optional leading `<annotation>` (at most once, first), then EXACTLY ONE `<selector>`, then ONE-OR-MORE `<field>`, nothing else — a `<field>` before the `<selector>`, a second `<selector>`, a misplaced `<annotation>`, or any unexpected child — XSD-namespaced OR foreign-namespaced — all raise `The content is not valid. Expected is (annotation?, (selector, field+)).` (the content model has no element wildcard, so a foreign direct child is rejected, matching libxml2; extension content belongs inside `xs:annotation`/`xs:appinfo`). Both `<selector>` and `<field>` REQUIRE an unqualified non-empty `@xpath` (`idcXPathAttr`, `hasAttr`-checked): an absent or empty `@xpath` (which would leave the selector/field `""` and silently disable the constraint) is fatal with `Element '{…}selector'`/`'{…}field': The attribute 'xpath' is required but missing.` (distinct from the missing-child diagnostics), and an empty field is then skipped by the XPath-compile loop so no redundant "not a valid field expression" follows. `reportIDCStructureError`/`reportIDCXPathError`/`idcXPathAttr` all attribute via `c.diagSource()` (not `c.filename`), so a malformed IDC in an INCLUDED/REDEFINED schema is cited under the declaring file, matching its line. After all elements are parsed, `checkKeyRefRefers` (in `compileSchema`) resolves every `xs:keyref/@refer` against a schema-wide set of key/unique constraint names (identity-constraint names share one symbol space) and raises a fatal error for an unknown/empty refer. The registry is built by `collectAllIDCs`, which walks EVERY element declaration — not just `schema.elements` (globals) — by recursively descending each global element's/type's/named-group's content model (`idcWalker`, with visited sets on `*ElementDecl`/`*ModelGroup`/`*TypeDef` to bound shared/recursive/circular structures), so a keyref (or the key it refers to) declared on a LOCAL element buried in a content model is checked too. **@refer resolution is schema-wide (the symbol space); keyref VALUE resolution is subtree-scoped** — the two are distinct (see Pass 2 below). A deferred `@refer` error is reported against the constraint's DECLARING file: `IDConstraint.Source` is pinned at parse time in `parseIDConstraint` (`c.includeFile` if inside an include/redefine, else `c.filename` — for an import sub-compiler that is the imported file's display location), and `checkKeyRefRefers` reports with `idc.Source`+`idc.Line` in place of the top-level compiler's filename, so an IMPORTED keyref's dangling-refer error cites the imported schema (where its line number is meaningful), not the importing schema. At validation time, an IDC whose selector/field XPath fails to evaluate is reported as a validity error (`Failed to evaluate identity-constraint '…'`), not swallowed.
+**Compile-time IDC checks:** a malformed `xs:selector`/`xs:field` `@xpath` is a fatal schema parser error
+(`parseIDConstraint` → `reportIDCXPathError`). A silently-dropped `xpath1.Compile` failure would disable the
+whole constraint. A structurally malformed IDC declaration is likewise fatal (`parseIDConstraint` →
+`reportIDCStructureError`, src-identity-constraint): a missing required `@name` (`The attribute 'name' is
+required but missing.`, drops the constraint), a missing `<selector>` child (`A child element is missing.`,
+short-circuits the field check like libxml2), or a `<selector>` present with zero `<field>` children (`The
+content is not valid. Expected is (annotation?, (selector, field+)).`). The `(annotation?, (selector,
+field+))` content model is enforced as an ordered scan (ORDER + CARDINALITY): an optional leading
+`<annotation>` (at most once, first), then EXACTLY ONE `<selector>`, then ONE-OR-MORE `<field>`, nothing else
+— a `<field>` before the `<selector>`, a second `<selector>`, a misplaced `<annotation>`, or any unexpected
+child — XSD-namespaced OR foreign-namespaced — all raise `The content is not valid. Expected is (annotation?,
+(selector, field+)).` (the content model has no element wildcard, so a foreign direct child is rejected,
+matching libxml2; extension content belongs inside `xs:annotation`/`xs:appinfo`). Both `<selector>` and
+`<field>` REQUIRE an unqualified non-empty `@xpath` (`idcXPathAttr`, `hasAttr`-checked): an absent or empty
+`@xpath` (which would leave the selector/field `""` and silently disable the constraint) is fatal with
+`Element '{…}selector'`/`'{…}field': The attribute 'xpath' is required but missing.` (distinct from the
+missing-child diagnostics), and an empty field is then skipped by the XPath-compile loop so no redundant "not
+a valid field expression" follows. `reportIDCStructureError`/`reportIDCXPathError`/`idcXPathAttr` all
+attribute via `c.diagSource()` (not `c.filename`), so a malformed IDC in an INCLUDED/REDEFINED schema is cited
+under the declaring file, matching its line. After all elements are parsed, `checkKeyRefRefers` (in
+`compileSchema`) resolves every `xs:keyref/@refer` against a schema-wide set of key/unique constraint names
+(identity-constraint names share one symbol space) and raises a fatal error for an unknown/empty refer. The
+registry is built by `collectAllIDCs`, which walks EVERY element declaration — not just `schema.elements`
+(globals) — by recursively descending each global element's/type's/named-group's content model (`idcWalker`,
+with visited sets on `*ElementDecl`/`*ModelGroup`/`*TypeDef` to bound shared/recursive/circular structures),
+so a keyref (or the key it refers to) declared on a LOCAL element buried in a content model is checked too.
+**@refer resolution is schema-wide (the symbol space); keyref VALUE resolution is subtree-scoped** — the two
+are distinct (see Pass 2 below). A deferred `@refer` error is reported against the constraint's DECLARING
+file: `IDConstraint.Source` is pinned at parse time in `parseIDConstraint` (`c.includeFile` if inside an
+include/redefine, else `c.filename` — for an import sub-compiler that is the imported file's display
+location), and `checkKeyRefRefers` reports with `idc.Source`+`idc.Line` in place of the top-level compiler's
+filename, so an IMPORTED keyref's dangling-refer error cites the imported schema (where its line number is
+meaningful), not the importing schema. At validation time, an IDC whose selector/field XPath fails to evaluate
+is reported as a validity error (`Failed to evaluate identity-constraint '…'`), not swallowed.
 
 **Pass 2 — Identity Constraints** (`validateIDConstraints` via second `helium.Walk()`):
 - **Host declaration resolution** (`idcHostDecl`): the declaration whose IDCs apply
@@ -605,10 +1814,50 @@ Files: `relaxng/relaxng.go` (API), `parse.go` (compiler), `validate.go` (engine)
 1. **Find root** — `<grammar>` or bare pattern (e.g., `<element>`)
 2. **Parse grammar content** — process `<start>`, `<define>` elements; handle `combine="choice"/"interleave"`; support `<div>` containers
 3. **Parse patterns** (recursive) — element, attribute, group, choice, interleave, optional, zeroOrMore, oneOrMore, ref, parentRef, data, value, list, mixed, text, empty, notAllowed
-4. **Resolve references (scoped)** — each `<grammar>` (including nested ones) gets its own lexical `grammarScope` with a `defines` table and a `parent` link. Every `<ref>`/`<parentRef>` node is recorded with the scope it was parsed in (`compiler.pendingRefs`); after the whole tree is parsed, `resolveScopedRefs` fixes each node's `pattern.resolved` pointer: `<ref>` resolves the name in its OWN grammar scope, `<parentRef>` in that scope's PARENT scope. A name not found in the target scope, or a `<parentRef>` with no parent grammar scope, is a FATAL compile error (`reportUnresolvedRef`, bumps `errorCount`) per RELAX NG §4.18 — not a silently-unresolved node. Scoped resolution keeps same-named defines across nested grammars distinct (D-RNG-001). The flat `Grammar.defines` map is populated by `resolveRefs` but is not the resolution authority. **`<include>` override interaction:** a start/define that the `<include>` body OVERRIDES is REMOVED from the included grammar per RELAX NG include semantics, so `parseInclude` collects the override names FIRST and `parseGrammarContentSkipping` skips parsing those top-level start/defines (through transparent `<div>`) when reading the included grammar — refs that live only inside a removed component are never recorded in `pendingRefs` and so never trigger a spurious fatal unresolved-ref. The override names are also `delete`d from the scope after parsing (to clear any entry leaked by a nested `<include>`) before the overrides are applied.
+4. **Resolve references (scoped)** — each `<grammar>` (including nested ones) gets its own lexical
+   `grammarScope` with a `defines` table and a `parent` link. Every `<ref>`/`<parentRef>` node is recorded
+   with the scope it was parsed in (`compiler.pendingRefs`); after the whole tree is parsed,
+   `resolveScopedRefs` fixes each node's `pattern.resolved` pointer: `<ref>` resolves the name in its OWN
+   grammar scope, `<parentRef>` in that scope's PARENT scope. A name not found in the target scope, or a
+   `<parentRef>` with no parent grammar scope, is a FATAL compile error (`reportUnresolvedRef`, bumps
+   `errorCount`) per RELAX NG §4.18 — not a silently-unresolved node. Scoped resolution keeps same-named
+   defines across nested grammars distinct (D-RNG-001). The flat `Grammar.defines` map is populated by
+   `resolveRefs` but is not the resolution authority. **`<include>` override interaction:** a start/define
+   that the `<include>` body OVERRIDES is REMOVED from the included grammar per RELAX NG include semantics, so
+   `parseInclude` collects the override names FIRST and `parseGrammarContentSkipping` skips parsing those
+   top-level start/defines (through transparent `<div>`) when reading the included grammar — refs that live
+   only inside a removed component are never recorded in `pendingRefs` and so never trigger a spurious fatal
+   unresolved-ref. The override names are also `delete`d from the scope after parsing (to clear any entry
+   leaked by a nested `<include>`) before the overrides are applied.
 5. **Check reference cycles** — `checkRefCycles` walks each define body across every scope, following `pattern.resolved` (cycle set keyed by define-pattern POINTER, not name); element patterns break the chain
-6. **Rule checks** — compile-time semantic validation (`checkPattern` also follows `pattern.resolved`; visited set keyed by `{define pattern, ruleFlags}` so a define reached under a new ancestor context — e.g. once normally and once under `<list>` — is re-checked in each context)
-7. **Content-type checks (§7.2)** — `checkContentTypes` (runs AFTER scoped-ref resolution, so it follows `<ref>`/`<parentRef>` into their resolved define body) checks every `<element>` body reachable in the LIVE grammar. The live element bodies are gathered by `collectLiveElements` walking ONLY from the resolved start pattern, descending children/attrs/resolved refs under a pointer-keyed cycle guard — reaching every `<element>` reachable through the live start/define graph (including those inside referenced defines and nested grammars), NOT a parse-time append-only list of every parsed `<element>` and NOT every entry of the append-only `c.scopes`. Seeding from the start alone is what keeps a removed/overridden define out of the check: a nested-grammar scope created while parsing a define that an `<include>` override later deletes lingers in `c.scopes` forever but is unreachable from the live start, so its dead content (e.g. a content-type-bad define inside a nested `<grammar>` under the overridden define) is not flagged. The define that REPLACED an overridden one is reachable from start and so IS checked. Reporting cites the original element node via the `elementNodes` (`*pattern`→`*helium.Element`) map. A `<ref>`/`<parentRef>` contributes the content-type of its TARGET define body (NOT the unconditional `complex()` the §7.2 table lists for the fully-simplified form), matching libxml2: a ref to a group-of-attributes is `empty` and groups with `<value>` (libvirt.rng), while a ref to `<data>` is `simple` and is rejected when mixed with sibling element content. It derives a RELAX NG §7.2 content-type (`empty`<`complex`<`simple`) for each body via `contentTypeOf`/`contentTypeOfSeq`: `empty`/`notAllowed`/`attribute`→empty, `text`/`element`→complex, `data`/`value`/`list`→simple (it STOPS at `element`/`attribute`/`list` boundaries — each opens a fresh content context). `group`/`interleave`/repetition bodies fold children as an implicit group requiring `groupableContentTypes` at each step (`empty` groupable with anything; `complex`+`complex` ok; `simple` groupable only with `empty`), so mixing `simple` content with `complex` (e.g. `group(data, element)`, `group(data, text)`), grouping two `simple` values (`group(data, value)`), or repeating `simple` content (`oneOrMore(data)`) is a content-type error. `choice` combines branches with max and NO groupable constraint (branches never coexist), so `choice(data, element)` COMPILES. A ref cycle (degenerate non-element recursion, already reported by step 5) contributes nothing; unresolved refs contribute nothing.
+6. **Rule checks** — compile-time semantic validation (`checkPattern` also follows `pattern.resolved`; visited
+   set keyed by `{define pattern, ruleFlags}` so a define reached under a new ancestor context — e.g. once
+   normally and once under `<list>` — is re-checked in each context)
+7. **Content-type checks (§7.2)** — `checkContentTypes` (runs AFTER scoped-ref resolution, so it follows
+   `<ref>`/`<parentRef>` into their resolved define body) checks every `<element>` body reachable in the LIVE
+   grammar. The live element bodies are gathered by `collectLiveElements` walking ONLY from the resolved start
+   pattern, descending children/attrs/resolved refs under a pointer-keyed cycle guard — reaching every
+   `<element>` reachable through the live start/define graph (including those inside referenced defines and
+   nested grammars), NOT a parse-time append-only list of every parsed `<element>` and NOT every entry of the
+   append-only `c.scopes`. Seeding from the start alone is what keeps a removed/overridden define out of the
+   check: a nested-grammar scope created while parsing a define that an `<include>` override later deletes
+   lingers in `c.scopes` forever but is unreachable from the live start, so its dead content (e.g. a
+   content-type-bad define inside a nested `<grammar>` under the overridden define) is not flagged. The define
+   that REPLACED an overridden one is reachable from start and so IS checked. Reporting cites the original
+   element node via the `elementNodes` (`*pattern`→`*helium.Element`) map. A `<ref>`/`<parentRef>` contributes
+   the content-type of its TARGET define body (NOT the unconditional `complex()` the §7.2 table lists for the
+   fully-simplified form), matching libxml2: a ref to a group-of-attributes is `empty` and groups with
+   `<value>` (libvirt.rng), while a ref to `<data>` is `simple` and is rejected when mixed with sibling
+   element content. It derives a RELAX NG §7.2 content-type (`empty`<`complex`<`simple`) for each body via
+   `contentTypeOf`/`contentTypeOfSeq`: `empty`/`notAllowed`/`attribute`→empty, `text`/`element`→complex,
+   `data`/`value`/`list`→simple (it STOPS at `element`/`attribute`/`list` boundaries — each opens a fresh
+   content context). `group`/`interleave`/repetition bodies fold children as an implicit group requiring
+   `groupableContentTypes` at each step (`empty` groupable with anything; `complex`+`complex` ok; `simple`
+   groupable only with `empty`), so mixing `simple` content with `complex` (e.g. `group(data, element)`,
+   `group(data, text)`), grouping two `simple` values (`group(data, value)`), or repeating `simple` content
+   (`oneOrMore(data)`) is a content-type error. `choice` combines branches with max and NO groupable
+   constraint (branches never coexist), so `choice(data, element)` COMPILES. A ref cycle (degenerate
+   non-element recursion, already reported by step 5) contributes nothing; unresolved refs contribute nothing.
 
 ### Validate: Document + Grammar → Errors
 
@@ -806,17 +2055,38 @@ Files: `schematron/schematron.go` (API), `parse.go` (compiler), `validate.go` (e
 
 ### Query language bindings
 
-The `queryBinding` attribute on `<schema>` selects the query language. `resolveQueryBinding` (`querybinding.go`) resolves in order: a forced `Compiler.QueryBinding()` (always wins, and skips the attribute entirely) → the schema's `queryBinding` attribute → a configured `Compiler.DefaultQueryBinding(b)` → `QueryBindingXPath1`. Only the values ISO/IEC 19757-3 defines normatively AND this package implements are accepted: `xslt` and an absent attribute resolve to `QueryBindingXPath1` (Annex C), `xslt3` (2020 Annex J) and `xpath3` (2020 Annex K) to `QueryBindingXPath3`. Values are trimmed (the attribute is `xsd:token`) and matched case-insensitively (each annex says "in any mix of upper and lower case letters"). Everything else fails compilation with `ErrUnsupportedQueryBinding` and a fatal diagnostic, as clause 6.4 requires: the 2.0 bindings are defined but unimplemented, and `xpath`/`xquery`/`exslt`/`stx` are reserved without a definition, so a schema naming one is refused rather than guessed at. The resolved binding is frozen onto the compiled `Schema` (`Schema.QueryBinding()`) along with the engine the `Validator` runs.
+The `queryBinding` attribute on `<schema>` selects the query language. `resolveQueryBinding`
+(`querybinding.go`) resolves in order: a forced `Compiler.QueryBinding()` (always wins, and skips the
+attribute entirely) → the schema's `queryBinding` attribute → a configured `Compiler.DefaultQueryBinding(b)` →
+`QueryBindingXPath1`. Only the values ISO/IEC 19757-3 defines normatively AND this package implements are
+accepted: `xslt` and an absent attribute resolve to `QueryBindingXPath1` (Annex C), `xslt3` (2020 Annex J) and
+`xpath3` (2020 Annex K) to `QueryBindingXPath3`. Values are trimmed (the attribute is `xsd:token`) and matched
+case-insensitively (each annex says "in any mix of upper and lower case letters"). Everything else fails
+compilation with `ErrUnsupportedQueryBinding` and a fatal diagnostic, as clause 6.4 requires: the 2.0 bindings
+are defined but unimplemented, and `xpath`/`xquery`/`exslt`/`stx` are reserved without a definition, so a
+schema naming one is refused rather than guessed at. The resolved binding is frozen onto the compiled `Schema`
+(`Schema.QueryBinding()`) along with the engine the `Validator` runs.
 
-`engine` (`engine.go`) is the seam between the two: it compiles an expression to a `compiledExpr` and builds a namespace-bound `runner`, whose `evaluate` returns a `value`. The `value` interface holds the per-binding conversions — `nodeSet`, `effectiveBoolean`, `stringValue`, `nodeName` — so compilation and validation never name a concrete XPath package. Differences that matter:
+`engine` (`engine.go`) is the seam between the two: it compiles an expression to a `compiledExpr` and builds a
+namespace-bound `runner`, whose `evaluate` returns a `value`. The `value` interface holds the per-binding
+conversions — `nodeSet`, `effectiveBoolean`, `stringValue`, `nodeName` — so compilation and validation never
+name a concrete XPath package. Differences that matter:
 
 - `effectiveBoolean` cannot fail under XPath 1.0. Under XPath 3.1 a sequence of more than one item starting with an atomic value raises FORG0006, which is reported and treated as a false test.
 - `stringValue` (`<value-of>`) takes the string-value of the first node under XPath 1.0, and joins every atomized item with a single space under XPath 3.1 (the XSLT 2.0-and-later rule).
 - `<let>` binds an XPath 1.0 object under the 1.0 binding, and a whole sequence under 3.1.
 
-Rule contexts go through `contextToXPath` in both bindings, so a context that is an XSLT match pattern but not an expression (`key('k','v')`) is unsupported. The XPath 3.1 engine passes no URI resolver and no HTTP client, and `xpath3` denies file and network retrieval without one, so `fn:doc`/`fn:collection`/`fn:unparsed-text` cannot read anything.
+Rule contexts go through `contextToXPath` in both bindings, so a context that is an XSLT match pattern but not
+an expression (`key('k','v')`) is unsupported. The XPath 3.1 engine passes no URI resolver and no HTTP client,
+and `xpath3` denies file and network retrieval without one, so `fn:doc`/`fn:collection`/`fn:unparsed-text`
+cannot read anything.
 
-Each `runner` carries ONE document-order cache for the whole validation run, shared by every rule context, test, let and message expression: `xpath1Runner` holds an `ixpath.DocOrderCache` and passes it through `ixpath.WithDocOrderCache` on every evaluate (xpath1 otherwise builds a throwaway cache per evaluation, `xpath1/eval.go`), and `xpath3Runner` sets `xpath3.Evaluator.DocOrderCache`. Re-indexing the instance per evaluation makes validation quadratic in document size. The cache lives exactly as long as the run, so a document mutated between two `Validate` calls is re-indexed.
+Each `runner` carries ONE document-order cache for the whole validation run, shared by every rule context,
+test, let and message expression: `xpath1Runner` holds an `ixpath.DocOrderCache` and passes it through
+`ixpath.WithDocOrderCache` on every evaluate (xpath1 otherwise builds a throwaway cache per evaluation,
+`xpath1/eval.go`), and `xpath3Runner` sets `xpath3.Evaluator.DocOrderCache`. Re-indexing the instance per
+evaluation makes validation quadratic in document size. The cache lives exactly as long as the run, so a
+document mutated between two `Validate` calls is re-indexed.
 
 ### Compile: Document → Schema
 
@@ -828,12 +2098,22 @@ Three-phase parsing (after the binding is resolved):
 Message content parsed into `[]messagePart`: text literals, `<name path="..."/>` (element name), `<value-of select="..."/>` (XPath value).
 
 **Namespace gating:** structural elements are only recognized when in the detected Schematron namespace (`isSchematronElement`/`elementInNamespace`). Foreign-namespaced elements are handled differently depending on position:
-- **Required structural position → fatal/rejected.** Where a specific Schematron element is expected (e.g. a `<rule>` under `<pattern>`, checked via `isSchematronElement(elem, schNS, "rule")` in `compilePattern`), a foreign element like `<x:rule>` does NOT satisfy the requirement and is rejected with a fatal `Expecting a rule element instead of ...` diagnostic. The same applies at the top level (`Expecting a pattern element instead of ...`).
-- **Free-content children → ignored.** Foreign-namespaced children inside rules, asserts, and reports are skipped as free content. `compileRuleChild` returns early when `!elementInNamespace(...)`, so e.g. `<x:assert>` inside a `<rule>` is not executed; likewise foreign `<name>`/`<value-of>` inside message content (`parseMessageElement`) are ignored, not interpolated.
+- **Required structural position → fatal/rejected.** Where a specific Schematron element is expected (e.g. a
+  `<rule>` under `<pattern>`, checked via `isSchematronElement(elem, schNS, "rule")` in `compilePattern`), a
+  foreign element like `<x:rule>` does NOT satisfy the requirement and is rejected with a fatal `Expecting a
+  rule element instead of ...` diagnostic. The same applies at the top level (`Expecting a pattern element
+  instead of ...`).
+- **Free-content children → ignored.** Foreign-namespaced children inside rules, asserts, and reports are
+  skipped as free content. `compileRuleChild` returns early when `!elementInNamespace(...)`, so e.g.
+  `<x:assert>` inside a `<rule>` is not executed; likewise foreign `<name>`/`<value-of>` inside message
+  content (`parseMessageElement`) are ignored, not interpolated.
 
 Structural attributes (`context`, `test`, `select`, `name`, `id`, `prefix`, `uri`, `value`, `path`) are read unqualified-only via `getStructuralAttr` (`NSPredicate{..., NamespaceURI: ""}`); a prefixed `x:test` is not read as Schematron.
 
-**Fatal compile errors:** `compileSchema` wraps the configured handler in a `fatalTrackingHandler`. If any `ErrorLevelFatal` diagnostic is emitted (no pattern, pattern with no rule, rule with no test, etc.), `Compile`/`CompileFile` return `ErrCompileFailed` with a **nil** `*Schema` — even when no error handler is configured, so a broken schema can never validate as success.
+**Fatal compile errors:** `compileSchema` wraps the configured handler in a `fatalTrackingHandler`. If any
+`ErrorLevelFatal` diagnostic is emitted (no pattern, pattern with no rule, rule with no test, etc.),
+`Compile`/`CompileFile` return `ErrCompileFailed` with a **nil** `*Schema` — even when no error handler is
+configured, so a broken schema can never validate as success.
 
 ### Validate: Document + Schema → Errors
 
@@ -842,13 +2122,20 @@ Structural attributes (`context`, `test`, `select`, `name`, `id`, `prefix`, `uri
 1. Create XPath context with schema's namespaces
 2. For each pattern/rule: evaluate `contextExpr` against document root → node set
    - If the context XPath **errors at evaluation**, surface an `XPath error : ...` diagnostic and mark the document invalid (the rule's assertions can't be checked, so it is not silently skipped)
-   - **First-match-only (ISO Schematron):** within a pattern, each node is processed by only the FIRST rule whose context matches it. A per-pattern `map[helium.Node]bool` (reset each pattern) skips nodes already claimed by an earlier rule. Scope is per pattern, so a later pattern still fires for the same node.
+   - **First-match-only (ISO Schematron):** within a pattern, each node is processed by only the FIRST rule
+     whose context matches it. A per-pattern `map[helium.Node]bool` (reset each pattern) skips nodes already
+     claimed by an earlier rule. Scope is per pattern, so a later pattern still fires for the same node.
 3. For each context node:
-   - Bind `<let>` variables in **document order** (accumulated, so a later let sees earlier ones, e.g. `<let name="b" value="$a"/>` after `a`). A let whose expression **errors at evaluation** surfaces an `XPath error : ...` diagnostic, so it is never silently dropped.
+   - Bind `<let>` variables in **document order** (accumulated, so a later let sees earlier ones, e.g. `<let
+     name="b" value="$a"/>` after `a`). A let whose expression **errors at evaluation** surfaces an `XPath
+     error : ...` diagnostic, so it is never silently dropped.
    - Create rule-specific XPath context with variables
 4. For each test:
    - Evaluate XPath, convert to boolean
-   - If the test XPath **errors at evaluation**, or its result has no effective boolean value (XPath 3.1 FORG0006), surface an `XPath error : ...` diagnostic and treat the test as `false` (mirrors libxml2 `xmlSchematronRunTest` returning 0): an **assert** then fires/fails, a **report** stays silent. A broken test is never treated as satisfied.
+   - If the test XPath **errors at evaluation**, or its result has no effective boolean value (XPath 3.1
+     FORG0006), surface an `XPath error : ...` diagnostic and treat the test as `false` (mirrors libxml2
+     `xmlSchematronRunTest` returning 0): an **assert** then fires/fails, a **report** stays silent. A broken
+     test is never treated as satisfied.
    - **Assert**: error if false
    - **Report**: error if true
 5. Format message (interpolate text/name/value-of parts)

--- a/.claude/docs/xpath3-api.md
+++ b/.claude/docs/xpath3-api.md
@@ -141,11 +141,28 @@ catching undeclared prefixes in function calls, type names, etc. before
 evaluation. The same validation runs automatically inside `Evaluate` /
 `EvaluateReuse`.
 
-`Compile()` first tries a direct fast path for simple path-like expressions on the lexer token stream, then falls back to parse+lower through the VM backend on the same lexer if the fast path does not apply. It does not retain the parsed AST on the `Expression`; `AST()` reparses from `source` on demand. `CompileExpr()` keeps the caller-provided AST and lowers it without mutating the input tree.
+`Compile()` first tries a direct fast path for simple path-like expressions on the lexer token stream, then
+falls back to parse+lower through the VM backend on the same lexer if the fast path does not apply. It does
+not retain the parsed AST on the `Expression`; `AST()` reparses from `source` on demand. `CompileExpr()` keeps
+the caller-provided AST and lowers it without mutating the input tree.
 
 `StreamInfo()` returns a snapshot of precomputed streamability properties (axis usage bitmask, downward steps, function names, etc.). Streamability query helpers live in `internal/xpathstream`, not on the xpath3 package.
 
-`StaticReferences(namespaces)` walks the expression's AST (reparsing from `source` when no AST is retained) and reports its FREE variable references (those not bound by an enclosing for/let/quantified binding or inline-function parameter), its type-name references (cast/castable/instance of/treat as, kind-test type annotations, nested array/map/function item types, and path-step node tests), and its function-call callees (FunctionCall including constructor calls and arrow targets, plus NamedFunctionRef). Every type and function name is RESOLVED to a namespace URI using the supplied in-scope `namespaces` (the same bindings `Validate` takes) plus xpath3's predeclared prefixes — handling prefixed, unprefixed (type → default element namespace; function → fn), and braced-URI `Q{uri}local` forms uniformly — and reports each function reference's static ARITY, so a caller does a pure URI+existence check with no name-form handling of its own. It is side-effect free and intended for schema-compile-time analysis (not the eval hot path); the XSD 1.1 conditional-type-assignment compiler uses it to reject an `xs:alternative` @test that references a variable, an unknown/non-built-in type (XPST0008, via `IsKnownXSDType`), or an unknown, wrong-arity, or non-standard (extension) standard-library function / built-in constructor (XPST0017, via `StandardFunctionAcceptsArity`), or a schema-element()/schema-attribute() node test (which references a global declaration outside the CTA static context), which the CTA static context disallows.
+`StaticReferences(namespaces)` walks the expression's AST (reparsing from `source` when no AST is retained)
+and reports its FREE variable references (those not bound by an enclosing for/let/quantified binding or
+inline-function parameter), its type-name references (cast/castable/instance of/treat as, kind-test type
+annotations, nested array/map/function item types, and path-step node tests), and its function-call callees
+(FunctionCall including constructor calls and arrow targets, plus NamedFunctionRef). Every type and function
+name is RESOLVED to a namespace URI using the supplied in-scope `namespaces` (the same bindings `Validate`
+takes) plus xpath3's predeclared prefixes — handling prefixed, unprefixed (type → default element namespace;
+function → fn), and braced-URI `Q{uri}local` forms uniformly — and reports each function reference's static
+ARITY, so a caller does a pure URI+existence check with no name-form handling of its own. It is side-effect
+free and intended for schema-compile-time analysis (not the eval hot path); the XSD 1.1
+conditional-type-assignment compiler uses it to reject an `xs:alternative` @test that references a variable,
+an unknown/non-built-in type (XPST0008, via `IsKnownXSDType`), or an unknown, wrong-arity, or non-standard
+(extension) standard-library function / built-in constructor (XPST0017, via `StandardFunctionAcceptsArity`),
+or a schema-element()/schema-attribute() node test (which references a global declaration outside the CTA
+static context), which the CTA static context disallows.
 
 `DumpVM()` writes a textual disassembly of compiled VM instructions. Use it for debugging or tooling around lowered expressions.
 
@@ -235,7 +252,10 @@ Pass bindings as plain maps: variables via `Evaluator.Variables(map[string]Seque
 `EvalBorrowing` is set. Supply lazy lookups with `Evaluator.VariableResolver` /
 `Evaluator.FunctionResolver`.
 
-**Resource loading is opt-in.** Without an explicit `URIResolver` or `HTTPClient` (`Evaluator.URIResolver` / `Evaluator.HTTPClient`), `fn:doc`, `fn:doc-available`, `fn:json-doc`, and the `fn:unparsed-text*` family error with `FODC0002` / `FOUT1170` for every URI — there is no implicit `http.DefaultClient` and no implicit `os.ReadFile`. Built-in helpers in `internal/unparsedtext`:
+**Resource loading is opt-in.** Without an explicit `URIResolver` or `HTTPClient` (`Evaluator.URIResolver` /
+`Evaluator.HTTPClient`), `fn:doc`, `fn:doc-available`, `fn:json-doc`, and the `fn:unparsed-text*` family error
+with `FODC0002` / `FOUT1170` for every URI — there is no implicit `http.DefaultClient` and no implicit
+`os.ReadFile`. Built-in helpers in `internal/unparsedtext`:
 - `FileURIResolver{BaseDir}` — file resolver confined to `BaseDir` (refuses `..` traversal and absolute paths outside it)
 - `NewFileResolver(fs.FS)` — file resolver backed by `io/fs`
 - `NewHTTPResolver(*http.Client)` — http(s) resolver; caller owns transport, timeouts, redirect policy
@@ -276,7 +296,9 @@ storage may be overwritten. Extract everything you need (e.g. via
 across calls with `Result.Copy()`, which returns a deep copy backed by
 independent storage. An `EvalState` is not safe for concurrent use.
 
-`Compile()` uses a direct compile fast path where possible, otherwise lowers parsed AST to VM program using an ownership-taking lowering path that can reuse parsed slices. `CompileExpr()` uses a non-mutating lowering path, with raw AST fallback for unsupported custom Expr implementations.
+`Compile()` uses a direct compile fast path where possible, otherwise lowers parsed AST to VM program using an
+ownership-taking lowering path that can reuse parsed slices. `CompileExpr()` uses a non-mutating lowering
+path, with raw AST fallback for unsupported custom Expr implementations.
 
 ## Errors
 
@@ -320,6 +342,9 @@ func (e *XPathError) Error() string
 func (e *XPathError) Is(target error) bool
 ```
 
-Standard codes: `XPTY0004` (type error), `FOER0000` (general), `FOTY0012` (typed value undefined — fn:data on element-only complex content), `FOTY0013` (atomization context), `FOAR0001` (division by zero), `FOAR0002` (numeric overflow/underflow, e.g. round precision past the non-terminating cap), `FOAY0001` (array index out of bounds), `FOMX0001` (map duplicate key reject).
+Standard codes: `XPTY0004` (type error), `FOER0000` (general), `FOTY0012` (typed value undefined — fn:data on
+element-only complex content), `FOTY0013` (atomization context), `FOAR0001` (division by zero), `FOAR0002`
+(numeric overflow/underflow, e.g. round precision past the non-terminating cap), `FOAY0001` (array index out
+of bounds), `FOMX0001` (map duplicate key reject).
 
 `try-catch` matches `*XPathError` by code. Non-`*XPathError` errors propagate through unchanged.

--- a/.claude/docs/xpath3-eval.md
+++ b/.claude/docs/xpath3-eval.md
@@ -49,7 +49,14 @@ type vmInstruction struct {
 type compiledExprRef struct { index int }
 ```
 
-Lowering is structural for non-trivial nodes: recursive children usually become `compiledExprRef` indexes, trivial leaves such as literals or variable refs can stay inline in the parent payload, and hot path forms now use VM-specific payloads instead of AST nodes. `LocationPath` / `PathExpr` lower to `vmLocationPathExpr` / `vmPathExpr` with `vmLocationStep` slices, and the direct-compile fast path can emit `vmLocationPathExpr` directly before lowering child predicate expressions. Common predicates on VM location steps also lower to inline VM predicate payloads for `[N]`, `[position() = N]`, `[@attr]`, and `[@attr = "literal"]`; other predicates stay as lowered `Expr`s. VM execution switches on `vmOpcode` for compiled refs, then reuses existing `eval_*` helpers for language semantics.
+Lowering is structural for non-trivial nodes: recursive children usually become `compiledExprRef` indexes,
+trivial leaves such as literals or variable refs can stay inline in the parent payload, and hot path forms now
+use VM-specific payloads instead of AST nodes. `LocationPath` / `PathExpr` lower to `vmLocationPathExpr` /
+`vmPathExpr` with `vmLocationStep` slices, and the direct-compile fast path can emit `vmLocationPathExpr`
+directly before lowering child predicate expressions. Common predicates on VM location steps also lower to
+inline VM predicate payloads for `[N]`, `[position() = N]`, `[@attr]`, and `[@attr = "literal"]`; other
+predicates stay as lowered `Expr`s. VM execution switches on `vmOpcode` for compiled refs, then reuses
+existing `eval_*` helpers for language semantics.
 
 ## Evaluation Rules by Expr Type
 
@@ -62,7 +69,12 @@ Evaluate each item, concatenate sequences through `appendBoundedSeq` so the aggr
 3. Hot axes (`child`, `attribute`, `self`, `parent`) fuse traversal and node-test filtering directly in `xpath3`, avoiding the generic `TraverseAxis` + extra filtered-slice path
 4. Return merged node-set
 
-**Cancellation:** the fused hot child/attribute loops check `ctx.Err()` once per enumerated node (the attribute path also inside its `ForEachAttribute` callback) so a cancelled context aborts mid-enumeration instead of scanning the whole child/attribute set before the next `countOps` boundary. Generic (non-hot) axes delegate to `ixpath.TraverseAxis(ctx, ...)`, which performs its own in-loop `ctx.Err()` checks; on the namespace axis those checks run inside the `NamespacePrefixesInScope` / `CollectNamespaceNodes` helper loops (outer and inner) so `namespace::*` cancels promptly too.
+**Cancellation:** the fused hot child/attribute loops check `ctx.Err()` once per enumerated node (the
+attribute path also inside its `ForEachAttribute` callback) so a cancelled context aborts mid-enumeration
+instead of scanning the whole child/attribute set before the next `countOps` boundary. Generic (non-hot) axes
+delegate to `ixpath.TraverseAxis(ctx, ...)`, which performs its own in-loop `ctx.Err()` checks; on the
+namespace axis those checks run inside the `NamespacePrefixesInScope` / `CollectNamespaceNodes` helper loops
+(outer and inner) so `namespace::*` cancels promptly too.
 
 ### Predicates
 - Numeric atomic → compare to position (1-based)
@@ -107,7 +119,9 @@ Evaluate start/end as xs:integer → produce sequence of integers. Apply `maxNod
 Evaluate condition → EBV → evaluate Then or Else branch.
 
 ### TryCatchExpr
-Evaluate Try. On `*XPathError`: match code against catch clause codes (`*` = catch-all). Bind `$err:code`, `$err:description`, `$err:value`, `$err:module`, `$err:line-number`, `$err:column-number` in catch scope. `err:` prefix → `http://www.w3.org/2005/xqt-errors`.
+Evaluate Try. On `*XPathError`: match code against catch clause codes (`*` = catch-all). Bind `$err:code`,
+`$err:description`, `$err:value`, `$err:module`, `$err:line-number`, `$err:column-number` in catch scope.
+`err:` prefix → `http://www.w3.org/2005/xqt-errors`.
 
 ### InstanceOfExpr
 Check each item against SequenceType at runtime → boolean.
@@ -158,10 +172,14 @@ Evaluate key/value pairs → keys must atomize to AtomicValue → build MapItem.
 ## Comparison Engine (`compare.go`)
 
 ### General Comparison (`= != < <= > >=`)
-Atomize both → for each pair → type promotion → value compare. True if ANY pair matches. The O(N·M) left×right scan charges one op (via `fnCountOp`) and checks `ctx.Err()` per candidate pair, so a comparison over two large sequences honors `OpLimit` / context cancellation instead of running unbounded.
+Atomize both → for each pair → type promotion → value compare. True if ANY pair matches. The O(N·M) left×right
+scan charges one op (via `fnCountOp`) and checks `ctx.Err()` per candidate pair, so a comparison over two
+large sequences honors `OpLimit` / context cancellation instead of running unbounded.
 
 ### Value Comparison (`eq ne lt le gt ge`)
-Both must be single items. Error (XPTY0004) if sequence length > 1. Operands are atomized with an early stop (`atomizeSingletonOperand`, cap 2) so a multi-item or unbounded-lazy operand raises the cardinality error without materializing the whole sequence.
+Both must be single items. Error (XPTY0004) if sequence length > 1. Operands are atomized with an early stop
+(`atomizeSingletonOperand`, cap 2) so a multi-item or unbounded-lazy operand raises the cardinality error
+without materializing the whole sequence.
 
 ### Node Comparison (`is << >>`)
 Compare node identity or document order.
@@ -319,7 +337,9 @@ and the default xpath3 behavior is unchanged.
 - `evalContext` created fresh per call, discarded after
 - Hot-path node/item rebinding during predicates, path steps, and simple-map evaluation mutates the current `evalContext` temporarily and restores it afterward instead of allocating copied child contexts
 - Default language comes from `WithDefaultLanguage`; built-ins fall back to `"en"` when unset
-- `DocOrderCache` lazy, O(n) build, O(1) lookup: one flat `map[helium.Node]sortKey` covering every indexed document, so a position lookup is a single hash probe with no parent-chain walk. A second map records each document root's registration order, which orders nodes from different trees
+- `DocOrderCache` lazy, O(n) build, O(1) lookup: one flat `map[helium.Node]sortKey` covering every indexed
+  document, so a position lookup is a single hash probe with no parent-chain walk. A second map records each
+  document root's registration order, which orders nodes from different trees
 - Inline functions and named function refs snapshot the dynamic context they close over, so later focus rebinding does not change captured behavior
 
 ## Safety Limits

--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -104,17 +104,66 @@ to the inline-function parameter/return paths and `coerceFunctionItem`
 ### `functions_node.go`
 `node-name`, `nilled`, `string`, `data`, `base-uri`, `document-uri`, `root`, `path`, `has-children`, `innermost`, `outermost`, `id`, `idref`, `lang`, `local-name`, `name`, `namespace-uri`, `number`, `generate-id`
 
-`fn:nilled` returns the PSVI [nil] property of an element node (`()` for a non-element): true iff the node is in the evaluator's `NilledElements` set (`Evaluator.NilledElements`, populated from `xsd.Validator.NilledElements`), else false. The same set drives two other nilled-aware behaviors: `fn:data` / atomization gives a nilled element the empty typed value `()` (via `typedValueItemCheck`, checked before content-kind), and an `element(name, type)` instance-of test excludes a nilled element while `element(name, type?)` matches it (`eval_path.go` `ElementTest`). Non-schema-aware evaluation leaves the set nil → every element is not-nilled.
+`fn:nilled` returns the PSVI [nil] property of an element node (`()` for a non-element): true iff the node is
+in the evaluator's `NilledElements` set (`Evaluator.NilledElements`, populated from
+`xsd.Validator.NilledElements`), else false. The same set drives two other nilled-aware behaviors: `fn:data` /
+atomization gives a nilled element the empty typed value `()` (via `typedValueItemCheck`, checked before
+content-kind), and an `element(name, type)` instance-of test excludes a nilled element while `element(name,
+type?)` matches it (`eval_path.go` `ElementTest`). Non-schema-aware evaluation leaves the set nil → every
+element is not-nilled.
 
-`fn:id`/`fn:element-with-id` (`idLookup`) resolve is-id nodes from three sources: DTD-declared IDs (`GetElementByID`), type annotations whose name is xs:ID or a subtype (`annotationMatchesIDType`), and the PSVI is-id set supplied via `Evaluator.IDNodes` (`ec.idNodes`). The is-id set is required for cases the type name alone cannot express — a SINGLETON list of xs:ID and a union that selects an xs:ID-derived member (a multi-item list / non-ID union member is not is-id); the xsd validator computes it (`Validator.IDNodes`). `idElementsFromTypeAnnotations` unions annotation-derived and set-derived candidates, then `idNodeResult` maps each is-id node to its result (`fn:id` → the ID element / bearing element; `fn:element-with-id` → that element's parent).
+`fn:id`/`fn:element-with-id` (`idLookup`) resolve is-id nodes from three sources: DTD-declared IDs
+(`GetElementByID`), type annotations whose name is xs:ID or a subtype (`annotationMatchesIDType`), and the
+PSVI is-id set supplied via `Evaluator.IDNodes` (`ec.idNodes`). The is-id set is required for cases the type
+name alone cannot express — a SINGLETON list of xs:ID and a union that selects an xs:ID-derived member (a
+multi-item list / non-ID union member is not is-id); the xsd validator computes it (`Validator.IDNodes`).
+`idElementsFromTypeAnnotations` unions annotation-derived and set-derived candidates, then `idNodeResult` maps
+each is-id node to its result (`fn:id` → the ID element / bearing element; `fn:element-with-id` → that
+element's parent).
 
 ### `functions_string.go`
-`codepoints-to-string`, `string-to-codepoints`, `compare`, `codepoint-equal`, `concat`, `string-join`, `substring`, `string-length`, `normalize-space`, `normalize-unicode`, `upper-case`, `lower-case`, `translate`, `contains`, `starts-with`, `ends-with`, `substring-before`, `substring-after`, `matches`, `replace`, `tokenize`, `analyze-string` (partial; result DOM built with helium)
+`codepoints-to-string`, `string-to-codepoints`, `compare`, `codepoint-equal`, `concat`, `string-join`,
+`substring`, `string-length`, `normalize-space`, `normalize-unicode`, `upper-case`, `lower-case`, `translate`,
+`contains`, `starts-with`, `ends-with`, `substring-before`, `substring-after`, `matches`, `replace`,
+`tokenize`, `analyze-string` (partial; result DOM built with helium)
 
 Regex: use Go `regexp` package by default; fall back to `github.com/dlclark/regexp2` for patterns requiring backreferences, character class subtraction, or large quantifiers. Map XPath flags (`i`,`m`,`s`,`x`) to Go equivalents.
-Compiled regexes are cached by pattern + flags pair so repeated literal calls do not repay translation/compilation cost. The cache (`regexLRUCache` in `regex_cache.go`) is a bounded LRU with a 1024-entry cap and least-recently-used eviction, so many distinct dynamic patterns cannot grow process memory without limit.
+Compiled regexes are cached by pattern + flags pair so repeated literal calls do not repay
+translation/compilation cost. The cache (`regexLRUCache` in `regex_cache.go`) is a bounded LRU with a
+1024-entry cap and least-recently-used eviction, so many distinct dynamic patterns cannot grow process memory
+without limit.
 
-**Resource bounds (XPATH3-102/105).** `string-to-codepoints` charges `fnCountOp` per produced codepoint so a huge input cannot build an item sequence below the node-set cap but above `OpLimit`. `analyze-string` STREAMS its regex matches via `compiledXPathRegex.eachStringSubmatchIndex` (the internal form of the public `Regex.EachSubmatchIndex`), leaving `FindAllStringSubmatchIndex` uncalled: when an op budget is in force it passes `fnRemainingOps(ec)+1` as the match limit and charges `fnCountOp` BEFORE building each match's result nodes, so an input with millions of matches rejects with `ErrOpLimit` (or honors cancellation) without ever materializing the O(matches) index slice. A non-streamable leading-context pattern over an oversized input surfaces `ErrRegexMatchLimit` as-is (errors.Is-compatible); other engine errors map to `FORX0002`. Nested capturing groups produce NESTED `fn:group` elements (F&O 3.1 §5.6.5): `analyzeStringGroupParents` derives each group's parent from the pattern's STATIC parenthesis structure (skipping escapes, XSD character-class subexpressions, and `(?…` non-capturing/modifier groups), not from match positions — `(b)(x?)` (siblings) and `(b(x?))` (nested) yield identical submatch spans, so position-only reconstruction cannot tell them apart. It MUST tokenize the SAME pattern the engine compiles, so it applies the identical preprocessing first: the `q` flag makes the whole pattern a literal (no groups), and the `x` flag runs `stripFreeSpacing` before scanning — otherwise a raw-pattern parse diverges (e.g. `( a \ ) (b) )` with `x` compiles to `(a\)(b))`, group 2 nested in group 1, but the raw form looks like two siblings and would duplicate text). The XPath 3.1 `x` flag (§5.6.1.1) removes unescaped whitespace outside character classes — EXACTLY the four XML whitespace chars `#x9/#xA/#xD/#x20` (`isXPathRegexWhitespace`, deliberately narrower than `unicode.IsSpace`: U+00A0 NBSP and other Unicode spaces stay literal) — and does NOT enable `#` comments (a Perl/Java extension absent from XPath 3.1 — `#` stays literal). That single shared whitespace definition governs BOTH the core regex-compilation stripping (`stripFreeSpacing`, used by fn:matches/replace/tokenize/analyze-string) and analyze-string group derivation. `buildAnalyzeStringMatch` builds the group tree by pattern nesting (`buildAnalyzeStringTreeByPattern`), then `renderAnalyzeStringGroup` distributes the matched substring text so each `fn:group` holds the text of its span not covered by a nested child, in document order. The fundamental invariant is that the `fn:match` string value equals the matched input substring; `buildAnalyzeStringMatch` ENFORCES it via `analyzeStringGroupText`: if the pattern-derived tree's string value ever disagrees with the input (a tokenization edge that would duplicate/drop text), it falls back to `buildAnalyzeStringTreeByPosition` (span-containment nesting, which always tiles the matched substring exactly) and, as a final floor, to a group-less match holding just the text — output whose string value differs from the input is never emitted. The result tree is still `xs:untyped`/untyped attributes (no PSVI type annotation from the built-in analyze-string-result schema).
+**Resource bounds (XPATH3-102/105).** `string-to-codepoints` charges `fnCountOp` per produced codepoint so a
+huge input cannot build an item sequence below the node-set cap but above `OpLimit`. `analyze-string` STREAMS
+its regex matches via `compiledXPathRegex.eachStringSubmatchIndex` (the internal form of the public
+`Regex.EachSubmatchIndex`), leaving `FindAllStringSubmatchIndex` uncalled: when an op budget is in force it
+passes `fnRemainingOps(ec)+1` as the match limit and charges `fnCountOp` BEFORE building each match's result
+nodes, so an input with millions of matches rejects with `ErrOpLimit` (or honors cancellation) without ever
+materializing the O(matches) index slice. A non-streamable leading-context pattern over an oversized input
+surfaces `ErrRegexMatchLimit` as-is (errors.Is-compatible); other engine errors map to `FORX0002`. Nested
+capturing groups produce NESTED `fn:group` elements (F&O 3.1 §5.6.5): `analyzeStringGroupParents` derives each
+group's parent from the pattern's STATIC parenthesis structure (skipping escapes, XSD character-class
+subexpressions, and `(?…` non-capturing/modifier groups), not from match positions — `(b)(x?)` (siblings) and
+`(b(x?))` (nested) yield identical submatch spans, so position-only reconstruction cannot tell them apart. It
+MUST tokenize the SAME pattern the engine compiles, so it applies the identical preprocessing first: the `q`
+flag makes the whole pattern a literal (no groups), and the `x` flag runs `stripFreeSpacing` before scanning —
+otherwise a raw-pattern parse diverges (e.g. `( a \ ) (b) )` with `x` compiles to `(a\)(b))`, group 2 nested
+in group 1, but the raw form looks like two siblings and would duplicate text). The XPath 3.1 `x` flag
+(§5.6.1.1) removes unescaped whitespace outside character classes — EXACTLY the four XML whitespace chars
+`#x9/#xA/#xD/#x20` (`isXPathRegexWhitespace`, deliberately narrower than `unicode.IsSpace`: U+00A0 NBSP and
+other Unicode spaces stay literal) — and does NOT enable `#` comments (a Perl/Java extension absent from XPath
+3.1 — `#` stays literal). That single shared whitespace definition governs BOTH the core regex-compilation
+stripping (`stripFreeSpacing`, used by fn:matches/replace/tokenize/analyze-string) and analyze-string group
+derivation. `buildAnalyzeStringMatch` builds the group tree by pattern nesting
+(`buildAnalyzeStringTreeByPattern`), then `renderAnalyzeStringGroup` distributes the matched substring text so
+each `fn:group` holds the text of its span not covered by a nested child, in document order. The fundamental
+invariant is that the `fn:match` string value equals the matched input substring; `buildAnalyzeStringMatch`
+ENFORCES it via `analyzeStringGroupText`: if the pattern-derived tree's string value ever disagrees with the
+input (a tokenization edge that would duplicate/drop text), it falls back to
+`buildAnalyzeStringTreeByPosition` (span-containment nesting, which always tiles the matched substring
+exactly) and, as a final floor, to a group-less match holding just the text — output whose string value
+differs from the input is never emitted. The result tree is still `xs:untyped`/untyped attributes (no PSVI
+type annotation from the built-in analyze-string-result schema).
 
 ### `functions_numeric.go`
 `abs`, `ceiling`, `floor`, `round`, `round-half-to-even`
@@ -134,7 +183,10 @@ Error/trace: `error` (raises `FOER0000` with optional code/description/value), `
 
 ### `functions_datetime.go`
 Constructors: `dateTime`
-Accessors: `year-from-dateTime`, `month-from-dateTime`, `day-from-dateTime`, `hours-from-dateTime`, `minutes-from-dateTime`, `seconds-from-dateTime`, `timezone-from-dateTime`, (same for date/time variants), `years-from-duration`, `months-from-duration`, `days-from-duration`, `hours-from-duration`, `minutes-from-duration`, `seconds-from-duration`
+Accessors: `year-from-dateTime`, `month-from-dateTime`, `day-from-dateTime`, `hours-from-dateTime`,
+`minutes-from-dateTime`, `seconds-from-dateTime`, `timezone-from-dateTime`, (same for date/time variants),
+`years-from-duration`, `months-from-duration`, `days-from-duration`, `hours-from-duration`,
+`minutes-from-duration`, `seconds-from-duration`
 Formatting: `format-date`, `format-dateTime`, `format-time`
 Misc: `adjust-dateTime-to-timezone`, `adjust-date-to-timezone`, `adjust-time-to-timezone`
 
@@ -474,7 +526,13 @@ readers report a present-empty value as not-found so the caller keeps its defaul
 `json-doc` uses same URI resolution/resource-loading stack as `doc` + `unparsed-text`:
 `WithBaseURI` → relative resolution, `WithURIResolver` → resolver for all schemes, `WithHTTPClient` → opt-in HTTP fetch.
 
-**Secure by default.** With no `URIResolver` and no `HTTPClient`, `fn:doc`, `fn:doc-available`, `fn:json-doc`, `fn:unparsed-text`, `fn:unparsed-text-available`, and `fn:unparsed-text-lines` cannot reach the filesystem or network — they error with `FODC0002` / `FOUT1170`. To allow access, supply a `URIResolver` (e.g. `unparsedtext.FileURIResolver{BaseDir:...}`, `unparsedtext.NewFileResolver(fs.FS)`, or `unparsedtext.NewHTTPResolver(*http.Client)`), or set an explicit `HTTPClient` whose transport/timeouts/redirect policy you control. `fn:doc` parses retrieved bytes with `BlockXXE(true).AllowNetwork(false)` so the returned document cannot pull additional externals.
+**Secure by default.** With no `URIResolver` and no `HTTPClient`, `fn:doc`, `fn:doc-available`, `fn:json-doc`,
+`fn:unparsed-text`, `fn:unparsed-text-available`, and `fn:unparsed-text-lines` cannot reach the filesystem or
+network — they error with `FODC0002` / `FOUT1170`. To allow access, supply a `URIResolver` (e.g.
+`unparsedtext.FileURIResolver{BaseDir:...}`, `unparsedtext.NewFileResolver(fs.FS)`, or
+`unparsedtext.NewHTTPResolver(*http.Client)`), or set an explicit `HTTPClient` whose
+transport/timeouts/redirect policy you control. `fn:doc` parses retrieved bytes with
+`BlockXXE(true).AllowNetwork(false)` so the returned document cannot pull additional externals.
 
 ### `functions_qname.go`
 `QName`, `resolve-QName`, `prefix-from-QName`, `local-name-from-QName`, `namespace-uri-from-QName`, `namespace-uri-for-prefix`, `in-scope-prefixes`
@@ -482,22 +540,55 @@ readers report a present-empty value as not-found so the caller keeps its defaul
 ### `functions_hof.go`
 `for-each`, `filter`, `fold-left`, `fold-right`, `apply`, `function-lookup`, `function-arity`, `function-name`
 
-**Resource bounds.** Accumulating higher-order / map / array built-ins honor the same limits as the evaluator's accumulation sites: per-iteration `ec.countOps` (op limit + context cancellation) and a `maxNodes` length cap (sequence/node-set length → `ErrNodeSetLimit`). Shared helpers `fnMaxNodes(ec)` / `fnCountOp(ctx, ec)` (in `functions_hof.go`) default to `maxNodeSetLength` and stay safe when `ec == nil` (function called outside an evaluation). Covers `for-each`, `for-each-pair`, `filter`, `fold-left`/`fold-right`, `map:for-each`, `map:find`, `array:join`, `array:flat-map`, `array:filter`, `array:for-each`/`for-each-pair`, `array:fold-left`/`fold-right`.
+**Resource bounds.** Accumulating higher-order / map / array built-ins honor the same limits as the
+evaluator's accumulation sites: per-iteration `ec.countOps` (op limit + context cancellation) and a `maxNodes`
+length cap (sequence/node-set length → `ErrNodeSetLimit`). Shared helpers `fnMaxNodes(ec)` / `fnCountOp(ctx,
+ec)` (in `functions_hof.go`) default to `maxNodeSetLength` and stay safe when `ec == nil` (function called
+outside an evaluation). Covers `for-each`, `for-each-pair`, `filter`, `fold-left`/`fold-right`,
+`map:for-each`, `map:find`, `array:join`, `array:flat-map`, `array:filter`, `array:for-each`/`for-each-pair`,
+`array:fold-left`/`fold-right`.
 
-Built-ins that clone or materialize a whole sub-sequence in **one shot**, in place of an item-by-item walk (`array:for-each`, `array:for-each-pair`, `array:join`, `array:flat-map`, `map:find`) additionally charge the sub-sequence length against the op-counter via `fnCountOps(ctx, ec, n)` **before** the bulk `NewArray`/`cloneSequence`/append. This rejects a result/member-list/value that is below `maxNodes` but above `OpLimit` with `ErrOpLimit` — length-only (`maxNodes`) checking would otherwise let it be cloned unbounded. Because `NewArray` clones **each** member sequence, `array:join` and `array:flat-map` charge `seqLen(member)` **per member** (not one op per member): a single member holding many items below `maxNodes` but above `OpLimit` is still rejected.
+Built-ins that clone or materialize a whole sub-sequence in **one shot**, in place of an item-by-item walk
+(`array:for-each`, `array:for-each-pair`, `array:join`, `array:flat-map`, `map:find`) additionally charge the
+sub-sequence length against the op-counter via `fnCountOps(ctx, ec, n)` **before** the bulk
+`NewArray`/`cloneSequence`/append. This rejects a result/member-list/value that is below `maxNodes` but above
+`OpLimit` with `ErrOpLimit` — length-only (`maxNodes`) checking would otherwise let it be cloned unbounded.
+Because `NewArray` clones **each** member sequence, `array:join` and `array:flat-map` charge `seqLen(member)`
+**per member** (not one op per member): a single member holding many items below `maxNodes` but above
+`OpLimit` is still rejected.
 
-Sites that build a result array with one **member** per callback result / matched value (`array:for-each`, `array:for-each-pair`, `map:find`) bound the **member count** independently of the item count: a callback returning an empty sequence (or an empty matched map value) adds zero items but still adds a member, so `len(results)+1 > maxNodes` is checked before each append, otherwise many empty results could build an array with more than `maxNodes` members. `array:flat-map` charges one op per callback-result item up front (including items that are empty arrays whose member expansion appends nothing), so many empty arrays cannot bypass `OpLimit`.
+Sites that build a result array with one **member** per callback result / matched value (`array:for-each`,
+`array:for-each-pair`, `map:find`) bound the **member count** independently of the item count: a callback
+returning an empty sequence (or an empty matched map value) adds zero items but still adds a member, so
+`len(results)+1 > maxNodes` is checked before each append, otherwise many empty results could build an array
+with more than `maxNodes` members. `array:flat-map` charges one op per callback-result item up front
+(including items that are empty arrays whose member expansion appends nothing), so many empty arrays cannot
+bypass `OpLimit`.
 
-The cap must trigger **before** materializing a lazy result, so the bound holds for genuinely lazy inputs (e.g. an `EvalBorrowing` variable bound to a large `NewRangeSequence`, or a `VariableResolver` result) — not only after a slice has already been allocated:
-- Callback-result accumulators (`for-each`, `for-each-pair`, `map:for-each`) use `appendBoundedSeq(dst, src, maxNodes)` (in `eval_operators.go`), which iterates `seqItems(src)` one item at a time and checks `maxNodes` before each append, so a callback returning an unbounded lazy `Sequence` is rejected without ever materializing it. `appendBounded` (the slice-taking variant) is still used where the source is already a materialized slice.
+The cap must trigger **before** materializing a lazy result, so the bound holds for genuinely lazy inputs
+(e.g. an `EvalBorrowing` variable bound to a large `NewRangeSequence`, or a `VariableResolver` result) — not
+only after a slice has already been allocated:
+- Callback-result accumulators (`for-each`, `for-each-pair`, `map:for-each`) use `appendBoundedSeq(dst, src,
+  maxNodes)` (in `eval_operators.go`), which iterates `seqItems(src)` one item at a time and checks `maxNodes`
+  before each append, so a callback returning an unbounded lazy `Sequence` is rejected without ever
+  materializing it. `appendBounded` (the slice-taking variant) is still used where the source is already a
+  materialized slice.
 - Fold accumulators check `seqLen(acc) > maxNodes` after each step; `seqLen` is O(1) on a lazy range, so an oversized lazy accumulator is rejected without materialization.
-- The iterative walkers `array:flatten` and `map:find` (`mapFindIter`) use an explicit stack of `seqCursor` frames (a member/value list + member/item index, in `functions_array.go`) that yields one `Item` per `next()` via `Sequence.Get`, instead of expanding child sequences into temporary `[]Item` slices. This bounds depth (no goroutine-stack recursion) and width (no per-level slice amplification), and stays op-counted and `maxNodes`-bounded. Maps and arrays are eager value types — `NewMap`/`NewArray` clone member/value sequences at construction — so member/value sequences are not lazy in practice; the cursor still avoids the intermediate slice amplification.
+- The iterative walkers `array:flatten` and `map:find` (`mapFindIter`) use an explicit stack of `seqCursor`
+  frames (a member/value list + member/item index, in `functions_array.go`) that yields one `Item` per
+  `next()` via `Sequence.Get`, instead of expanding child sequences into temporary `[]Item` slices. This
+  bounds depth (no goroutine-stack recursion) and width (no per-level slice amplification), and stays
+  op-counted and `maxNodes`-bounded. Maps and arrays are eager value types — `NewMap`/`NewArray` clone
+  member/value sequences at construction — so member/value sequences are not lazy in practice; the cursor
+  still avoids the intermediate slice amplification.
 
 ### `functions_map.go`
 `map:merge`, `map:size`, `map:keys`, `map:contains`, `map:get`, `map:put`, `map:entry`, `map:remove`, `map:for-each`, `map:find`
 
 ### `functions_array.go`
-`array:size`, `array:get`, `array:put`, `array:append`, `array:subarray`, `array:remove`, `array:insert-before`, `array:head`, `array:tail`, `array:reverse`, `array:join`, `array:flat-map`, `array:filter`, `array:fold-left`, `array:fold-right`, `array:for-each`, `array:for-each-pair`, `array:sort`
+`array:size`, `array:get`, `array:put`, `array:append`, `array:subarray`, `array:remove`,
+`array:insert-before`, `array:head`, `array:tail`, `array:reverse`, `array:join`, `array:flat-map`,
+`array:filter`, `array:fold-left`, `array:fold-right`, `array:for-each`, `array:for-each-pair`, `array:sort`
 
 ### `functions_math.go`
 `math:pi`, `math:exp`, `math:exp10`, `math:log`, `math:log10`, `math:pow`, `math:sqrt`, `math:sin`, `math:cos`, `math:tan`, `math:asin`, `math:acos`, `math:atan`, `math:atan2`

--- a/.claude/docs/xpath3-types.md
+++ b/.claude/docs/xpath3-types.md
@@ -50,12 +50,45 @@ type NodeItemUnionMember struct {
 
 - `TypeAnnotation` → schema-aware node type annotation (`xs:*` or `Q{ns}local`)
 - `AtomizedType` → built-in base type used when atomizing schema-derived node types
-- `ListItemType` → item type name for a list-typed node; `ListItemAtomized` → that item type's built-in base (e.g. `xs:QName` for a QName-derived list item), so list-token atomization (`atomizeListToken`) can resolve QName/NOTATION items namespace-aware; `UnionMemberTypes` → member type names for a union-typed node
-- `ActiveUnionMember` → the value-dependent ACTIVE LEAF member of a union node (the first direct member the value FULLY validates against — lexical/value cast AND facets/list-length via `SchemaDeclarations.ValidateCastWithNS`; when that member is itself a union, resolution descends recursively to the nested leaf, matching the `$value` selection), or nil. A list leaf expands to per-item atoms; an atomic leaf yields a single atom typed as that member. The `NodeItemUnionMember` it points at is immutable (shared across clones)
-- `ListItemLeaves` → populated only when a list node's ITEM type is a UNION: the per-token ACTIVE union leaf (resolved value-dependently in `nodeItemFor` via `resolveActiveUnionLeafForValue`, one entry per token in document order). `atomizeListTokenAt(i, …)` atomizes token `i` through `ListItemLeaves[i]` when present, so `xs:list itemType="<union>"` atomizes each token by its own active member (agreeing with `$value`) instead of forcing every token through one static base; nil/short slice falls back to `atomizeListToken` on the declared item type
+- `ListItemType` → item type name for a list-typed node; `ListItemAtomized` → that item type's built-in base
+  (e.g. `xs:QName` for a QName-derived list item), so list-token atomization (`atomizeListToken`) can resolve
+  QName/NOTATION items namespace-aware; `UnionMemberTypes` → member type names for a union-typed node
+- `ActiveUnionMember` → the value-dependent ACTIVE LEAF member of a union node (the first direct member the
+  value FULLY validates against — lexical/value cast AND facets/list-length via
+  `SchemaDeclarations.ValidateCastWithNS`; when that member is itself a union, resolution descends recursively
+  to the nested leaf, matching the `$value` selection), or nil. A list leaf expands to per-item atoms; an
+  atomic leaf yields a single atom typed as that member. The `NodeItemUnionMember` it points at is immutable
+  (shared across clones)
+- `ListItemLeaves` → populated only when a list node's ITEM type is a UNION: the per-token ACTIVE union leaf
+  (resolved value-dependently in `nodeItemFor` via `resolveActiveUnionLeafForValue`, one entry per token in
+  document order). `atomizeListTokenAt(i, …)` atomizes token `i` through `ListItemLeaves[i]` when present, so
+  `xs:list itemType="<union>"` atomizes each token by its own active member (agreeing with `$value`) instead
+  of forcing every token through one static base; nil/short slice falls back to `atomizeListToken` on the
+  declared item type
 - `QNameNoDefaultNS` → set from `Evaluator.QNameValueNoDefaultNamespace()`; when true an UNPREFIXED QName/NOTATION value atomizes to no namespace (XSD value-space semantics) instead of the node's default namespace
 
-`resolveQNameFromNode` predeclares the `xml` prefix (→ the XML namespace) without requiring a binding on any node, matching `xsd.resolveLexicalQName`, so an xs:QName value such as `xml:lang`/`xml:space` atomizes correctly. List-typed node atomization splits on XSD whitespace ONLY (`xsdListFields`: space/tab/CR/LF — NOT NBSP/other Unicode whitespace, matching XSD list tokenization and the validation/`$value` paths) and atomizes each token via `atomizeListToken` (used by both `atomizeStream` and the value-comparison atom iterator). When the item type's built-in base is `xs:QName`/`xs:NOTATION` it resolves each token against the node's in-scope namespaces (preserving the user/list-item type name and its built-in base); a NON-QName USER item type (a `Q{...}` name `CastFromString` can't resolve) is cast through its `ListItemAtomized` built-in base and typed as the user type with that base, so a list whose item type derives from xs:int yields numeric atoms usable by `sum()`. A UNION-typed node is atomized through its precomputed ACTIVE LEAF member (`ActiveUnionMember`, resolved by `resolveActiveUnionLeaf` in `nodeItemFor` with FULL schema-aware validation — cast validity AND facets/list-length/assertions via `SchemaDeclarations.ValidateCastWithNS`, the ctx threaded through `nodeItemFor`): `atomizeUnionItems` (used by both the stream and comparison paths) expands a LIST leaf to per-item atoms (via `atomizeListTokenAt`, so when the leaf's list item type is ITSELF a UNION the per-token active leaves carried on `NodeItemUnionMember.ListItemLeaves` — precomputed in `resolveActiveUnionLeafRec` — type each token by its own active member, matching `$value`) and yields an ATOMIC leaf as a single atom typed as that member. Resolution descends recursively through NESTED unions to the leaf (mirroring `fixedUnionActiveMember`), so `data()` and `$value` agree for `Outer=union(Inner,…)` / `Inner=union(IntList,…)`. Because selection is full validation, a member that casts but fails its own facets (e.g. an xs:list with `xs:length=2` against `"1 2 3"`) is correctly skipped — matching the `$value` path. All of this only activates when `ActiveUnionMember`/`ListItemType` are populated (schema-aware atomization), so non-schema-aware xpath3/xslt3 behavior is unchanged.
+`resolveQNameFromNode` predeclares the `xml` prefix (→ the XML namespace) without requiring a binding on any
+node, matching `xsd.resolveLexicalQName`, so an xs:QName value such as `xml:lang`/`xml:space` atomizes
+correctly. List-typed node atomization splits on XSD whitespace ONLY (`xsdListFields`: space/tab/CR/LF — NOT
+NBSP/other Unicode whitespace, matching XSD list tokenization and the validation/`$value` paths) and atomizes
+each token via `atomizeListToken` (used by both `atomizeStream` and the value-comparison atom iterator). When
+the item type's built-in base is `xs:QName`/`xs:NOTATION` it resolves each token against the node's in-scope
+namespaces (preserving the user/list-item type name and its built-in base); a NON-QName USER item type (a
+`Q{...}` name `CastFromString` can't resolve) is cast through its `ListItemAtomized` built-in base and typed
+as the user type with that base, so a list whose item type derives from xs:int yields numeric atoms usable by
+`sum()`. A UNION-typed node is atomized through its precomputed ACTIVE LEAF member (`ActiveUnionMember`,
+resolved by `resolveActiveUnionLeaf` in `nodeItemFor` with FULL schema-aware validation — cast validity AND
+facets/list-length/assertions via `SchemaDeclarations.ValidateCastWithNS`, the ctx threaded through
+`nodeItemFor`): `atomizeUnionItems` (used by both the stream and comparison paths) expands a LIST leaf to
+per-item atoms (via `atomizeListTokenAt`, so when the leaf's list item type is ITSELF a UNION the per-token
+active leaves carried on `NodeItemUnionMember.ListItemLeaves` — precomputed in `resolveActiveUnionLeafRec` —
+type each token by its own active member, matching `$value`) and yields an ATOMIC leaf as a single atom typed
+as that member. Resolution descends recursively through NESTED unions to the leaf (mirroring
+`fixedUnionActiveMember`), so `data()` and `$value` agree for `Outer=union(Inner,…)` /
+`Inner=union(IntList,…)`. Because selection is full validation, a member that casts but fails its own facets
+(e.g. an xs:list with `xs:length=2` against `"1 2 3"`) is correctly skipped — matching the `$value` path. All
+of this only activates when `ActiveUnionMember`/`ListItemType` are populated (schema-aware atomization), so
+non-schema-aware xpath3/xslt3 behavior is unchanged.
 
 ## AtomicValue
 
@@ -107,9 +140,24 @@ Produced by: inline functions, named refs (`fn#2`), partial application.
 Immutable. `Put` returns new map (copy-on-write).
 Construction + outward-facing accessors clone `Sequence` values via `cloneSequence`. Caller mutation MUST NOT change stored contents.
 
-KEYS are cloned too: every map ingress (`newSingleEntryMap`, `NewMap`, `Put`, `MergeMaps`, `MapBuilder.Add`) clones the `AtomicValue` key via `cloneMapKey` (an O(1) single-atomic copy reusing `deepCloneAtomicValue`), and outward-facing `Keys`/`ForEach` return cloned keys. This stops a pointer-backed key (e.g. `xs:integer` backed by `*big.Int`) from being mutated after insertion — single-entry maps recompute the stored key in `Get`, so a mutated key would otherwise silently change the map's key. Public `ForEach` clones both key and value; trusted internal read-only/bounded/lazy callers use the private no-clone `forEach0`/`keys0`/`get0`/`entries0` accessors (caller must not mutate, and clones once at the call-site egress).
+KEYS are cloned too: every map ingress (`newSingleEntryMap`, `NewMap`, `Put`, `MergeMaps`, `MapBuilder.Add`)
+clones the `AtomicValue` key via `cloneMapKey` (an O(1) single-atomic copy reusing `deepCloneAtomicValue`),
+and outward-facing `Keys`/`ForEach` return cloned keys. This stops a pointer-backed key (e.g. `xs:integer`
+backed by `*big.Int`) from being mutated after insertion — single-entry maps recompute the stored key in
+`Get`, so a mutated key would otherwise silently change the map's key. Public `ForEach` clones both key and
+value; trusted internal read-only/bounded/lazy callers use the private no-clone
+`forEach0`/`keys0`/`get0`/`entries0` accessors (caller must not mutate, and clones once at the call-site
+egress).
 
-`cloneSequence` (`types.go`) is a **deep** clone of each item, not a shallow slice copy: pointer/slice-backed `AtomicValue` payloads (`*big.Int`, `*big.Rat`, `*FloatValue`, `[]byte`, and a `Duration`'s `*big.Rat` fields) are duplicated so mutating the caller's original payload cannot reach the stored value. It does NOT recurse into nested `MapItem`/`ArrayItem` items: those are immutable (all mutators are copy-on-write) and every value they hold was already deep-cloned at its own ingress, so they are shared by value — this keeps incremental construction of a depth-N nested structure at O(N), where recursing would cost O(N²) and preserves the OpLimit/maxNodes resource bounds (charged once per inserted value, not per nesting level). Immutable atomic payloads (int64, string, bool, float64, time.Time, QNameValue, by-value Duration without rationals) are returned as the original boxed item to avoid an interface re-allocation per item.
+`cloneSequence` (`types.go`) is a **deep** clone of each item, not a shallow slice copy: pointer/slice-backed
+`AtomicValue` payloads (`*big.Int`, `*big.Rat`, `*FloatValue`, `[]byte`, and a `Duration`'s `*big.Rat` fields)
+are duplicated so mutating the caller's original payload cannot reach the stored value. It does NOT recurse
+into nested `MapItem`/`ArrayItem` items: those are immutable (all mutators are copy-on-write) and every value
+they hold was already deep-cloned at its own ingress, so they are shared by value — this keeps incremental
+construction of a depth-N nested structure at O(N), where recursing would cost O(N²) and preserves the
+OpLimit/maxNodes resource bounds (charged once per inserted value, not per nesting level). Immutable atomic
+payloads (int64, string, bool, float64, time.Time, QNameValue, by-value Duration without rationals) are
+returned as the original boxed item to avoid an interface re-allocation per item.
 
 ```go
 type MapItem struct {
@@ -207,11 +255,42 @@ Per XPath 3.1 Section 2.6.2:
 
 The same flatten-arrays / error-on-function-or-map rule governs the `||` string-concatenation path (`concatToString`, `eval_operators.go`): array operands flatten to their atomized members, only function and map items raise `FOTY0014`.
 
-The typed-value atomizer (`atomizeTypedValue`, `functions_node.go`) applies a per-item pre-check (`typedValueItemCheck` / `typedValueItemCheckFor`, an `atomizeItemCheck`) that selects a typed-value ACTION per XDM 3.1 §5.15. **Nilled** elements come first: an element in the evaluator's `NilledElements` set has no typed value → the item is SKIPPED (typed value `()`), regardless of its content kind. Then, when the active `SchemaDeclarations` also implements the optional `ContentTypeKindProvider` (reached by type assertion; the xsd adapter `schemaDecls` implements it) and the annotation resolves, an element node's complex content kind selects: **element-only** content has no typed value → error `FOTY0012`; **empty** content has typed value `()` → SKIPPED (no atoms, no error); **mixed** content still atomizes to `xs:untypedAtomic` and simple/simpleContent to its typed value. The content-kind check (`checkContentKindItem`, returning `(skip, err)`) is INTERLEAVED with atomization — threaded into `atomizeStreamCont` as an optional per-item pre-check — so it walks items in the SAME encounter order and with the SAME array recursion as atomization: the FIRST offending item wins (a map/function atomized earlier still raises `FOTY0013` before a later element-only element is reached), and element-only / empty nodes nested inside arrays are handled.
+The typed-value atomizer (`atomizeTypedValue`, `functions_node.go`) applies a per-item pre-check
+(`typedValueItemCheck` / `typedValueItemCheckFor`, an `atomizeItemCheck`) that selects a typed-value ACTION
+per XDM 3.1 §5.15. **Nilled** elements come first: an element in the evaluator's `NilledElements` set has no
+typed value → the item is SKIPPED (typed value `()`), regardless of its content kind. Then, when the active
+`SchemaDeclarations` also implements the optional `ContentTypeKindProvider` (reached by type assertion; the
+xsd adapter `schemaDecls` implements it) and the annotation resolves, an element node's complex content kind
+selects: **element-only** content has no typed value → error `FOTY0012`; **empty** content has typed value
+`()` → SKIPPED (no atoms, no error); **mixed** content still atomizes to `xs:untypedAtomic` and
+simple/simpleContent to its typed value. The content-kind check (`checkContentKindItem`, returning `(skip,
+err)`) is INTERLEAVED with atomization — threaded into `atomizeStreamCont` as an optional per-item pre-check —
+so it walks items in the SAME encounter order and with the SAME array recursion as atomization: the FIRST
+offending item wins (a map/function atomized earlier still raises `FOTY0013` before a later element-only
+element is reached), and element-only / empty nodes nested inside arrays are handled.
 
-This check backs both `fn:data` AND the atomization that occurs when coercing a value to an atomic-typed value: the **function-signature coercion** (`coerceToSequenceTypeE`, `eval_types.go` — the atomization of a node arg against an atomic parameter type such as `xs:string?`, using its explicit `ec` via `typedValueItemCheckFor`, since the fnContext is not yet stashed in `ctx` at coercion time) and the `xs:string?` function-conversion helpers (`coerceAtomizedString` / `seqToStringErr`, for functions with no registered signature, and the `||` `concatToString` path, via `typedValueItemCheck(ctx)`). So atomizing an element-only-typed node as any atomic-coerced argument raises `FOTY0012` for ALL callers (per XDM, an element-only node has no typed value) — e.g. `string-length(.)`/`normalize-space(.)`/`upper-case(.)` over such a node (QT3 `fn-string-length-23`/`fn-normalize-space-24`). Cardinality is still applied AFTER atomization (arrays flatten first), so an `xs:string?` parameter given `([], "x")` coerces to the single `"x"`, not `XPTY0004`. Non-schema-aware nodes and every other `AtomizeItem` caller (comparisons, casts) are unaffected — with no nilled set AND no provider the check is nil and the atomizers are byte-identical to plain `AtomizeSequence` / `atomizeStream`.
+This check backs both `fn:data` AND the atomization that occurs when coercing a value to an atomic-typed
+value: the **function-signature coercion** (`coerceToSequenceTypeE`, `eval_types.go` — the atomization of a
+node arg against an atomic parameter type such as `xs:string?`, using its explicit `ec` via
+`typedValueItemCheckFor`, since the fnContext is not yet stashed in `ctx` at coercion time) and the
+`xs:string?` function-conversion helpers (`coerceAtomizedString` / `seqToStringErr`, for functions with no
+registered signature, and the `||` `concatToString` path, via `typedValueItemCheck(ctx)`). So atomizing an
+element-only-typed node as any atomic-coerced argument raises `FOTY0012` for ALL callers (per XDM, an
+element-only node has no typed value) — e.g. `string-length(.)`/`normalize-space(.)`/`upper-case(.)` over such
+a node (QT3 `fn-string-length-23`/`fn-normalize-space-24`). Cardinality is still applied AFTER atomization
+(arrays flatten first), so an `xs:string?` parameter given `([], "x")` coerces to the single `"x"`, not
+`XPTY0004`. Non-schema-aware nodes and every other `AtomizeItem` caller (comparisons, casts) are unaffected —
+with no nilled set AND no provider the check is nil and the atomizers are byte-identical to plain
+`AtomizeSequence` / `atomizeStream`.
 
-**dm:string-value (schema-aware whitespace stripping).** `evalContext.nodeStringValue` (`functions_node.go`) computes an element/document node's string value and, in a schema-aware run (`ContentTypeKindProvider` + `typeAnnotations` present), strips INSIGNIFICANT whitespace: a whitespace-only text- or CDATA-section-node child of an element whose annotation resolves to ELEMENT-ONLY complex content is not part of the string value (XDM 3.1 PSVI construction), so `fn:string` / `fn:string-length` / `fn:normalize-space` with no argument (which use the string value) see only the child element string values. Used by `contextStringValue` and `fn:string`'s node argument. Without a provider/annotations, or for a non-element-only element, it is byte-identical to `ixpath.StringValue` — non-schema-aware runs and mixed/simple content are unchanged.
+**dm:string-value (schema-aware whitespace stripping).** `evalContext.nodeStringValue` (`functions_node.go`)
+computes an element/document node's string value and, in a schema-aware run (`ContentTypeKindProvider` +
+`typeAnnotations` present), strips INSIGNIFICANT whitespace: a whitespace-only text- or CDATA-section-node
+child of an element whose annotation resolves to ELEMENT-ONLY complex content is not part of the string value
+(XDM 3.1 PSVI construction), so `fn:string` / `fn:string-length` / `fn:normalize-space` with no argument
+(which use the string value) see only the child element string values. Used by `contextStringValue` and
+`fn:string`'s node argument. Without a provider/annotations, or for a non-element-only element, it is
+byte-identical to `ixpath.StringValue` — non-schema-aware runs and mixed/simple content are unchanged.
 
 ## SequenceType (used in `instance of`, `cast as`, etc.)
 

--- a/.claude/docs/xsd11-content-models.md
+++ b/.claude/docs/xsd11-content-models.md
@@ -1,60 +1,551 @@
 # XSD 1.1 — Content Models
 
-> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
+> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the
+> 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the
+> governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
 
 - **UPA weakening** (`check_upa.go` `entriesOverlap`: in 1.1 an element competing with a wildcard is not a cos-nonambig violation — the element wins). Element-over-wildcard precedence is enforced at validation, gated `vc.version == Version11`:
-  - CHOICE (`validate_elem.go` `matchChoice`/`tryMatchChoice`): a branch consuming the current child via an element leaf AS ITS FIRST CONSUMING TERM beats one consuming it via a wildcard, regardless of declaration order/nesting. Classifier `particleConsumesViaElement` → `particleFirstConsumerKind`/`groupFirstConsumerKind` is PATH-AWARE (compositor order, occurrences, emptiable prefixes via `particleEmptiable`), so a LEADING wildcard in a sequence (`sequence(any skip, element a)`) is wildcard-first and does NOT win precedence; bounded, no backtracking. Selection is COMMIT-NO-FALLBACK: once any branch is element-first the choice MUST use an element-first branch and NEVER falls back to a wildcard branch, even if the chosen branch then fails structurally (`choice(sequence(a:int, b:int), any skip)` with only `<a>`) or by content.
-  - SEQUENCE (`matchSequence`/`tryMatchSequenceOnce`/`tryMatchSequence` via `sequenceElementReservedLimit`, Version11): before matching each particle, the children a LATER element particle is element-first-consumer for are reserved (particle sees `children[:limit]`), so a leading minOccurs=0 wildcard does not consume required named elements. REACHABILITY-GATED: fires ONLY when the current particle would consume the child via a wildcard (element-vs-element stays in declaration order) AND only for a later element REACHABLE from the current position (every intervening particle emptiable, `particleEmptiable`); bounded lookahead, no backtracking, XSD 1.0 byte-identical.
-  - cos-nonambig position automaton carries a per-position ORIGIN tag (`firstSetEntry.origin`, `positionAutomaton.nextOrigin`): `applyOccurs` RESETS the counter before each occurrence copy, so all occurrence-copies of ONE textual element leaf (any depth, `(a{1,2}){1,2}`) share an origin while two DISTINCT leaves get distinct origins even when same-named and sharing an `*ElementDecl` through a group ref. `entriesOverlap` treats same-name/SAME-origin element positions as non-ambiguous, same-name/distinct-origin as a violation (`choice(a,a)`, `choice(ref g, ref g)`) — VERSION-INDEPENDENT (only element-vs-wildcard is version-specific). Same-origin dedup ALSO covers two WILDCARD positions: occurrence-copies of ONE `xs:any` (`sequence maxOccurs>1(any ##other maxOccurs>1)`, W3C addB194) never overlap, while two DISTINCT wildcards (`choice(any, any)`) overlap when namespace constraints intersect — so `sequence maxOccurs="100"(a maxOccurs="unbounded")` (W3C particlesZ034/Z036/V001/M035) is accepted in 1.0 too.
-  - Two guards keep these invalid schemas rejected: `checkAllGroupRef` (`link_refs.go`) rejects a DIRECT `xs:group ref` to an all group with `{min occurs}` > 1 (cos-all-limited, W3C particlesEa023); the XSD 1.0 derived-GROUP-restricting-base-ELEMENT path (`restriction_particle.go` `particleValidRestriction`) uses `groupRestrictsElement` ONLY when the base element is AT-MOST-ONCE (`MaxOccurs == 1`), else falls back to conservative `pointlessReduce` (§3.9.6 occurrence hoisting) so a repeating group or emptiable-group-over-multi-occur-member hole is still rejected (W3C particlesHb011).
-  - `groupLeavesRestrictElement` accepts a derived element leaf that is an instance-admissible SUBSTITUTION-GROUP member of the base element (`leafIsSubstMemberOfBaseElement`; W3C elemZ027). DIRECT element:element — `elementRestrictsElement`'s name-mismatch branch accepts a derived element that is an instance-admissible substitution-group MEMBER of the base AND validly restricts that concrete member (W3C elemZ027_e/f, particlesZ008), but ONLY from the DIRECT positional mapping (`recurseOrdered` sets `substElementRestrictionKey` exclusively for element-vs-element, so a group-mapping recursion — sequence:choice MapAndSum, choice/all reductions — does NOT inherit it) AND when the base element is AT-MOST-ONCE (`b.MaxOccurs == 1`). The flag confinement keeps a subst-member narrowing in a MapAndSum rejected (W3C particlesZ028 — invalid in 1.0/valid in 1.1); the `MaxOccurs == 1` gate keeps a subst member of a REPEATING base element rejected (W3C elemZ026, particlesV020). BOTH paths route through `derivedRestrictsSubstMemberOf`, resolving each side's EFFECTIVE type (`effectiveDeclType`, following an untyped member's substitution-head inheritance) into shallow decl copies before the NameAndTypeOK check (a derived LOCAL element sharing a member's name but widening its type is rejected; an unresolved derived type falls closed).
-  - `elementRestrictsElement`'s NameAndTypeOK derivation check is BUILT-IN-AWARE (`strictBuiltinAwareDerivedFrom`, version-INDEPENDENT — the 1.0 built-in simple types are not BaseType-linked), so derived `xs:int` restricting base `xs:integer` is accepted (W3C particlesHa120, stZ067). The whole check (built-in-aware derived-from plus the two gates below) is `elementTypeValidlyRestricts(rtType, btType, version)` (`restriction_particle.go`), used at every element-type-restriction site: direct element:element (`elementRestrictsElement`); the XSD 1.1 xs:all occurrence-counting path (`all_subsumption.go` `derivedElemNameAndTypeOK`, feeding `memberContributions`/`allRestrictsByCounting` AND `allRestrictsWithWildcards`); and transitively the substitution-member path (`derivedRestrictsSubstMemberOf`) and the language-inclusion fallback leaf (`restriction_subsume.go` `elemSymbolRestricts`). Derivation must be by RESTRICTION only (NameAndTypeOK clause 3.2.5.2, disallowed subset {extension, list, union}, version-INDEPENDENT): after confirming R's type derives from B's, `isDerivationBlocked(rtType, btType, BlockExtension)` rejects a type reaching B's through an EXTENSION step (W3C particlesIj008) or an UNRELATED same-structure type (the `!ok` check rejects that — W3C particlesL032). The list/union arm is NOT enforced — a list/union derived from `xs:anySimpleType` is unconditionally valid (Type Derivation OK (Simple) §3.16.3 clause 2.2.3; W3C stZ067/stZ068/stZ069, particlesIk014/Ik017/Ik018 expected-valid). UNCONDITIONAL (independent of `@block`), separate from the base-TYPE-`@block` cvc-elt.4.3 gate (`typeDerivationBlocked(rtType, btType, 0)`, same helper). A `type=`-form element ref prefers the TYPE symbol space over a same-named global element (`typeExistsForRef`, `link_refs.go`; W3C particlesL032). 1.1 keeps `groupRestrictsElement` for every base-element occurrence and reaches particlesZ028 through `particleLanguageSubset`.
-- **open content** (`opencontent.go`: `<xs:openContent>` interleave/suffix). Interleave seeds the DECLARED sub-sequence with every child matching a declared ELEMENT NAME or declared WILDCARD particle (`modelGroupWildcardAdmitsName` — the declared model may itself contain xs:any), routes the rest matching the open wildcard to open, then matches the declared model on the declared set. Suffix matches the declared model (resolved including declared wildcards) then requires every trailing child to match the wildcard. Interleave is REFINED to the §3.4.4.3.2 existential partition (`refineInterleavePartition`): a declared-seeded child the model cannot place — a STRUCTURAL blocker (extra occurrence after a bounded particle is exhausted, at the trial's `consumed` index) OR a child a declared STRICT/lax WILDCARD structurally CONSUMED whose CONTENT validation FAILED (trial errors with `consumed` at the end; the LAST open-eligible NON-declared-name child moves — a declared element NAME stays for element-precedence reporting, never spilled) — moves into open when it ALSO matches the open wildcard, found by TRIAL-matching with diagnostics suppressed (`suppressDepth++`) then re-running for real. Suffix open content inside an `xs:all` uses a LENIENT member matcher (`matchAll11(...lenient=true)` via `matchContentModelSuffix`) that stops at the first non-member child.
-- **Schema-level `<xs:defaultOpenContent>`** (`readDefaultOpenContent`): PER-DOCUMENT (captured on each complex type lacking an explicit `<xs:openContent>` as `TypeDef.pendingDefaultOpenContent`, saved/reset/restored across xs:include/xs:redefine/xs:override/import like the form defaults — an xs:override/xs:redefine REPLACEMENT child uses the OVERRIDDEN/redefining document's default per §4.2.5, threaded via `overrideLoadTarget`'s returned `*OpenContent`). Must appear before any component declaration; carries mode interleave|suffix (NOT none) and `appliesToEmpty` (default false). `@mode` is whitespace-COLLAPSED before the enum comparison (`normalizeWhiteSpace(.,"collapse")`, in parseOpenContent and readDefaultOpenContent); `appliesToEmpty` collapses via readBooleanAttr/parseSchemaBool, processContents via readProcessContents.
-  - **Effective {open content}** resolved BASE-FIRST by `resolveOpenContent`/`computeEffectiveOpenContent` (`resolveRefs`): explicit `<xs:openContent>` (mode="none" → absent, suppresses default) OR per-document default (unless the content type is empty and appliesToEmpty=false — `contentTypeEmptyForOpenContent`). EXTENSION inherits/merges base open content (§3.4.2.2: base interleave mode wins, wildcards union; may not relax base interleave to suffix — §3.4.6.2). RESTRICTION validity via §3.4.6.4 `checkOpenContentRestriction`: may not ADD open content to a closed base, derived wildcard a subset, derived pc at least as strong, mode may differ only when base is interleave (for an EMPTY derived content model only the MODE comparison is waived).
-  - **`baseModelAdmitsOpenContent`** (CONSERVATIVE-SOUND, fail-closed): a base lacking open content but whose declared model carries an admitting wildcard permits the restriction ONLY for the single PROVABLY-SOUND shape — EXACTLY ONE wildcard particle W, NO element-declaration particles anywhere (`baseModelWildcardScan.walk`), W's own occurrence minOccurs=0/maxOccurs=unbounded, every ANCESTOR group at-most-once (maxOccurs=1) — base language is EXACTLY W*, subset iff `wildcardConstraintSubset(derived,W)` with derived pc at least as strong. A min/max PRODUCT of 0..unbounded is NOT sufficient (sequence(0,unbounded){any(minOccurs=2)} gaps at 1). ANY EMITTING declared element disqualifies (even EMPTIABLE); a NON-EMITTING element (effective maxOccurs 0) does NOT (`baseModelWildcardScan.walk` threads an emitting flag). A second wildcard, a required/bounded wildcard, or any repeating ancestor group are conservatively deferred. open022 accepts; the declared-emptiable-sibling repro and the shared (G,G)* group-ref case reject.
-  - **QUADRANT A — derived OPEN re-admits base DECLARED** (`checkOpenContentDropsBaseLocal` for elements, `checkOpenContentDropsBaseWildcard` for wildcards): a restriction may not DROP a base element/wildcard and re-admit its name/namespace through an open-content wildcard that loses a base constraint. Both run in the restriction branch.
-    - Dropped base element, three unsoundness sources. TYPE loss — a dropped name re-admitted by an UNENFORCING wildcard (skip; or lax with NO global) escapes the base type → reject (strict/lax-with-global resolves a governing type the DYNAMIC wildcard-EDC enforces). CONSTRAINT loss — on the ENFORCED path the re-admitting GLOBAL must be at least as restrictive as the dropped base LOCAL (`localElementDeclsByName`, refs excluded) on the SIX properties the dynamic EDC does NOT enforce, all in `globalDropsLocalConstraint` (shared by dropped-local and kept-narrowed branches): a CTA {type table} not equivalent (`typeTablesConsistent`, absent-both=equivalent); a base-local `fixed` the global lacks/differs on in VALUE space (`fixedValueMatches` with each decl's FixedNS, NOT lexical — a QName/NOTATION same-lexical/different-prefix value is DIFFERENT, "1.0" vs "1.00" EQUAL); a global `nillable` while the local is not; a base-local identity constraint (xs:key/unique/keyref by resolved QName) the global lacks; a `block`/{disallowed substitutions} the local sets but the global lacks — the EFFECTIVE blocked set masked to derivation bits (`(local.Block | effectiveDeclType(local).prohibitedSubstitutions()) & derivBits` vs global's, `BlockExtension | BlockRestriction`, cvc-elt.4.3, nil-safe — SUBSTITUTION bit dropped, so `block="substitution"` re-admitted via an equivalent global is NOT over-rejected, while `validateWildcardChild` applies the GLOBAL's block so a base-local block="extension"/"restriction"/"#all" or TYPE block rejecting an xsi:type derivation is lost); or ASYMMETRICALLY a `default` the GLOBAL supplies but the local does not/differs on in VALUE space, DefaultNS-aware (`global.Default != nil && (local.Default == nil || !fixedValueMatches(...))`) → reject. ORDER loss — a SUFFIX-mode BASE requires a declared name in the prefix region, so a dropped suffix-base name is rejected for ANY pc (strict included); interleave imposes no ordering. The guard fires only when the derived open content ACTUALLY ACCEPTS the dropped name: a STRICT wildcard WITHOUT a matching global REJECTS the child (no spill), so the drop is EXEMPT.
-    - Kept base name (derived KEEPS it as a declared element): needs OCCURRENCE COVERAGE only in INTERLEAVE mode with an UNENFORCING wildcard — the EXCESS beyond the derived particle's maxOccurs spills into interleave open content (`refineInterleavePartition`); if the derived narrows below the base's effective maxOccurs (`maxOccursForName`, summing sequence/all members, max over choice branches, folding group maxOccurs, counting substitution members; `occursCovers`: unbounded base needs unbounded derived) the spill is unsound two ways — an UNENFORCING wildcard loses the TYPE → REJECT; an ENFORCING wildcard type-checks via the GLOBAL, losing the base local's fixed/nillable/identity constraints → REJECT when the global is not constraint-compatible (same `globalDropsLocalConstraint`; a strict wildcard without a global rejects the spilled child, so the check is skipped). When the derived COVERS the base occurrence no excess spills. SUFFIX is always safe for a kept name (trailing declared-name child rejected as misplaced).
-    - Name sets: the drop guard protects every name the base model ADMITS at runtime (`baseAdmissibleElementNames` mirrors `elemMatchesDeclOrSubst`): each element particle's OWN name when concrete PLUS its INSTANCE-ADMISSIBLE (abstract-excluded) transitive SUBSTITUTION-GROUP members (a derived wildcard excluding the head via notQName="h" but re-admitting member m loses m's type). A skip wildcard never enforces type; a ref/member under lax is exempt (a global exists). An abstract head's own name is excluded. A NON-EMITTING base name (effective base maxOccurs 0, own or ANCESTOR group via `mulOccurs`) is filtered out before the dropped/kept split. The DERIVED kept-name set and the SUFFIX misplaced-trailing-name set use `collectEmittingModelElementNames` (EMITTING particles, names `elemMatchesDeclOrSubst` can consume: own name when CONCRETE plus instance-admissible abstract-EXCLUDED substitution members via `instanceSubstMembers`) — a derived element narrowed to maxOccurs=0 counts as DROPPED, a non-emitting/abstract suffix name is open content. The INTERLEAVE name-split keeps `collectModelElementNames` (abstract-included) but is sound (the matcher cannot consume an abstract member; `refineInterleavePartition` moves it to open).
-    - RUNTIME `validateContentModelOpen` PRUNES non-emitting particles (`pruneNonEmittingParticles`: maxOccurs=0 particles, whole maxOccurs=0 groups, and any group emptied by pruning — propagating up). SEMANTICS-PRESERVING for xs:choice EMPTIABILITY: in a SEQUENCE/all parent an emptied member is dropped (required siblings stay required); in a CHOICE parent it is REPLACED by a normalized emptiable empty-SEQUENCE particle (minOccurs 0) so the choice still matches the empty string — never a literally-empty choice (else `choice(<empty>, g)` becomes `choice(g)` and falsely requires g). A DIRECT prohibited element leaf `choice(e{0,0}, g)` is dropped outright, g stays required (empty-branch handling fires only on a GROUP that prunes empty). Pruning at the top BEFORE matching stops a DIRECT prohibited particle consuming a child (`matchElementParticle` grabs one child before its maxOccurs check) — the child falls to open content in suffix and interleave. A fully non-emitting model prunes to zero particles, NORMALIZED to an empty sequence (minOccurs=0). One non-emitting definition across `baseModelAdmitsOpenContent`, the drop guard, suffix+interleave validation, and the runtime matcher; scoped to Version11 `validateContentModelOpen`, ordinary matcher byte-identical.
-    - `materializeOpenContentSiblings` (from `computeEffectiveOpenContent` on the LOCAL effective open content BEFORE any extension union / restriction check / base inherit): populates `SiblingNames` on an open-content/defaultOpenContent wildcard carrying ##definedSibling (the type's own content-model element names), CLONING the wildcard first (shared across types). `wildcardExcludesName` checks `SiblingNames`, not the marker. Must run BEFORE the extension union (`wildcardUnion`/cos-aw-union computes union `SiblingNames` from the operands', retaining a sibling neither admits) so a one-sided union retains the sibling as a finite exclusion even when the live marker is folded away; base operand materialized BASE-FIRST. A name the derived wildcard EXCLUDES (notQName/##defined) is exempt; xsi:type is instance-driven, not a compile-time name source. The dropped-name rule keys on the BASE's mode (suffix→reject any pc; interleave→reject only if unenforcing); the kept-name coverage keys on the DERIVED's mode (interleave-only). Suffix is the only mode imposing ordering.
-    - `checkOpenContentDropsBaseWildcard` (symmetric, dropped/narrowed base DECLARED WILDCARD): a declared xs:any wins attribution (interleave seeds it via `modelGroupWildcardAdmitsName`, suffix matches it in the prefix; a suffix leftover declared-WILDCARD match is NOT flagged misplaced so it spills). For each emitting base wildcard bw (`collectEmittingDeclaredWildcards`, effective max) whose namespace the derived OPEN wildcard re-admits (`constraintsIntersect` FIRST — an open content excluding bw's namespace is exempt; AND for a STRICT open, `strictOpenAdmitsGlobalIn` — no global in bw's region → exempt) AND where the open does not enforce at least as strictly (interleave: open pc weaker than bw; SUFFIX: ANY pc), check AGGREGATE occurrence coverage over the SPILL-RELEVANT REGION = bw's namespace ∩ the derived open wildcard's (`spillCon = constraintIntersect(bwCon, openCon)`; `spillWC = constraintToWildcard(spillCon)`): baseCap = sum effMax over base wildcards INTERSECTING the region with pc≥bw's; derivedCap = sum over derived wildcards namespace-SUPERSETTING it (`wildcardConstraintSubset(spillWC, dw)`) with pc≥bw's; `!occursCovers(derivedCap, baseCap)` → reject (suffix=order loss / interleave=type loss). Fail-closed accounting; UPA forbids two overlapping declared wildcards in one content model, so it reduces to single-wildcard coverage for constructible schemas.
-  - **QUADRANT B — derived DECLARED wildcard re-admits BASE OPEN** (`checkDerivedWildcardReadmitsBaseOpen`): a restriction may DROP the base's open content O and re-introduce its language as a declared wildcard (restriction_particle.go's Wildcard-restricting-ModelGroup conservatism compiles it), and a declared wildcard WINS attribution so its pc governs, not O's. For each emitting derived declared wildcard whose namespace intersects O, unless it VALIDLY RESTRICTS a base DECLARED wildcard (W_d ⊆ W_b, pc≥ — quadrant D), it must validly restrict O: for INTERLEAVE O, namespace ⊆ O AND `processContentsStrength(W_d)` ≥ O's (else REJECT); for SUFFIX O the trailing-ORDERING cannot be preserved by a non-trailing declared wildcard, so re-admitting O's namespace is REJECTED — but only when the derived wildcard ACTUALLY admits a child there (skip/lax always; a STRICT derived wildcard with NO matching global admits nothing via `strictOpenAdmitsGlobalIn` → EXEMPT, mirroring the quadrant-A strict/no-global exemption). A base WITHOUT open content is unaffected.
-  - **Four quadrants** for restriction subset: (A) derived OPEN re-admits base DECLARED → `checkOpenContentDropsBaseLocal`/`checkOpenContentDropsBaseWildcard`; (B) derived DECLARED wildcard re-admits base OPEN → `checkDerivedWildcardReadmitsBaseOpen`; (C) derived OPEN vs base OPEN → `checkOpenContentRestriction`; (D) base DECLARED vs derived DECLARED → `restriction_particle.go`. SUFFIX base-mode ORDERING preserved in every quadrant: A (drop guards reject a dropped suffix-declared name / spilled suffix wildcard for ANY pc), B (rejects a derived declared wildcard re-admitting a suffix base open content), C (`checkOpenContentRestriction` rejects a mode change off a suffix base; an interleave base may not be extended to suffix). D's Wildcard-vs-ModelGroup case is conservative (a derived declared wildcard re-admitting a base declared ELEMENT's name under skip/weaker validation is a RESIDUAL not covered by B).
-  - **Grammar/child-order**: the `<xs:any>` of open content must NOT carry minOccurs/maxOccurs (`parseOpenContentWildcard`); an open-content element (xs:openContent OR xs:defaultOpenContent) has a STRICT (annotation?, any?) child grammar (`scanOpenContentChildren`/`reportOpenContentChildGrammar`: any stray child a schema error); mode="none" must not carry a wildcard child; a complex type must not have >1 xs:openContent (all three parse loops). VALIDATION enforces effective open content on a type with NO declared model group (`validate.go`: a mixed-or-appliesToEmpty type picking up a defaultOpenContent does not admit arbitrary children via `annotateAnyTypeChildren` — every child element must match the open wildcard, mixed text allowed), so all four ContentType branches enforce `td.OpenContent`. CHILD ORDER (§3.4.2, `openContentOrderViolation`, all three complexType parse loops): xs:openContent PRECEDES the content-model particle, attribute uses, anyAttribute, and trailing xs:assert region, and is NOT a sibling of an xs:simpleContent/xs:complexContent wrapper (direct complexType grammar is a CHOICE — wrapper branch (simpleContent|complexContent) or non-wrapper branch (openContent?, particle?, attrs, anyAttribute?, assert*), so every non-wrapper child kind is mutually exclusive with a wrapper in BOTH orders, including xs:assert; assert 1.1-only, guards never affect 1.0). xs:openContent is rejected INSIDE a simpleContent extension/restriction (`parseSimpleContentChildren`).
-    - `<xs:complexContent>` and `<xs:simpleContent>` share `(annotation?, (restriction | extension))`, enforced by `parseDerivationWrapper` in BOTH 1.0 and 1.1 (version-INDEPENDENT): a ZERO/SECOND derivation, an annotation AFTER, or any stray child (notably a trailing `<xs:openContent>`) is a schema error. In the OUTER `parseSimpleContent`. Valid-wrapper dispatch byte-identical; only invalid forms newly rejected in 1.0. The direct complexType `assert*` trailing region: a particle/attribute/attributeGroup/anyAttribute AFTER an `<xs:assert>` is out of order (the `assertSeen`/`contentWrapperChild` mutual-exclusion guards never affect 1.0).
-    - DERIVATION-BODY grammar (version-INDEPENDENT), child ORDER/CARDINALITY enforced (reject-stray, LEAF parsers untouched): the complexContent body `(annotation?, openContent?, (group|all|choice|sequence)?, ((attribute|attributeGroup)*, anyAttribute?), assert*)` parsed by `parseComplexContentDerivationBody` (parseRestriction/parseExtension thin wrappers, kind-parameterized for the extension prohibited-attr warning). simpleContent bodies (`parseSimpleContentChildren`): restriction `(annotation?, simpleType?, facet*, (attribute|attributeGroup)*, anyAttribute?, assert*)` and extension `(annotation?, (attribute|attributeGroup)*, anyAttribute?, assert*)` — facets/simpleType only in restriction (`isSimpleTypeFacetElement`). openContent/assert body cases stay Version11-gated (in 1.0 an `<xs:openContent>`/`<xs:assert>` in a body is a stray child).
-    - DIRECT `<xs:complexType>` child grammar enforces the ANNOTATION rule version-INDEPENDENTLY (at most one, must be FIRST child). Its stray-rejecting default (only annotation, simpleContent, complexContent, openContent, a model-group particle (group|all|sequence|choice), attribute, attributeGroup, anyAttribute, assert — else schema error, e.g. a direct `<xs:element>`) stays Version11-gated (1.0 keeps prior lenient default). A schema-level xs:defaultOpenContent must FOLLOW the composition elements (include/import/redefine/override). `<xs:complexContent>`/@mixed honored version-INDEPENDENTLY, must not conflict with `<xs:complexType>`/@mixed, and an extension's content type and its base's must both be mixed or both element-only (§3.4.6.2 cos-ct-extends). A global `<xs:complexType>`/@name must be a valid `xs:NCName` (`parseNamedComplexType` via `xmlchar.IsValidNCName`; version-INDEPENDENT).
-  - **KNOWN GAPS**: whitespace in a genuinely-EMPTY (`<xs:sequence/>`, empty/no model group) element-only content type with no effective open content IS rejected in 1.1 (`validate.go` `validateContentByType`: an `ContentTypeElementOnly` type with no content per `modelGroupHasContent` routes to `validateEmptyContent(..., strict=true)`, rejecting ALL character content per cvc-complex-type.2.1; open012.n3 — read_types.go still classifies an empty compositor as element-only with a non-nil empty model group, so emptiness is detected at validation; 1.0 keeps the whitespace tolerance, byte-identical). GAP: an attribute-only `ContentTypeEmpty` complex type still tolerates whitespace-only character content in 1.1 (a pre-existing false-accept, not in the W3C suite; the fix landed only for the element-only-misclassified `<xs:sequence/>` case, NOT the genuine `ContentTypeEmpty` classification). Schema-component `@id` uniqueness/NCName validity IS enforced (`check_ids.go` `checkSchemaComponentIDs`: a DOM walk validating every XSD-namespace element's `id` as a valid xs:ID — NCName after whitespace-collapse — unique within the document; open038/open039; version-INDEPENDENT). Does NOT descend into xs:appinfo/xs:documentation PAYLOAD, but an xs:annotation's OWN `id` participates. Run on EVERY schema document with a FRESH per-document `seen` set — entry (`compile.go`), each xs:include/xs:redefine document (`compile_imports.go`), xs:import (sub-compiler, via `propagateImpErrors`), xs:override (`override.go`) — after conditional-inclusion pruning. xs:ID uniqueness is PER-DOCUMENT (same value may recur ACROSS documents, not within one).
-- **element restriction disallowed-substitutions superset** (version-INDEPENDENT, §3.9.6 NameAndTypeOK 3.2.4): `restriction_particle.go` `elementRestrictsElement` rejects a derived element whose `{disallowed substitutions}` (`@block`, blockDefault-folded) is not a superset of the base element's (`bt.Block &^ rt.Block != 0`), so a base `block="#all"` cannot be restricted by a derived `block="extension"`.
-- **complexType `{prohibited substitutions}` (block) in cvc-elt.4.3 / Substitution Group OK** (version-INDEPENDENT): `parseComplexType` (`read_types.go`) stores each complex type's `@block` (folded with schema-level `blockDefault`, masked to `{extension, restriction}`) on `TypeDef.Block`; a type silent on block (including every anonymous complexType) picks up `blockDefault`. `typeDerivationBlocked(derived, base, elemBlock)` (`validate_elem.go`) centralizes the effective-block gate: `isDerivationBlocked` with the UNION of `elemBlock` and the BASE type's `TypeDef.Block` (nil-safe `TypeDef.prohibitedSubstitutions`), masked to derivation bits, so a derivation blocked by the TYPE's `@block` is rejected even when the referring element declaration carries no block. Sites: the xsi:type checks (`validate.go`/`validate_elem.go` — root, per-child particle, xs:all, xs:anyType/lax, strict-wildcard child); the dynamic wildcard-EDC (`validateWildcardElementConsistent`); substitution-group membership (`substitutableMembersFor` feeding the 1.0 matcher, UPA, and the 1.1 instance path via `instanceSubstMembers`; static `foldSubstitutionMembers` in `check_element_consistent.go`). The two substitution sites use `substTypeDerivationBlocked` (`validate_elem.go`): applies the head/base gate, then walks the member's `BaseType` chain and rejects when any INTERMEDIATE complex type's `Block` prohibits a method used anywhere in the member-down-to-that-intermediate suffix (Substitution Group OK / Transitive §3.3.6.3, via `isDerivationBlocked(derived, mid, mid.Block & derivBits)` — full suffix, nil-safe) — so `Base <- Mid(block="extension") <- R(restriction) <- Leaf(extension)` is not substitutable for a head of type `Base` even though neither `Base` nor the head element blocks extension. Only the substitution-group path considers intermediate-type blocks; xsi:type and CTA stay on `typeDerivationBlocked`. Also: CTA `<xs:alternative>` substitutability (`checkAltSubstitutability`, `alternative.go`, Version11 — `xs:error` always allowed, else validly substitutable AND not blocked by the element's effective block); and ordinary particle-restriction element retyping (`elementRestrictsElement`, `restriction_particle.go` — a derivation the base TYPE's block forbids rejects the restriction).
-- **complexContent restriction mixedness** (cos-ct-restricts clause 5.3.2, version-INDEPENDENT): the `resolveRefs` restriction loop (`link_refs.go`) rejects an element-only base restricted to a mixed derived type — ASYMMETRIC (a mixed base MAY be restricted to element-only, not the reverse), unlike the symmetric extension rule cos-ct-extends enforced alongside it.
-- **src-redefine.6.2 group restriction (sound core)** (§4.2.3, version-INDEPENDENT): `checkRedefineGroupRestriction` (`compile_imports.go`) rejects a no-self-reference redefining `<xs:group>` that REQUIRES an element the original group forbids (`maxOccurs=0`) — the provably-sound core (a no-self-reference group is otherwise a documented clause-6.2 gap).
-- **wildcard `notNamespace`/`notQName`** (`xs:any`/`xs:anyAttribute`): `readWildcard` (`read_elements.go`) parses `@notNamespace` (an `xs:basicNamespaceList` of anyURI/`##targetNamespace`/`##local`, mutually exclusive with `@namespace`; an EMPTY list `notNamespace=""` is VALID — a `not` with an empty excluded set admitting ALL namespaces, a NON-NIL empty slice distinct from an ABSENT/nil, `wildcardMatches` treats it as "excludes nothing") into `Wildcard.NotNamespace`, and `@notQName` (QName/`##defined`/`##definedSibling`) into `Wildcard.NotQName`/`NotQNameDefined`/`NotQNameDefinedSibling` (`schema.go`). `wildcardMatches` excludes `NotNamespace`; `wildcardAllowsExpandedName`/`wildcardExcludesName` (`validate_elem.go`) add name-level `notQName`/`##defined` exclusion (consulting `schema.elements`/`schema.globalAttrs`), used by element content (`matchWildcardParticle`, `matchAll`), attribute (`validateWildcardAttr`, `validate.go`), and open content. `##definedSibling` resolved post-`resolveRefs` by `resolveDefinedSiblings` (`opencontent.go`) into `SiblingNames`. The UPA overlap test (`check_upa.go` `firstSetEntry.wc`, `wildcardsOverlap`→`constraintsIntersect`) and the restriction-subset check (`wildcardConstraintSubset11`, `wildcard_algebra.go`) are 1.1-aware — the latter rejects a derived wildcard DROPPING a `##defined` the base carries, or (for `##definedSibling`) whose resolved `SiblingNames` is NARROWER than the base's (iterates `super.SiblingNames`, requires `sub` to exclude each).
-  - `resolveDefinedSiblings` runs INSIDE `resolveRefs` (after group-ref expansion, before restriction-derivation checks), visiting ALL parsed complex types — named `schema.types` AND inline ANONYMOUS (iterating `c.typeDefSources` keys, deduped by `*TypeDef`). Content-model trees are SHARED across types (group-ref expansion reuses the group's particle slice; type extension embeds the base model-group pointer), so it DEEP-CLONES a type's content model (`cloneModelGroupForSiblings` — fresh ModelGroup/Particle/Wildcard, ElementDecls shared read-only) before assigning `SiblingNames`, else one type's set could overwrite another's through the shared `*Wildcard` (NONDETERMINISTIC). Clone taken only for Version11 types whose model carries a `##definedSibling` wildcard (`modelGroupHasDefinedSibling`).
-  - Restriction-derivation functions thread `*Schema` (and an `isAttr` flag into `wildcardConstraintSubset`/`wildcardConstraintSubset11`) so EVERY derivation site uses the full `wildcardAllowsExpandedName` (notQName/`##defined`-aware): `wildcardAllowsName` (element-restricts-wildcard); `checkRestrictionAttrs` (`link_refs.go`, a derived CONCRETE attribute vs base `anyAttribute`, isAttr=true); the per-name SUBSET checks in `wildcardConstraintSubset11` (cos-ns-subset — each name `super` disallows must be DISALLOWED by `sub` under the full test, so a derived wildcard's `##defined` can discharge a base wildcard's `notQName="g"` when `g` is globally declared, while `super.NotQNameDefined && !sub.NotQNameDefined` still requires `sub` to carry `##defined`). `##definedSibling` permitted ONLY on element wildcards (`parseNotQName` rejects it on `xs:anyAttribute`, `isAttr` flag from `readWildcard`).
-  - A normalized wildcard algebra (`wildcard_algebra.go`: `wcConstraint` + union/intersection) drives attribute-wildcard UNION (extension, `wildcardUnion`) and INTERSECTION (the type's "complete wildcard" across `xs:attributeGroup` refs — group wildcards in `attrGroupWildcards`, intersected in `link_refs.go`). `attrGroupWildcards` is initialized AND merged into the parent in import sub-compilers (`compile_imports.go`); the `xs:redefine` override path parses the group's `xs:anyAttribute`, clears the stale base wildcard, intersects a self-reference's original, and stores the replacement. A group's `xs:anyAttribute` must be the optional FINAL, unique child (`parseNamedAttributeGroup` and the redefine override, Version11). `notQName` tokens validated with `internal/xmlchar.IsValidQName` (accepts non-ASCII XML NameChars) and resolved with `resolveNotQName` (NOT `resolveQName`): QName ACTUAL VALUES, so an UNPREFIXED token resolves through the in-scope DEFAULT namespace, or ABSENT when none — NEVER the schema's `targetNamespace`.
-  - `constraintToWildcard` and its union/intersection callers carry `SiblingNames` through materialization (intersection unions the sibling exclusions; union retains names neither operand admits). A materialized union may retain `SiblingNames` even when the `NotQNameDefinedSibling` MARKER is dropped (marker survives only when BOTH operands carry it); those names are still first-class exclusions, so `wildcardHas11Fields` counts `len(SiblingNames)>0` as 1.1 state and `wildcardConstraintSubset11` checks `super.SiblingNames` UNCONDITIONALLY, the marker-only reject kept solely for the live open-ended case. Intersection carries the STRONGER processContents (`strongerProcessContents`, strict>lax>skip) — ORDER-INDEPENDENT. The 1.1 UNION (`unionWildcards11`) takes the SECOND operand's pc: its only pc-sensitive caller is TYPE EXTENSION, which passes `wildcardUnion(base, derived)`, and per XSD 3.4.2 the extension takes the DERIVED wildcard's pc. Routing is VERSION-aware: `wildcardUnion(w1, w2, version)` routes to `unionWildcards11` for EVERY `Version11` union (plus a defensive 1.1-field fallback), keeping the legacy 1.0 case analysis STRICTLY for `Version10` (byte-identical; the 1.0 path keys pc on `w1` and approximates `##other|##local` as `##any`). UNION `{disallowed names}` follows cos-aw-union (§3.10.6.3): a candidate QName is excluded iff NEITHER operand admits it by NAMESPACE-and-explicit-`notQName` (`wildcardAdmitsNameIgnoringDefined`); `##defined`/`##definedSibling` folded ONLY as whole markers (kept iff BOTH carry them), NOT per-QName — so a global-attr name one operand excludes via `##defined` but admits by namespace, the other excluding it explicitly, is still ADMITTED (W3C wild083 `surprise`).
-  - `xs:all` may contain wildcards — matched by `matchAll` (Version11, 1.0 byte-identical); restriction by `allRestrictsWithWildcards` (`restriction_particle.go`) enforcing per-base-wildcard MIN and MAX cardinality (MAX only for base wildcards that EXCLUSIVELY own their namespace). CONCRETE derived elements admitted by a base wildcard participate in that accounting keyed on their exact name. A derived wildcard's pc must be at least as strong as EVERY base wildcard it INTERSECTS. A GLOBAL attribute in the XSI namespace is rejected (no-xsi) — `parseGlobalAttribute` (`read_elements.go`), gated Version11 (the pre-existing LOCAL-qualified-attribute XSI check in `check_elements.go` untouched for 1.0).
-  - All gated `Version11`; 1.0 ignores notNamespace/notQName and does NOT merge group wildcards into a type's `{attribute wildcard}` at validation. 1.0 DOES record each attribute group's `xs:anyAttribute` diagnostic-free in `attrGroupWildcards` (`parseNamedAttributeGroup`, via `quietProcessContents`, namespace + pc only) so the COMPILE-TIME restriction check (`checkRestrictionAttrs` `effectiveAttrWildcard`, 1.0 only) can recognize a base whose attribute wildcard comes SOLELY through a referenced group: a DIRECT `td.AnyAttribute` is returned as-is and NEVER narrowed; only when nil does it fill in the FIRST group-ref complete wildcard (`attrGroupCompleteWildcard`) so a transitive-only base satisfies derivation-ok-restriction 4.1 and is compared for 4.2/4.3 (a valid `##other`-adding restriction of `schema-for-xslt20.xsd`'s `transform-element-base-type` compiles; a widening derived wildcard still rejected). In 1.1 group wildcards are already merged into `td.AnyAttribute`. The multi-group intersection and the base-chain-inherited-via-extension transitive-group case are not modeled (fail-closed). The derived side still uses direct `td.AnyAttribute` in 1.0, so a derived wildcard contributed only via a group ref does not trigger the 4.x checks (1.0 byte-identical).
-- **xs:all relaxations** (Saxon `All.testSet` 62/62; gated `Version11`, 1.0 byte-identical): the all group's OWN maxOccurs may be 0 or 1 in 1.1 (`check_elements.go` `validateAllOccurs`; 1.0 requires exactly 1 — mgO001/mgO018); element members may carry `minOccurs`/`maxOccurs>1`/`unbounded` (`check_elements.go` `checkAllElementParticleOccurs`); `xs:all` may contain element WILDCARDS; an `xs:group ref` resolving to an all group may be nested directly inside another `xs:all` with occurrence 1/1 (flattened — `link_refs.go` `checkAllGroupRef`/`groupRefSource.parentCompositor`; a referenced sequence/choice or occurrence ≠ 1/1 rejected; an INLINE `<xs:all>` directly inside an `<xs:all>` is also rejected — cos-all-limited, `read_particles.go`).
-  - `matchAll`/`tryMatchAll` (`validate_elem.go`) DISPATCH by version: 1.0 keeps the legacy boolean-`seen[]` matcher (`matchAll10`/`tryMatchAll10`) BYTE-IDENTICAL; 1.1 uses a FLAT member list (`flattenAllMembers`) with PER-MEMBER occurrence counting (`matchAll11`/`tryMatchAll11`) — element members (matched only when ADMISSIBLY substitutable via `elemMatchesDeclOrSubst`/`allMemberForChild`, honoring block="substitution"/derivation-block and rejecting abstract heads AND abstract substitution members), wildcard members, and flattened nested-all members, all ORDER-INDEPENDENT against each member's min/max.
-  - Restriction subsumption of a base `xs:all` is occurrence-COUNTING per BASE MEMBER (`all_subsumption.go` `allRestrictsByCounting`/`memberContributions`, from `restriction_particle.go` `groupRestrictsGroup` for Version11 no-wildcard all:all / sequence:all / choice:all): the derived contribution is computed PER base-member index (a choice's branches correlate on the base member — `choice(A1{2},A2{2})` with A1/A2 in base member a's substitution group restricts a{2}), a derived element maps to a base member by name or substitution group (`findBaseAllMember`, using `admissibleSubstitutionMember`) with a BUILT-IN-AWARE NameAndTypeOK check (`strictBuiltinAwareDerivedFrom`), a non-emitting particle contributes nothing, and every unmapped base member must be emptiable. Wildcard cases route to `allRestrictsWithWildcards`, which FLATTENS nested 1/1 all-groups on both sides (`flattenAllParticles`) and SUMS concrete derived elements per base element before accounting against the base wildcards' cardinality; a nested NON-all derived group surviving flattening is rejected (fail-closed).
-  - An `xs:all` may be EXTENDED by another `xs:all` (`link_refs.go` extension loop merges the two member sets into a SINGLE all group — both must be all groups with the SAME minOccurs; a sequence/choice extending an all, or vice-versa, rejected; an open-content `interleave` base may not be extended to `suffix`).
-  - **Empty-base extension by an `xs:all`** (§3.4.2 effective content, version-INDEPENDENT — the 1.0 path too): when the base type's effective content is EMPTY (an empty `xs:all`/`xs:sequence` model group) and the derived particle is an `xs:all`, the extension's content model is the derived `xs:all` ALONE — the base contributes nothing, so no wrapping sequence is formed (which would nest an `all` inside a sequence, forbidden by All Group Limited and falsely rejecting a valid instance — W3C `mgZ003`: an `xs:group` ref to an all group extending an empty base `xs:all`). The `link_refs.go` extension merge's derived-`all`-over-empty-base case sets `td.ContentModel = derivedMG`; a non-empty base keeps the sequence merge, byte-identical.
-  - UPA over all members (`check_upa.go` `walkAllBody`) is fed by MULTI-HEAD substitution groups (`substitutionGroup="a b"` registers the member under every head — `read_elements.go`/`compile.go` `buildSubstGroups`, `ElementDecl.SubstitutionGroups`). UPA competition is by DECLARATION membership, so an ABSTRACT substitution member STILL competes (XSD 1.1 §3.8.6.4 / bug 4337) — `walkTerm` does NOT skip abstract members (instance MATCHING does, via `elemMatchesDeclOrSubst`/`admissibleSubstitutionMember`).
-  - Substitution-group membership: a TRANSITIVE, cycle-guarded closure (`substitutableMembersForUncached`, `subst_closure.go`) SEPARATING traversal from inclusion — an edge is traversed unless block/derivation-blocked (`substTypeDerivationBlocked`; ABSTRACT members traversable) so a concrete descendant behind an abstract intermediate (`h <- abstract m1 <- concrete m2`) is reached; `block="substitution"`/derivation-block PRUNE the subtree. TWO variants differ only in inclusion: `instanceSubstMembers` includes only CONCRETE (abstract excluded) — runtime matching (`elemMatchesDeclOrSubst`) and restriction subsumption (`findBaseAllMember`); `substitutableMembersFor` (DECLARATION membership, abstract INCLUDED) — UPA (`walkTerm`) and the 1.0 matcher (`matchAll10`/`tryMatchAll10`/`resolveSubstDecl`). A substitution group is a property of the GLOBAL head declaration (or a `ref`), so a distinct LOCAL element particle sharing a head's QName admits NO members (version-INDEPENDENT: elemZ011/elemZ021b/elemZ021f/elemZ023). The cos-element-consistent fold (`check_element_consistent.go` `collectContentModelElements` → `foldSubstitutionMembers`) applies the SAME gate.
-  - The closure of every global head is precomputed once, at the very end of `compileSchema`, into `Schema.substClosures` (`subst_closure.go` `buildSubstClosures`): a map keyed by the head's QName holding its full closure, an abstract-filtered concrete subset, and — above `substClosureByNameThreshold` members — a by-name index. `substitutableMembersFor`, `instanceSubstMembers`, and `substMemberFor` (the byName-indexed lookup behind `elemMatchesDeclOrSubst`/`resolveSubstDecl`) resolve through `lookupSubstClosure`, serving a global head or a resolved `ref` straight from the cache. `substClosures` is nil for the whole of `compileSchema` — built as the LAST step, after every compile-time check has read `substGroups`/`elements` — so every compile-time caller (UPA, cos-element-consistent, restriction subsumption, open content) still runs `substitutableMembersForUncached` directly against a schema that has not finished compiling. `schemaWithInstanceHints` (`instance_schema_location.go`) rebuilds the cache after merging `xsi:schemaLocation`-contributed substitution-group members, so a member contributed only by an instance hint is still found.
-  - A nilled element with whitespace-only character content is rejected in 1.1 (cvc-elt.3.2.1; 1.0 tolerates it). all308 (an empty mixed `xs:all` base extended by an all — bug 6202, RESOLVED WONTFIX 2008-11-21, invalid per All Group Limited §3.8.6.2) is correctly REJECTED in `link_refs.go`, while an empty *non-mixed* base stays valid.
-- **Particle restriction language-inclusion fallback** (`restriction_subsume.go` `particleLanguageSubset`, gated Version11): the 1.0 syntactic Particle Valid (Restriction) clauses (`restriction_particle.go`) are known-incomplete and reject many restrictions whose derived content-model LANGUAGE is genuinely a subset of the base's (particlesHa161/Hb008/Hb011/Z001/Z028). When the syntactic check FAILS in 1.1, `checkRestrictionParticles` PROVES `L(derived) ⊆ L(base)` by product simulation of the two content-model automata over the finite alphabet of derivable names. FAIL-CLOSED / SOUND: accepts only on a rigorous inclusion proof (each derived element declaration validly restricting via `elementRestrictsElement` every same-named base declaration — a base wildcard imposes no type constraint), returning "not proven" (keeping the rejection) for anything it cannot represent — a DERIVED wildcard, an xs:all group, or an over-large occurrence unroll (`subsumeNFAStateCap`/`subsumePairStateCap`/`subsumeUnrollCap`). Element leaves expand to instance-admissible substitution-group members; a base wildcard matches every admitted name (`wildcardAllowsName`). Runs only as a fallback AFTER the syntactic check and only ACCEPTS; XSD 1.0 keeps the syntactic verdict, byte-identical.
-- **Content-model instance occurrence backtracking** (`content_backtrack.go`, version-INDEPENDENT): the runtime matcher (`validate_elem.go` `matchSequence`/`matchChoice`/`matchElementParticle`) is GREEDY, so an occurrence-partition-ambiguous but UPA-clean model false-rejects a VALID instance by starving a later required occurrence (`sequence minOccurs=2 (a{1,2}, b?)` over `a,a,b`; W3C ctZ006/ctZ008/ctZ009/ctZ009_b/ctZ009_d/addB176).
-  - A PROHIBITED particle (maxOccurs=0) consumes ZERO children in the greedy matcher too (version-INDEPENDENT): `matchElementParticle`/`tryMatchElementParticle` enforce MaxOccurs BEFORE consuming, and `matchAll10`/`tryMatchAll10` exclude a maxOccurs=0 member from the by-name map (`matchAll11`/`tryMatchAll11` already via the per-member `count < max` guard) — a prohibited element present in the instance is "not expected" (W3C addB092).
-  - `validateContentModelTop` FIRST runs the pure greedy try (`tryMatchModelGroup`, no side effects): if it fully consumes, the greedy matcher runs for real (`matchContentModelFull`) — common path unchanged, byte-identical. Only when greedy CANNOT fully consume does `contentModelAccepts` decide via bounded backtracking. The model is kept INTACT: a PROHIBITED particle (effective maxOccurs=0 — element leaf via `btReachElem`, or a group via `btReachGroupAt`, covering own OR ancestor group maxOccurs 0) is given SKIP-ONLY reach — the zero-occurrence endpoint, NEVER a consume branch. Correct both ways: `sequence(seq{2,2}(x+), a{0,0}, b)` over `x,x,a,b` REJECTS (`a{0,0}` cannot consume `<a>`), yet a maxOccurs=0 particle inside an `xs:choice` still contributes the empty (ε) branch keeping a NULLABLE choice nullable (`sequence(seq{2,2}(x+), choice(a{0,0}, b))` over `x,x` ACCEPTS via the empty `a{0,0}` branch). Pruning would drop a direct maxOccurs=0 choice leaf and wrongly make the choice non-nullable.
-  - Backtracking runs ONLY inside a provably-safe ENGAGEMENT ENVELOPE (`inBacktrackEnvelope`, a one-pass walk; outside it defers to greedy — fail-closed). ALL three conditions must hold: (1) EMITTING-WILDCARD-FREE (no child-consuming `xs:any` at any depth; maxOccurs=0 wildcards skip-only) — eliminates the XSD 1.1 element-over-wildcard precedence class; (2) UNAMBIGUOUS name→declaration — no two DISTINCT element-declaration leaves share a name (a UPA-clean model may still contain positional same-name locals differing in nillable/fixed/default, e.g. `sequence(a nillable=true, a nillable=false)`); (3) NO substitution complication — no element leaf is a substitution-group head with INSTANCE-admissible concrete members. Within the envelope every child's name selects its UNIQUE declaration.
-  - Computes, memoized, the reachable end positions for each (element|group, position) state — an element leaf contributes `pos+k` for every `k∈[minOccurs, feasible]`, a sequence composes its particles' reach sets, a choice unions its branches', each compositor applies its `{minOccurs, maxOccurs}` with an emptiable-body zero-length pad — using the SAME per-child predicate as the greedy matcher (`elemMatchesDeclOrSubst`). FAIL-CLOSED: a hard `btStateCap` returns "not proven"; `xs:all` groups matched greedily (`btReachAll`: deterministic per-member counting, no occurrence backtracking). An OPTIONAL `xs:all` (minOccurs=0) additionally contributes the zero-consumption SKIP endpoint (mirroring the greedy minOccurs==0 skip that `tryMatchAll` itself does not apply); only that endpoint is added, never a partial all match.
-  - When acceptance is proven, `validateContentModelChildren` validates each child against its unique element leaf declaration (`elemLeafForChild` first-name-match; content/type/xsi:type/assertion/IDC-annotation side effects match the greedy path), visiting each child once and reusing `matchElementParticle`. Runs only as a recovery AFTER greedy fails, only inside the envelope, and only ACCEPTS; the greedy path stays authoritative.
-- **Particle-restriction occurrence relaxation** (`restriction_particle.go` `occurrenceEmptiableRestriction`): an EMPTIABLE base group particle has an effective minOccurs of 0, so a derived group may narrow a base group{1,1} whose content is emptiable to {0,1}. Wired into the `groupRestrictsGroup` choice:choice case AND the base-all cases — both the XSD 1.1 occurrence-COUNTING fast-path (`bg.Compositor == CompositorAll`, no wildcards, gating `allRestrictsByCounting`) and the all:all switch branch (gating `recurseAll`/`allRestrictsWithWildcards`). The emptiable-base sequence:sequence case is handled by `particleLanguageSubset`. Gated Version11; XSD 1.0 keeps the strict `rMin >= bMin` check, byte-identical.
+  - CHOICE (`validate_elem.go` `matchChoice`/`tryMatchChoice`): a branch consuming the current child via an
+    element leaf AS ITS FIRST CONSUMING TERM beats one consuming it via a wildcard, regardless of declaration
+    order/nesting. Classifier `particleConsumesViaElement` →
+    `particleFirstConsumerKind`/`groupFirstConsumerKind` is PATH-AWARE (compositor order, occurrences,
+    emptiable prefixes via `particleEmptiable`), so a LEADING wildcard in a sequence (`sequence(any skip,
+    element a)`) is wildcard-first and does NOT win precedence; bounded, no backtracking. Selection is
+    COMMIT-NO-FALLBACK: once any branch is element-first the choice MUST use an element-first branch and NEVER
+    falls back to a wildcard branch, even if the chosen branch then fails structurally
+    (`choice(sequence(a:int, b:int), any skip)` with only `<a>`) or by content.
+  - SEQUENCE (`matchSequence`/`tryMatchSequenceOnce`/`tryMatchSequence` via `sequenceElementReservedLimit`,
+    Version11): before matching each particle, the children a LATER element particle is element-first-consumer
+    for are reserved (particle sees `children[:limit]`), so a leading minOccurs=0 wildcard does not consume
+    required named elements. REACHABILITY-GATED: fires ONLY when the current particle would consume the child
+    via a wildcard (element-vs-element stays in declaration order) AND only for a later element REACHABLE from
+    the current position (every intervening particle emptiable, `particleEmptiable`); bounded lookahead, no
+    backtracking, XSD 1.0 byte-identical.
+  - cos-nonambig position automaton carries a per-position ORIGIN tag (`firstSetEntry.origin`,
+    `positionAutomaton.nextOrigin`): `applyOccurs` RESETS the counter before each occurrence copy, so all
+    occurrence-copies of ONE textual element leaf (any depth, `(a{1,2}){1,2}`) share an origin while two
+    DISTINCT leaves get distinct origins even when same-named and sharing an `*ElementDecl` through a group
+    ref. `entriesOverlap` treats same-name/SAME-origin element positions as non-ambiguous,
+    same-name/distinct-origin as a violation (`choice(a,a)`, `choice(ref g, ref g)`) — VERSION-INDEPENDENT
+    (only element-vs-wildcard is version-specific). Same-origin dedup ALSO covers two WILDCARD positions:
+    occurrence-copies of ONE `xs:any` (`sequence maxOccurs>1(any ##other maxOccurs>1)`, W3C addB194) never
+    overlap, while two DISTINCT wildcards (`choice(any, any)`) overlap when namespace constraints intersect —
+    so `sequence maxOccurs="100"(a maxOccurs="unbounded")` (W3C particlesZ034/Z036/V001/M035) is accepted in
+    1.0 too.
+  - Two guards keep these invalid schemas rejected: `checkAllGroupRef` (`link_refs.go`) rejects a DIRECT
+    `xs:group ref` to an all group with `{min occurs}` > 1 (cos-all-limited, W3C particlesEa023); the XSD 1.0
+    derived-GROUP-restricting-base-ELEMENT path (`restriction_particle.go` `particleValidRestriction`) uses
+    `groupRestrictsElement` ONLY when the base element is AT-MOST-ONCE (`MaxOccurs == 1`), else falls back to
+    conservative `pointlessReduce` (§3.9.6 occurrence hoisting) so a repeating group or
+    emptiable-group-over-multi-occur-member hole is still rejected (W3C particlesHb011).
+  - `groupLeavesRestrictElement` accepts a derived element leaf that is an instance-admissible
+    SUBSTITUTION-GROUP member of the base element (`leafIsSubstMemberOfBaseElement`; W3C elemZ027). DIRECT
+    element:element — `elementRestrictsElement`'s name-mismatch branch accepts a derived element that is an
+    instance-admissible substitution-group MEMBER of the base AND validly restricts that concrete member (W3C
+    elemZ027_e/f, particlesZ008), but ONLY from the DIRECT positional mapping (`recurseOrdered` sets
+    `substElementRestrictionKey` exclusively for element-vs-element, so a group-mapping recursion —
+    sequence:choice MapAndSum, choice/all reductions — does NOT inherit it) AND when the base element is
+    AT-MOST-ONCE (`b.MaxOccurs == 1`). The flag confinement keeps a subst-member narrowing in a MapAndSum
+    rejected (W3C particlesZ028 — invalid in 1.0/valid in 1.1); the `MaxOccurs == 1` gate keeps a subst member
+    of a REPEATING base element rejected (W3C elemZ026, particlesV020). BOTH paths route through
+    `derivedRestrictsSubstMemberOf`, resolving each side's EFFECTIVE type (`effectiveDeclType`, following an
+    untyped member's substitution-head inheritance) into shallow decl copies before the NameAndTypeOK check (a
+    derived LOCAL element sharing a member's name but widening its type is rejected; an unresolved derived
+    type falls closed).
+  - `elementRestrictsElement`'s NameAndTypeOK derivation check is BUILT-IN-AWARE
+    (`strictBuiltinAwareDerivedFrom`, version-INDEPENDENT — the 1.0 built-in simple types are not
+    BaseType-linked), so derived `xs:int` restricting base `xs:integer` is accepted (W3C particlesHa120,
+    stZ067). The whole check (built-in-aware derived-from plus the two gates below) is
+    `elementTypeValidlyRestricts(rtType, btType, version)` (`restriction_particle.go`), used at every
+    element-type-restriction site: direct element:element (`elementRestrictsElement`); the XSD 1.1 xs:all
+    occurrence-counting path (`all_subsumption.go` `derivedElemNameAndTypeOK`, feeding
+    `memberContributions`/`allRestrictsByCounting` AND `allRestrictsWithWildcards`); and transitively the
+    substitution-member path (`derivedRestrictsSubstMemberOf`) and the language-inclusion fallback leaf
+    (`restriction_subsume.go` `elemSymbolRestricts`). Derivation must be by RESTRICTION only (NameAndTypeOK
+    clause 3.2.5.2, disallowed subset {extension, list, union}, version-INDEPENDENT): after confirming R's
+    type derives from B's, `isDerivationBlocked(rtType, btType, BlockExtension)` rejects a type reaching B's
+    through an EXTENSION step (W3C particlesIj008) or an UNRELATED same-structure type (the `!ok` check
+    rejects that — W3C particlesL032). The list/union arm is NOT enforced — a list/union derived from
+    `xs:anySimpleType` is unconditionally valid (Type Derivation OK (Simple) §3.16.3 clause 2.2.3; W3C
+    stZ067/stZ068/stZ069, particlesIk014/Ik017/Ik018 expected-valid). UNCONDITIONAL (independent of `@block`),
+    separate from the base-TYPE-`@block` cvc-elt.4.3 gate (`typeDerivationBlocked(rtType, btType, 0)`, same
+    helper). A `type=`-form element ref prefers the TYPE symbol space over a same-named global element
+    (`typeExistsForRef`, `link_refs.go`; W3C particlesL032). 1.1 keeps `groupRestrictsElement` for every
+    base-element occurrence and reaches particlesZ028 through `particleLanguageSubset`.
+- **open content** (`opencontent.go`: `<xs:openContent>` interleave/suffix). Interleave seeds the DECLARED
+  sub-sequence with every child matching a declared ELEMENT NAME or declared WILDCARD particle
+  (`modelGroupWildcardAdmitsName` — the declared model may itself contain xs:any), routes the rest matching
+  the open wildcard to open, then matches the declared model on the declared set. Suffix matches the declared
+  model (resolved including declared wildcards) then requires every trailing child to match the wildcard.
+  Interleave is REFINED to the §3.4.4.3.2 existential partition (`refineInterleavePartition`): a
+  declared-seeded child the model cannot place — a STRUCTURAL blocker (extra occurrence after a bounded
+  particle is exhausted, at the trial's `consumed` index) OR a child a declared STRICT/lax WILDCARD
+  structurally CONSUMED whose CONTENT validation FAILED (trial errors with `consumed` at the end; the LAST
+  open-eligible NON-declared-name child moves — a declared element NAME stays for element-precedence
+  reporting, never spilled) — moves into open when it ALSO matches the open wildcard, found by TRIAL-matching
+  with diagnostics suppressed (`suppressDepth++`) then re-running for real. Suffix open content inside an
+  `xs:all` uses a LENIENT member matcher (`matchAll11(...lenient=true)` via `matchContentModelSuffix`) that
+  stops at the first non-member child.
+- **Schema-level `<xs:defaultOpenContent>`** (`readDefaultOpenContent`): PER-DOCUMENT (captured on each
+  complex type lacking an explicit `<xs:openContent>` as `TypeDef.pendingDefaultOpenContent`,
+  saved/reset/restored across xs:include/xs:redefine/xs:override/import like the form defaults — an
+  xs:override/xs:redefine REPLACEMENT child uses the OVERRIDDEN/redefining document's default per §4.2.5,
+  threaded via `overrideLoadTarget`'s returned `*OpenContent`). Must appear before any component declaration;
+  carries mode interleave|suffix (NOT none) and `appliesToEmpty` (default false). `@mode` is
+  whitespace-COLLAPSED before the enum comparison (`normalizeWhiteSpace(.,"collapse")`, in parseOpenContent
+  and readDefaultOpenContent); `appliesToEmpty` collapses via readBooleanAttr/parseSchemaBool, processContents
+  via readProcessContents.
+  - **Effective {open content}** resolved BASE-FIRST by `resolveOpenContent`/`computeEffectiveOpenContent`
+    (`resolveRefs`): explicit `<xs:openContent>` (mode="none" → absent, suppresses default) OR per-document
+    default (unless the content type is empty and appliesToEmpty=false — `contentTypeEmptyForOpenContent`).
+    EXTENSION inherits/merges base open content (§3.4.2.2: base interleave mode wins, wildcards union; may not
+    relax base interleave to suffix — §3.4.6.2). RESTRICTION validity via §3.4.6.4
+    `checkOpenContentRestriction`: may not ADD open content to a closed base, derived wildcard a subset,
+    derived pc at least as strong, mode may differ only when base is interleave (for an EMPTY derived content
+    model only the MODE comparison is waived).
+  - **`baseModelAdmitsOpenContent`** (CONSERVATIVE-SOUND, fail-closed): a base lacking open content but whose
+    declared model carries an admitting wildcard permits the restriction ONLY for the single PROVABLY-SOUND
+    shape — EXACTLY ONE wildcard particle W, NO element-declaration particles anywhere
+    (`baseModelWildcardScan.walk`), W's own occurrence minOccurs=0/maxOccurs=unbounded, every ANCESTOR group
+    at-most-once (maxOccurs=1) — base language is EXACTLY W*, subset iff `wildcardConstraintSubset(derived,W)`
+    with derived pc at least as strong. A min/max PRODUCT of 0..unbounded is NOT sufficient
+    (sequence(0,unbounded){any(minOccurs=2)} gaps at 1). ANY EMITTING declared element disqualifies (even
+    EMPTIABLE); a NON-EMITTING element (effective maxOccurs 0) does NOT (`baseModelWildcardScan.walk` threads
+    an emitting flag). A second wildcard, a required/bounded wildcard, or any repeating ancestor group are
+    conservatively deferred. open022 accepts; the declared-emptiable-sibling repro and the shared (G,G)*
+    group-ref case reject.
+  - **QUADRANT A — derived OPEN re-admits base DECLARED** (`checkOpenContentDropsBaseLocal` for elements,
+    `checkOpenContentDropsBaseWildcard` for wildcards): a restriction may not DROP a base element/wildcard and
+    re-admit its name/namespace through an open-content wildcard that loses a base constraint. Both run in the
+    restriction branch.
+    - Dropped base element, three unsoundness sources. TYPE loss — a dropped name re-admitted by an
+      UNENFORCING wildcard (skip; or lax with NO global) escapes the base type → reject
+      (strict/lax-with-global resolves a governing type the DYNAMIC wildcard-EDC enforces). CONSTRAINT loss —
+      on the ENFORCED path the re-admitting GLOBAL must be at least as restrictive as the dropped base LOCAL
+      (`localElementDeclsByName`, refs excluded) on the SIX properties the dynamic EDC does NOT enforce, all
+      in `globalDropsLocalConstraint` (shared by dropped-local and kept-narrowed branches): a CTA {type table}
+      not equivalent (`typeTablesConsistent`, absent-both=equivalent); a base-local `fixed` the global
+      lacks/differs on in VALUE space (`fixedValueMatches` with each decl's FixedNS, NOT lexical — a
+      QName/NOTATION same-lexical/different-prefix value is DIFFERENT, "1.0" vs "1.00" EQUAL); a global
+      `nillable` while the local is not; a base-local identity constraint (xs:key/unique/keyref by resolved
+      QName) the global lacks; a `block`/{disallowed substitutions} the local sets but the global lacks — the
+      EFFECTIVE blocked set masked to derivation bits (`(local.Block |
+      effectiveDeclType(local).prohibitedSubstitutions()) & derivBits` vs global's, `BlockExtension |
+      BlockRestriction`, cvc-elt.4.3, nil-safe — SUBSTITUTION bit dropped, so `block="substitution"`
+      re-admitted via an equivalent global is NOT over-rejected, while `validateWildcardChild` applies the
+      GLOBAL's block so a base-local block="extension"/"restriction"/"#all" or TYPE block rejecting an
+      xsi:type derivation is lost); or ASYMMETRICALLY a `default` the GLOBAL supplies but the local does
+      not/differs on in VALUE space, DefaultNS-aware (`global.Default != nil && (local.Default == nil ||
+      !fixedValueMatches(...))`) → reject. ORDER loss — a SUFFIX-mode BASE requires a declared name in the
+      prefix region, so a dropped suffix-base name is rejected for ANY pc (strict included); interleave
+      imposes no ordering. The guard fires only when the derived open content ACTUALLY ACCEPTS the dropped
+      name: a STRICT wildcard WITHOUT a matching global REJECTS the child (no spill), so the drop is EXEMPT.
+    - Kept base name (derived KEEPS it as a declared element): needs OCCURRENCE COVERAGE only in INTERLEAVE
+      mode with an UNENFORCING wildcard — the EXCESS beyond the derived particle's maxOccurs spills into
+      interleave open content (`refineInterleavePartition`); if the derived narrows below the base's effective
+      maxOccurs (`maxOccursForName`, summing sequence/all members, max over choice branches, folding group
+      maxOccurs, counting substitution members; `occursCovers`: unbounded base needs unbounded derived) the
+      spill is unsound two ways — an UNENFORCING wildcard loses the TYPE → REJECT; an ENFORCING wildcard
+      type-checks via the GLOBAL, losing the base local's fixed/nillable/identity constraints → REJECT when
+      the global is not constraint-compatible (same `globalDropsLocalConstraint`; a strict wildcard without a
+      global rejects the spilled child, so the check is skipped). When the derived COVERS the base occurrence
+      no excess spills. SUFFIX is always safe for a kept name (trailing declared-name child rejected as
+      misplaced).
+    - Name sets: the drop guard protects every name the base model ADMITS at runtime
+      (`baseAdmissibleElementNames` mirrors `elemMatchesDeclOrSubst`): each element particle's OWN name when
+      concrete PLUS its INSTANCE-ADMISSIBLE (abstract-excluded) transitive SUBSTITUTION-GROUP members (a
+      derived wildcard excluding the head via notQName="h" but re-admitting member m loses m's type). A skip
+      wildcard never enforces type; a ref/member under lax is exempt (a global exists). An abstract head's own
+      name is excluded. A NON-EMITTING base name (effective base maxOccurs 0, own or ANCESTOR group via
+      `mulOccurs`) is filtered out before the dropped/kept split. The DERIVED kept-name set and the SUFFIX
+      misplaced-trailing-name set use `collectEmittingModelElementNames` (EMITTING particles, names
+      `elemMatchesDeclOrSubst` can consume: own name when CONCRETE plus instance-admissible abstract-EXCLUDED
+      substitution members via `instanceSubstMembers`) — a derived element narrowed to maxOccurs=0 counts as
+      DROPPED, a non-emitting/abstract suffix name is open content. The INTERLEAVE name-split keeps
+      `collectModelElementNames` (abstract-included) but is sound (the matcher cannot consume an abstract
+      member; `refineInterleavePartition` moves it to open).
+    - RUNTIME `validateContentModelOpen` PRUNES non-emitting particles (`pruneNonEmittingParticles`:
+      maxOccurs=0 particles, whole maxOccurs=0 groups, and any group emptied by pruning — propagating up).
+      SEMANTICS-PRESERVING for xs:choice EMPTIABILITY: in a SEQUENCE/all parent an emptied member is dropped
+      (required siblings stay required); in a CHOICE parent it is REPLACED by a normalized emptiable
+      empty-SEQUENCE particle (minOccurs 0) so the choice still matches the empty string — never a
+      literally-empty choice (else `choice(<empty>, g)` becomes `choice(g)` and falsely requires g). A DIRECT
+      prohibited element leaf `choice(e{0,0}, g)` is dropped outright, g stays required (empty-branch handling
+      fires only on a GROUP that prunes empty). Pruning at the top BEFORE matching stops a DIRECT prohibited
+      particle consuming a child (`matchElementParticle` grabs one child before its maxOccurs check) — the
+      child falls to open content in suffix and interleave. A fully non-emitting model prunes to zero
+      particles, NORMALIZED to an empty sequence (minOccurs=0). One non-emitting definition across
+      `baseModelAdmitsOpenContent`, the drop guard, suffix+interleave validation, and the runtime matcher;
+      scoped to Version11 `validateContentModelOpen`, ordinary matcher byte-identical.
+    - `materializeOpenContentSiblings` (from `computeEffectiveOpenContent` on the LOCAL effective open content
+      BEFORE any extension union / restriction check / base inherit): populates `SiblingNames` on an
+      open-content/defaultOpenContent wildcard carrying ##definedSibling (the type's own content-model element
+      names), CLONING the wildcard first (shared across types). `wildcardExcludesName` checks `SiblingNames`,
+      not the marker. Must run BEFORE the extension union (`wildcardUnion`/cos-aw-union computes union
+      `SiblingNames` from the operands', retaining a sibling neither admits) so a one-sided union retains the
+      sibling as a finite exclusion even when the live marker is folded away; base operand materialized
+      BASE-FIRST. A name the derived wildcard EXCLUDES (notQName/##defined) is exempt; xsi:type is
+      instance-driven, not a compile-time name source. The dropped-name rule keys on the BASE's mode
+      (suffix→reject any pc; interleave→reject only if unenforcing); the kept-name coverage keys on the
+      DERIVED's mode (interleave-only). Suffix is the only mode imposing ordering.
+    - `checkOpenContentDropsBaseWildcard` (symmetric, dropped/narrowed base DECLARED WILDCARD): a declared
+      xs:any wins attribution (interleave seeds it via `modelGroupWildcardAdmitsName`, suffix matches it in
+      the prefix; a suffix leftover declared-WILDCARD match is NOT flagged misplaced so it spills). For each
+      emitting base wildcard bw (`collectEmittingDeclaredWildcards`, effective max) whose namespace the
+      derived OPEN wildcard re-admits (`constraintsIntersect` FIRST — an open content excluding bw's namespace
+      is exempt; AND for a STRICT open, `strictOpenAdmitsGlobalIn` — no global in bw's region → exempt) AND
+      where the open does not enforce at least as strictly (interleave: open pc weaker than bw; SUFFIX: ANY
+      pc), check AGGREGATE occurrence coverage over the SPILL-RELEVANT REGION = bw's namespace ∩ the derived
+      open wildcard's (`spillCon = constraintIntersect(bwCon, openCon)`; `spillWC =
+      constraintToWildcard(spillCon)`): baseCap = sum effMax over base wildcards INTERSECTING the region with
+      pc≥bw's; derivedCap = sum over derived wildcards namespace-SUPERSETTING it
+      (`wildcardConstraintSubset(spillWC, dw)`) with pc≥bw's; `!occursCovers(derivedCap, baseCap)` → reject
+      (suffix=order loss / interleave=type loss). Fail-closed accounting; UPA forbids two overlapping declared
+      wildcards in one content model, so it reduces to single-wildcard coverage for constructible schemas.
+  - **QUADRANT B — derived DECLARED wildcard re-admits BASE OPEN** (`checkDerivedWildcardReadmitsBaseOpen`): a
+    restriction may DROP the base's open content O and re-introduce its language as a declared wildcard
+    (restriction_particle.go's Wildcard-restricting-ModelGroup conservatism compiles it), and a declared
+    wildcard WINS attribution so its pc governs, not O's. For each emitting derived declared wildcard whose
+    namespace intersects O, unless it VALIDLY RESTRICTS a base DECLARED wildcard (W_d ⊆ W_b, pc≥ — quadrant
+    D), it must validly restrict O: for INTERLEAVE O, namespace ⊆ O AND `processContentsStrength(W_d)` ≥ O's
+    (else REJECT); for SUFFIX O the trailing-ORDERING cannot be preserved by a non-trailing declared wildcard,
+    so re-admitting O's namespace is REJECTED — but only when the derived wildcard ACTUALLY admits a child
+    there (skip/lax always; a STRICT derived wildcard with NO matching global admits nothing via
+    `strictOpenAdmitsGlobalIn` → EXEMPT, mirroring the quadrant-A strict/no-global exemption). A base WITHOUT
+    open content is unaffected.
+  - **Four quadrants** for restriction subset: (A) derived OPEN re-admits base DECLARED →
+    `checkOpenContentDropsBaseLocal`/`checkOpenContentDropsBaseWildcard`; (B) derived DECLARED wildcard
+    re-admits base OPEN → `checkDerivedWildcardReadmitsBaseOpen`; (C) derived OPEN vs base OPEN →
+    `checkOpenContentRestriction`; (D) base DECLARED vs derived DECLARED → `restriction_particle.go`. SUFFIX
+    base-mode ORDERING preserved in every quadrant: A (drop guards reject a dropped suffix-declared name /
+    spilled suffix wildcard for ANY pc), B (rejects a derived declared wildcard re-admitting a suffix base
+    open content), C (`checkOpenContentRestriction` rejects a mode change off a suffix base; an interleave
+    base may not be extended to suffix). D's Wildcard-vs-ModelGroup case is conservative (a derived declared
+    wildcard re-admitting a base declared ELEMENT's name under skip/weaker validation is a RESIDUAL not
+    covered by B).
+  - **Grammar/child-order**: the `<xs:any>` of open content must NOT carry minOccurs/maxOccurs
+    (`parseOpenContentWildcard`); an open-content element (xs:openContent OR xs:defaultOpenContent) has a
+    STRICT (annotation?, any?) child grammar (`scanOpenContentChildren`/`reportOpenContentChildGrammar`: any
+    stray child a schema error); mode="none" must not carry a wildcard child; a complex type must not have >1
+    xs:openContent (all three parse loops). VALIDATION enforces effective open content on a type with NO
+    declared model group (`validate.go`: a mixed-or-appliesToEmpty type picking up a defaultOpenContent does
+    not admit arbitrary children via `annotateAnyTypeChildren` — every child element must match the open
+    wildcard, mixed text allowed), so all four ContentType branches enforce `td.OpenContent`. CHILD ORDER
+    (§3.4.2, `openContentOrderViolation`, all three complexType parse loops): xs:openContent PRECEDES the
+    content-model particle, attribute uses, anyAttribute, and trailing xs:assert region, and is NOT a sibling
+    of an xs:simpleContent/xs:complexContent wrapper (direct complexType grammar is a CHOICE — wrapper branch
+    (simpleContent|complexContent) or non-wrapper branch (openContent?, particle?, attrs, anyAttribute?,
+    assert*), so every non-wrapper child kind is mutually exclusive with a wrapper in BOTH orders, including
+    xs:assert; assert 1.1-only, guards never affect 1.0). xs:openContent is rejected INSIDE a simpleContent
+    extension/restriction (`parseSimpleContentChildren`).
+    - `<xs:complexContent>` and `<xs:simpleContent>` share `(annotation?, (restriction | extension))`,
+      enforced by `parseDerivationWrapper` in BOTH 1.0 and 1.1 (version-INDEPENDENT): a ZERO/SECOND
+      derivation, an annotation AFTER, or any stray child (notably a trailing `<xs:openContent>`) is a schema
+      error. In the OUTER `parseSimpleContent`. Valid-wrapper dispatch byte-identical; only invalid forms
+      newly rejected in 1.0. The direct complexType `assert*` trailing region: a
+      particle/attribute/attributeGroup/anyAttribute AFTER an `<xs:assert>` is out of order (the
+      `assertSeen`/`contentWrapperChild` mutual-exclusion guards never affect 1.0).
+    - DERIVATION-BODY grammar (version-INDEPENDENT), child ORDER/CARDINALITY enforced (reject-stray, LEAF
+      parsers untouched): the complexContent body `(annotation?, openContent?, (group|all|choice|sequence)?,
+      ((attribute|attributeGroup)*, anyAttribute?), assert*)` parsed by `parseComplexContentDerivationBody`
+      (parseRestriction/parseExtension thin wrappers, kind-parameterized for the extension prohibited-attr
+      warning). simpleContent bodies (`parseSimpleContentChildren`): restriction `(annotation?, simpleType?,
+      facet*, (attribute|attributeGroup)*, anyAttribute?, assert*)` and extension `(annotation?,
+      (attribute|attributeGroup)*, anyAttribute?, assert*)` — facets/simpleType only in restriction
+      (`isSimpleTypeFacetElement`). openContent/assert body cases stay Version11-gated (in 1.0 an
+      `<xs:openContent>`/`<xs:assert>` in a body is a stray child).
+    - DIRECT `<xs:complexType>` child grammar enforces the ANNOTATION rule version-INDEPENDENTLY (at most one,
+      must be FIRST child). Its stray-rejecting default (only annotation, simpleContent, complexContent,
+      openContent, a model-group particle (group|all|sequence|choice), attribute, attributeGroup,
+      anyAttribute, assert — else schema error, e.g. a direct `<xs:element>`) stays Version11-gated (1.0 keeps
+      prior lenient default). A schema-level xs:defaultOpenContent must FOLLOW the composition elements
+      (include/import/redefine/override). `<xs:complexContent>`/@mixed honored version-INDEPENDENTLY, must not
+      conflict with `<xs:complexType>`/@mixed, and an extension's content type and its base's must both be
+      mixed or both element-only (§3.4.6.2 cos-ct-extends). A global `<xs:complexType>`/@name must be a valid
+      `xs:NCName` (`parseNamedComplexType` via `xmlchar.IsValidNCName`; version-INDEPENDENT).
+  - **KNOWN GAPS**: whitespace in a genuinely-EMPTY (`<xs:sequence/>`, empty/no model group) element-only
+    content type with no effective open content IS rejected in 1.1 (`validate.go` `validateContentByType`: an
+    `ContentTypeElementOnly` type with no content per `modelGroupHasContent` routes to
+    `validateEmptyContent(..., strict=true)`, rejecting ALL character content per cvc-complex-type.2.1;
+    open012.n3 — read_types.go still classifies an empty compositor as element-only with a non-nil empty model
+    group, so emptiness is detected at validation; 1.0 keeps the whitespace tolerance, byte-identical). GAP:
+    an attribute-only `ContentTypeEmpty` complex type still tolerates whitespace-only character content in 1.1
+    (a pre-existing false-accept, not in the W3C suite; the fix landed only for the element-only-misclassified
+    `<xs:sequence/>` case, NOT the genuine `ContentTypeEmpty` classification). Schema-component `@id`
+    uniqueness/NCName validity IS enforced (`check_ids.go` `checkSchemaComponentIDs`: a DOM walk validating
+    every XSD-namespace element's `id` as a valid xs:ID — NCName after whitespace-collapse — unique within the
+    document; open038/open039; version-INDEPENDENT). Does NOT descend into xs:appinfo/xs:documentation
+    PAYLOAD, but an xs:annotation's OWN `id` participates. Run on EVERY schema document with a FRESH
+    per-document `seen` set — entry (`compile.go`), each xs:include/xs:redefine document
+    (`compile_imports.go`), xs:import (sub-compiler, via `propagateImpErrors`), xs:override (`override.go`) —
+    after conditional-inclusion pruning. xs:ID uniqueness is PER-DOCUMENT (same value may recur ACROSS
+    documents, not within one).
+- **element restriction disallowed-substitutions superset** (version-INDEPENDENT, §3.9.6 NameAndTypeOK 3.2.4):
+  `restriction_particle.go` `elementRestrictsElement` rejects a derived element whose `{disallowed
+  substitutions}` (`@block`, blockDefault-folded) is not a superset of the base element's (`bt.Block &^
+  rt.Block != 0`), so a base `block="#all"` cannot be restricted by a derived `block="extension"`.
+- **complexType `{prohibited substitutions}` (block) in cvc-elt.4.3 / Substitution Group OK**
+  (version-INDEPENDENT): `parseComplexType` (`read_types.go`) stores each complex type's `@block` (folded with
+  schema-level `blockDefault`, masked to `{extension, restriction}`) on `TypeDef.Block`; a type silent on
+  block (including every anonymous complexType) picks up `blockDefault`. `typeDerivationBlocked(derived, base,
+  elemBlock)` (`validate_elem.go`) centralizes the effective-block gate: `isDerivationBlocked` with the UNION
+  of `elemBlock` and the BASE type's `TypeDef.Block` (nil-safe `TypeDef.prohibitedSubstitutions`), masked to
+  derivation bits, so a derivation blocked by the TYPE's `@block` is rejected even when the referring element
+  declaration carries no block. Sites: the xsi:type checks (`validate.go`/`validate_elem.go` — root, per-child
+  particle, xs:all, xs:anyType/lax, strict-wildcard child); the dynamic wildcard-EDC
+  (`validateWildcardElementConsistent`); substitution-group membership (`substitutableMembersFor` feeding the
+  1.0 matcher, UPA, and the 1.1 instance path via `instanceSubstMembers`; static `foldSubstitutionMembers` in
+  `check_element_consistent.go`). The two substitution sites use `substTypeDerivationBlocked`
+  (`validate_elem.go`): applies the head/base gate, then walks the member's `BaseType` chain and rejects when
+  any INTERMEDIATE complex type's `Block` prohibits a method used anywhere in the
+  member-down-to-that-intermediate suffix (Substitution Group OK / Transitive §3.3.6.3, via
+  `isDerivationBlocked(derived, mid, mid.Block & derivBits)` — full suffix, nil-safe) — so `Base <-
+  Mid(block="extension") <- R(restriction) <- Leaf(extension)` is not substitutable for a head of type `Base`
+  even though neither `Base` nor the head element blocks extension. Only the substitution-group path considers
+  intermediate-type blocks; xsi:type and CTA stay on `typeDerivationBlocked`. Also: CTA `<xs:alternative>`
+  substitutability (`checkAltSubstitutability`, `alternative.go`, Version11 — `xs:error` always allowed, else
+  validly substitutable AND not blocked by the element's effective block); and ordinary particle-restriction
+  element retyping (`elementRestrictsElement`, `restriction_particle.go` — a derivation the base TYPE's block
+  forbids rejects the restriction).
+- **complexContent restriction mixedness** (cos-ct-restricts clause 5.3.2, version-INDEPENDENT): the
+  `resolveRefs` restriction loop (`link_refs.go`) rejects an element-only base restricted to a mixed derived
+  type — ASYMMETRIC (a mixed base MAY be restricted to element-only, not the reverse), unlike the symmetric
+  extension rule cos-ct-extends enforced alongside it.
+- **src-redefine.6.2 group restriction (sound core)** (§4.2.3, version-INDEPENDENT):
+  `checkRedefineGroupRestriction` (`compile_imports.go`) rejects a no-self-reference redefining `<xs:group>`
+  that REQUIRES an element the original group forbids (`maxOccurs=0`) — the provably-sound core (a
+  no-self-reference group is otherwise a documented clause-6.2 gap).
+- **wildcard `notNamespace`/`notQName`** (`xs:any`/`xs:anyAttribute`): `readWildcard` (`read_elements.go`)
+  parses `@notNamespace` (an `xs:basicNamespaceList` of anyURI/`##targetNamespace`/`##local`, mutually
+  exclusive with `@namespace`; an EMPTY list `notNamespace=""` is VALID — a `not` with an empty excluded set
+  admitting ALL namespaces, a NON-NIL empty slice distinct from an ABSENT/nil, `wildcardMatches` treats it as
+  "excludes nothing") into `Wildcard.NotNamespace`, and `@notQName` (QName/`##defined`/`##definedSibling`)
+  into `Wildcard.NotQName`/`NotQNameDefined`/`NotQNameDefinedSibling` (`schema.go`). `wildcardMatches`
+  excludes `NotNamespace`; `wildcardAllowsExpandedName`/`wildcardExcludesName` (`validate_elem.go`) add
+  name-level `notQName`/`##defined` exclusion (consulting `schema.elements`/`schema.globalAttrs`), used by
+  element content (`matchWildcardParticle`, `matchAll`), attribute (`validateWildcardAttr`, `validate.go`),
+  and open content. `##definedSibling` resolved post-`resolveRefs` by `resolveDefinedSiblings`
+  (`opencontent.go`) into `SiblingNames`. The UPA overlap test (`check_upa.go` `firstSetEntry.wc`,
+  `wildcardsOverlap`→`constraintsIntersect`) and the restriction-subset check (`wildcardConstraintSubset11`,
+  `wildcard_algebra.go`) are 1.1-aware — the latter rejects a derived wildcard DROPPING a `##defined` the base
+  carries, or (for `##definedSibling`) whose resolved `SiblingNames` is NARROWER than the base's (iterates
+  `super.SiblingNames`, requires `sub` to exclude each).
+  - `resolveDefinedSiblings` runs INSIDE `resolveRefs` (after group-ref expansion, before
+    restriction-derivation checks), visiting ALL parsed complex types — named `schema.types` AND inline
+    ANONYMOUS (iterating `c.typeDefSources` keys, deduped by `*TypeDef`). Content-model trees are SHARED
+    across types (group-ref expansion reuses the group's particle slice; type extension embeds the base
+    model-group pointer), so it DEEP-CLONES a type's content model (`cloneModelGroupForSiblings` — fresh
+    ModelGroup/Particle/Wildcard, ElementDecls shared read-only) before assigning `SiblingNames`, else one
+    type's set could overwrite another's through the shared `*Wildcard` (NONDETERMINISTIC). Clone taken only
+    for Version11 types whose model carries a `##definedSibling` wildcard (`modelGroupHasDefinedSibling`).
+  - Restriction-derivation functions thread `*Schema` (and an `isAttr` flag into
+    `wildcardConstraintSubset`/`wildcardConstraintSubset11`) so EVERY derivation site uses the full
+    `wildcardAllowsExpandedName` (notQName/`##defined`-aware): `wildcardAllowsName`
+    (element-restricts-wildcard); `checkRestrictionAttrs` (`link_refs.go`, a derived CONCRETE attribute vs
+    base `anyAttribute`, isAttr=true); the per-name SUBSET checks in `wildcardConstraintSubset11`
+    (cos-ns-subset — each name `super` disallows must be DISALLOWED by `sub` under the full test, so a derived
+    wildcard's `##defined` can discharge a base wildcard's `notQName="g"` when `g` is globally declared, while
+    `super.NotQNameDefined && !sub.NotQNameDefined` still requires `sub` to carry `##defined`).
+    `##definedSibling` permitted ONLY on element wildcards (`parseNotQName` rejects it on `xs:anyAttribute`,
+    `isAttr` flag from `readWildcard`).
+  - A normalized wildcard algebra (`wildcard_algebra.go`: `wcConstraint` + union/intersection) drives
+    attribute-wildcard UNION (extension, `wildcardUnion`) and INTERSECTION (the type's "complete wildcard"
+    across `xs:attributeGroup` refs — group wildcards in `attrGroupWildcards`, intersected in `link_refs.go`).
+    `attrGroupWildcards` is initialized AND merged into the parent in import sub-compilers
+    (`compile_imports.go`); the `xs:redefine` override path parses the group's `xs:anyAttribute`, clears the
+    stale base wildcard, intersects a self-reference's original, and stores the replacement. A group's
+    `xs:anyAttribute` must be the optional FINAL, unique child (`parseNamedAttributeGroup` and the redefine
+    override, Version11). `notQName` tokens validated with `internal/xmlchar.IsValidQName` (accepts non-ASCII
+    XML NameChars) and resolved with `resolveNotQName` (NOT `resolveQName`): QName ACTUAL VALUES, so an
+    UNPREFIXED token resolves through the in-scope DEFAULT namespace, or ABSENT when none — NEVER the schema's
+    `targetNamespace`.
+  - `constraintToWildcard` and its union/intersection callers carry `SiblingNames` through materialization
+    (intersection unions the sibling exclusions; union retains names neither operand admits). A materialized
+    union may retain `SiblingNames` even when the `NotQNameDefinedSibling` MARKER is dropped (marker survives
+    only when BOTH operands carry it); those names are still first-class exclusions, so `wildcardHas11Fields`
+    counts `len(SiblingNames)>0` as 1.1 state and `wildcardConstraintSubset11` checks `super.SiblingNames`
+    UNCONDITIONALLY, the marker-only reject kept solely for the live open-ended case. Intersection carries the
+    STRONGER processContents (`strongerProcessContents`, strict>lax>skip) — ORDER-INDEPENDENT. The 1.1 UNION
+    (`unionWildcards11`) takes the SECOND operand's pc: its only pc-sensitive caller is TYPE EXTENSION, which
+    passes `wildcardUnion(base, derived)`, and per XSD 3.4.2 the extension takes the DERIVED wildcard's pc.
+    Routing is VERSION-aware: `wildcardUnion(w1, w2, version)` routes to `unionWildcards11` for EVERY
+    `Version11` union (plus a defensive 1.1-field fallback), keeping the legacy 1.0 case analysis STRICTLY for
+    `Version10` (byte-identical; the 1.0 path keys pc on `w1` and approximates `##other|##local` as `##any`).
+    UNION `{disallowed names}` follows cos-aw-union (§3.10.6.3): a candidate QName is excluded iff NEITHER
+    operand admits it by NAMESPACE-and-explicit-`notQName` (`wildcardAdmitsNameIgnoringDefined`);
+    `##defined`/`##definedSibling` folded ONLY as whole markers (kept iff BOTH carry them), NOT per-QName — so
+    a global-attr name one operand excludes via `##defined` but admits by namespace, the other excluding it
+    explicitly, is still ADMITTED (W3C wild083 `surprise`).
+  - `xs:all` may contain wildcards — matched by `matchAll` (Version11, 1.0 byte-identical); restriction by
+    `allRestrictsWithWildcards` (`restriction_particle.go`) enforcing per-base-wildcard MIN and MAX
+    cardinality (MAX only for base wildcards that EXCLUSIVELY own their namespace). CONCRETE derived elements
+    admitted by a base wildcard participate in that accounting keyed on their exact name. A derived wildcard's
+    pc must be at least as strong as EVERY base wildcard it INTERSECTS. A GLOBAL attribute in the XSI
+    namespace is rejected (no-xsi) — `parseGlobalAttribute` (`read_elements.go`), gated Version11 (the
+    pre-existing LOCAL-qualified-attribute XSI check in `check_elements.go` untouched for 1.0).
+  - All gated `Version11`; 1.0 ignores notNamespace/notQName and does NOT merge group wildcards into a type's
+    `{attribute wildcard}` at validation. 1.0 DOES record each attribute group's `xs:anyAttribute`
+    diagnostic-free in `attrGroupWildcards` (`parseNamedAttributeGroup`, via `quietProcessContents`, namespace
+    + pc only) so the COMPILE-TIME restriction check (`checkRestrictionAttrs` `effectiveAttrWildcard`, 1.0
+    only) can recognize a base whose attribute wildcard comes SOLELY through a referenced group: a DIRECT
+    `td.AnyAttribute` is returned as-is and NEVER narrowed; only when nil does it fill in the FIRST group-ref
+    complete wildcard (`attrGroupCompleteWildcard`) so a transitive-only base satisfies
+    derivation-ok-restriction 4.1 and is compared for 4.2/4.3 (a valid `##other`-adding restriction of
+    `schema-for-xslt20.xsd`'s `transform-element-base-type` compiles; a widening derived wildcard still
+    rejected). In 1.1 group wildcards are already merged into `td.AnyAttribute`. The multi-group intersection
+    and the base-chain-inherited-via-extension transitive-group case are not modeled (fail-closed). The
+    derived side still uses direct `td.AnyAttribute` in 1.0, so a derived wildcard contributed only via a
+    group ref does not trigger the 4.x checks (1.0 byte-identical).
+- **xs:all relaxations** (Saxon `All.testSet` 62/62; gated `Version11`, 1.0 byte-identical): the all group's
+  OWN maxOccurs may be 0 or 1 in 1.1 (`check_elements.go` `validateAllOccurs`; 1.0 requires exactly 1 —
+  mgO001/mgO018); element members may carry `minOccurs`/`maxOccurs>1`/`unbounded` (`check_elements.go`
+  `checkAllElementParticleOccurs`); `xs:all` may contain element WILDCARDS; an `xs:group ref` resolving to an
+  all group may be nested directly inside another `xs:all` with occurrence 1/1 (flattened — `link_refs.go`
+  `checkAllGroupRef`/`groupRefSource.parentCompositor`; a referenced sequence/choice or occurrence ≠ 1/1
+  rejected; an INLINE `<xs:all>` directly inside an `<xs:all>` is also rejected — cos-all-limited,
+  `read_particles.go`).
+  - `matchAll`/`tryMatchAll` (`validate_elem.go`) DISPATCH by version: 1.0 keeps the legacy boolean-`seen[]`
+    matcher (`matchAll10`/`tryMatchAll10`) BYTE-IDENTICAL; 1.1 uses a FLAT member list (`flattenAllMembers`)
+    with PER-MEMBER occurrence counting (`matchAll11`/`tryMatchAll11`) — element members (matched only when
+    ADMISSIBLY substitutable via `elemMatchesDeclOrSubst`/`allMemberForChild`, honoring
+    block="substitution"/derivation-block and rejecting abstract heads AND abstract substitution members),
+    wildcard members, and flattened nested-all members, all ORDER-INDEPENDENT against each member's min/max.
+  - Restriction subsumption of a base `xs:all` is occurrence-COUNTING per BASE MEMBER (`all_subsumption.go`
+    `allRestrictsByCounting`/`memberContributions`, from `restriction_particle.go` `groupRestrictsGroup` for
+    Version11 no-wildcard all:all / sequence:all / choice:all): the derived contribution is computed PER
+    base-member index (a choice's branches correlate on the base member — `choice(A1{2},A2{2})` with A1/A2 in
+    base member a's substitution group restricts a{2}), a derived element maps to a base member by name or
+    substitution group (`findBaseAllMember`, using `admissibleSubstitutionMember`) with a BUILT-IN-AWARE
+    NameAndTypeOK check (`strictBuiltinAwareDerivedFrom`), a non-emitting particle contributes nothing, and
+    every unmapped base member must be emptiable. Wildcard cases route to `allRestrictsWithWildcards`, which
+    FLATTENS nested 1/1 all-groups on both sides (`flattenAllParticles`) and SUMS concrete derived elements
+    per base element before accounting against the base wildcards' cardinality; a nested NON-all derived group
+    surviving flattening is rejected (fail-closed).
+  - An `xs:all` may be EXTENDED by another `xs:all` (`link_refs.go` extension loop merges the two member sets
+    into a SINGLE all group — both must be all groups with the SAME minOccurs; a sequence/choice extending an
+    all, or vice-versa, rejected; an open-content `interleave` base may not be extended to `suffix`).
+  - **Empty-base extension by an `xs:all`** (§3.4.2 effective content, version-INDEPENDENT — the 1.0 path
+    too): when the base type's effective content is EMPTY (an empty `xs:all`/`xs:sequence` model group) and
+    the derived particle is an `xs:all`, the extension's content model is the derived `xs:all` ALONE — the
+    base contributes nothing, so no wrapping sequence is formed (which would nest an `all` inside a sequence,
+    forbidden by All Group Limited and falsely rejecting a valid instance — W3C `mgZ003`: an `xs:group` ref to
+    an all group extending an empty base `xs:all`). The `link_refs.go` extension merge's
+    derived-`all`-over-empty-base case sets `td.ContentModel = derivedMG`; a non-empty base keeps the sequence
+    merge, byte-identical.
+  - UPA over all members (`check_upa.go` `walkAllBody`) is fed by MULTI-HEAD substitution groups
+    (`substitutionGroup="a b"` registers the member under every head — `read_elements.go`/`compile.go`
+    `buildSubstGroups`, `ElementDecl.SubstitutionGroups`). UPA competition is by DECLARATION membership, so an
+    ABSTRACT substitution member STILL competes (XSD 1.1 §3.8.6.4 / bug 4337) — `walkTerm` does NOT skip
+    abstract members (instance MATCHING does, via `elemMatchesDeclOrSubst`/`admissibleSubstitutionMember`).
+  - Substitution-group membership: a TRANSITIVE, cycle-guarded closure (`substitutableMembersForUncached`,
+    `subst_closure.go`) SEPARATING traversal from inclusion — an edge is traversed unless
+    block/derivation-blocked (`substTypeDerivationBlocked`; ABSTRACT members traversable) so a concrete
+    descendant behind an abstract intermediate (`h <- abstract m1 <- concrete m2`) is reached;
+    `block="substitution"`/derivation-block PRUNE the subtree. TWO variants differ only in inclusion:
+    `instanceSubstMembers` includes only CONCRETE (abstract excluded) — runtime matching
+    (`elemMatchesDeclOrSubst`) and restriction subsumption (`findBaseAllMember`); `substitutableMembersFor`
+    (DECLARATION membership, abstract INCLUDED) — UPA (`walkTerm`) and the 1.0 matcher
+    (`matchAll10`/`tryMatchAll10`/`resolveSubstDecl`). A substitution group is a property of the GLOBAL head
+    declaration (or a `ref`), so a distinct LOCAL element particle sharing a head's QName admits NO members
+    (version-INDEPENDENT: elemZ011/elemZ021b/elemZ021f/elemZ023). The cos-element-consistent fold
+    (`check_element_consistent.go` `collectContentModelElements` → `foldSubstitutionMembers`) applies the SAME
+    gate.
+  - The closure of every global head is precomputed once, at the very end of `compileSchema`, into
+    `Schema.substClosures` (`subst_closure.go` `buildSubstClosures`): a map keyed by the head's QName holding
+    its full closure, an abstract-filtered concrete subset, and — above `substClosureByNameThreshold` members
+    — a by-name index. `substitutableMembersFor`, `instanceSubstMembers`, and `substMemberFor` (the
+    byName-indexed lookup behind `elemMatchesDeclOrSubst`/`resolveSubstDecl`) resolve through
+    `lookupSubstClosure`, serving a global head or a resolved `ref` straight from the cache. `substClosures`
+    is nil for the whole of `compileSchema` — built as the LAST step, after every compile-time check has read
+    `substGroups`/`elements` — so every compile-time caller (UPA, cos-element-consistent, restriction
+    subsumption, open content) still runs `substitutableMembersForUncached` directly against a schema that has
+    not finished compiling. `schemaWithInstanceHints` (`instance_schema_location.go`) rebuilds the cache after
+    merging `xsi:schemaLocation`-contributed substitution-group members, so a member contributed only by an
+    instance hint is still found.
+  - A nilled element with whitespace-only character content is rejected in 1.1 (cvc-elt.3.2.1; 1.0 tolerates
+    it). all308 (an empty mixed `xs:all` base extended by an all — bug 6202, RESOLVED WONTFIX 2008-11-21,
+    invalid per All Group Limited §3.8.6.2) is correctly REJECTED in `link_refs.go`, while an empty
+    *non-mixed* base stays valid.
+- **Particle restriction language-inclusion fallback** (`restriction_subsume.go` `particleLanguageSubset`,
+  gated Version11): the 1.0 syntactic Particle Valid (Restriction) clauses (`restriction_particle.go`) are
+  known-incomplete and reject many restrictions whose derived content-model LANGUAGE is genuinely a subset of
+  the base's (particlesHa161/Hb008/Hb011/Z001/Z028). When the syntactic check FAILS in 1.1,
+  `checkRestrictionParticles` PROVES `L(derived) ⊆ L(base)` by product simulation of the two content-model
+  automata over the finite alphabet of derivable names. FAIL-CLOSED / SOUND: accepts only on a rigorous
+  inclusion proof (each derived element declaration validly restricting via `elementRestrictsElement` every
+  same-named base declaration — a base wildcard imposes no type constraint), returning "not proven" (keeping
+  the rejection) for anything it cannot represent — a DERIVED wildcard, an xs:all group, or an over-large
+  occurrence unroll (`subsumeNFAStateCap`/`subsumePairStateCap`/`subsumeUnrollCap`). Element leaves expand to
+  instance-admissible substitution-group members; a base wildcard matches every admitted name
+  (`wildcardAllowsName`). Runs only as a fallback AFTER the syntactic check and only ACCEPTS; XSD 1.0 keeps
+  the syntactic verdict, byte-identical.
+- **Content-model instance occurrence backtracking** (`content_backtrack.go`, version-INDEPENDENT): the
+  runtime matcher (`validate_elem.go` `matchSequence`/`matchChoice`/`matchElementParticle`) is GREEDY, so an
+  occurrence-partition-ambiguous but UPA-clean model false-rejects a VALID instance by starving a later
+  required occurrence (`sequence minOccurs=2 (a{1,2}, b?)` over `a,a,b`; W3C
+  ctZ006/ctZ008/ctZ009/ctZ009_b/ctZ009_d/addB176).
+  - A PROHIBITED particle (maxOccurs=0) consumes ZERO children in the greedy matcher too
+    (version-INDEPENDENT): `matchElementParticle`/`tryMatchElementParticle` enforce MaxOccurs BEFORE
+    consuming, and `matchAll10`/`tryMatchAll10` exclude a maxOccurs=0 member from the by-name map
+    (`matchAll11`/`tryMatchAll11` already via the per-member `count < max` guard) — a prohibited element
+    present in the instance is "not expected" (W3C addB092).
+  - `validateContentModelTop` FIRST runs the pure greedy try (`tryMatchModelGroup`, no side effects): if it
+    fully consumes, the greedy matcher runs for real (`matchContentModelFull`) — common path unchanged,
+    byte-identical. Only when greedy CANNOT fully consume does `contentModelAccepts` decide via bounded
+    backtracking. The model is kept INTACT: a PROHIBITED particle (effective maxOccurs=0 — element leaf via
+    `btReachElem`, or a group via `btReachGroupAt`, covering own OR ancestor group maxOccurs 0) is given
+    SKIP-ONLY reach — the zero-occurrence endpoint, NEVER a consume branch. Correct both ways:
+    `sequence(seq{2,2}(x+), a{0,0}, b)` over `x,x,a,b` REJECTS (`a{0,0}` cannot consume `<a>`), yet a
+    maxOccurs=0 particle inside an `xs:choice` still contributes the empty (ε) branch keeping a NULLABLE
+    choice nullable (`sequence(seq{2,2}(x+), choice(a{0,0}, b))` over `x,x` ACCEPTS via the empty `a{0,0}`
+    branch). Pruning would drop a direct maxOccurs=0 choice leaf and wrongly make the choice non-nullable.
+  - Backtracking runs ONLY inside a provably-safe ENGAGEMENT ENVELOPE (`inBacktrackEnvelope`, a one-pass walk;
+    outside it defers to greedy — fail-closed). ALL three conditions must hold: (1) EMITTING-WILDCARD-FREE (no
+    child-consuming `xs:any` at any depth; maxOccurs=0 wildcards skip-only) — eliminates the XSD 1.1
+    element-over-wildcard precedence class; (2) UNAMBIGUOUS name→declaration — no two DISTINCT
+    element-declaration leaves share a name (a UPA-clean model may still contain positional same-name locals
+    differing in nillable/fixed/default, e.g. `sequence(a nillable=true, a nillable=false)`); (3) NO
+    substitution complication — no element leaf is a substitution-group head with INSTANCE-admissible concrete
+    members. Within the envelope every child's name selects its UNIQUE declaration.
+  - Computes, memoized, the reachable end positions for each (element|group, position) state — an element leaf
+    contributes `pos+k` for every `k∈[minOccurs, feasible]`, a sequence composes its particles' reach sets, a
+    choice unions its branches', each compositor applies its `{minOccurs, maxOccurs}` with an emptiable-body
+    zero-length pad — using the SAME per-child predicate as the greedy matcher (`elemMatchesDeclOrSubst`).
+    FAIL-CLOSED: a hard `btStateCap` returns "not proven"; `xs:all` groups matched greedily (`btReachAll`:
+    deterministic per-member counting, no occurrence backtracking). An OPTIONAL `xs:all` (minOccurs=0)
+    additionally contributes the zero-consumption SKIP endpoint (mirroring the greedy minOccurs==0 skip that
+    `tryMatchAll` itself does not apply); only that endpoint is added, never a partial all match.
+  - When acceptance is proven, `validateContentModelChildren` validates each child against its unique element
+    leaf declaration (`elemLeafForChild` first-name-match; content/type/xsi:type/assertion/IDC-annotation side
+    effects match the greedy path), visiting each child once and reusing `matchElementParticle`. Runs only as
+    a recovery AFTER greedy fails, only inside the envelope, and only ACCEPTS; the greedy path stays
+    authoritative.
+- **Particle-restriction occurrence relaxation** (`restriction_particle.go` `occurrenceEmptiableRestriction`):
+  an EMPTIABLE base group particle has an effective minOccurs of 0, so a derived group may narrow a base
+  group{1,1} whose content is emptiable to {0,1}. Wired into the `groupRestrictsGroup` choice:choice case AND
+  the base-all cases — both the XSD 1.1 occurrence-COUNTING fast-path (`bg.Compositor == CompositorAll`, no
+  wildcards, gating `allRestrictsByCounting`) and the all:all switch branch (gating
+  `recurseAll`/`allRestrictsWithWildcards`). The emptiable-base sequence:sequence case is handled by
+  `particleLanguageSubset`. Gated Version11; XSD 1.0 keeps the strict `rMin >= bMin` check, byte-identical.
 - **Wildcard Element Declarations Consistent (EDC)**:
-  - STATIC type-table check (`check_element_consistent.go` `checkWildcardElementConsistent`, gated Version11): rejects a content model whose LOCAL element particle and a same-named GLOBAL element declaration reachable through a lax/strict wildcard have inconsistent {type table}s (CTA). Only the type TABLE is compared — a differing type DEFINITION is permitted; both-present {type table}s must be EQUIVALENT and the asymmetric empty-vs-present case is flagged (`typeTablesConsistent` reuses `typeTablesEquivalent`); a `skip` wildcard imposes no constraint (`anyWildcardAllows` skips it). The examined set INCLUDES the type's EFFECTIVE OPEN-CONTENT wildcard (td.OpenContent, threaded at the call site): interleave open content can move an extra same-name declared child into the open partition and suffix can match a trailing one, where `validateWildcardChild` governs it via the GLOBAL's CTA type table (a skip open wildcard exempt). The STATIC check SUFFICES; the DYNAMIC EDC enforces a DIFFERENT constraint (governing-type DEFINITION substitutability), not type-table equivalence.
-  - DYNAMIC check (`validate_elem.go` `validateWildcardElementConsistent` + `edcLocalDecls`): walks the matched type's BASE chain (`vc.edcType`, set/restored by `validateContentByType`) in addition to the current content model — a restriction that drops a base's local element declaration but admits the name through a wildcard must have its wildcard governing type validly substitutable for the base's local type AND not blocked by the base-local's EFFECTIVE `{disallowed substitutions}` — the UNION of the element declaration's block and its declared TYPE's `{prohibited substitutions}` masked to the DERIVATION bits (`(decl.Block | localType.prohibitedSubstitutions()) & (BlockExtension | BlockRestriction)`, cvc-elt.4.3) — else invalid. Open-content-admitted children get the SAME check: `validateOpenChildren` threads the declared content model as the edcScope into `matchWildcardParticle` (NOT nil), so an interleave-refined declared-name child moved into open is checked against the same-named local declaration's type.
+  - STATIC type-table check (`check_element_consistent.go` `checkWildcardElementConsistent`, gated Version11):
+    rejects a content model whose LOCAL element particle and a same-named GLOBAL element declaration reachable
+    through a lax/strict wildcard have inconsistent {type table}s (CTA). Only the type TABLE is compared — a
+    differing type DEFINITION is permitted; both-present {type table}s must be EQUIVALENT and the asymmetric
+    empty-vs-present case is flagged (`typeTablesConsistent` reuses `typeTablesEquivalent`); a `skip` wildcard
+    imposes no constraint (`anyWildcardAllows` skips it). The examined set INCLUDES the type's EFFECTIVE
+    OPEN-CONTENT wildcard (td.OpenContent, threaded at the call site): interleave open content can move an
+    extra same-name declared child into the open partition and suffix can match a trailing one, where
+    `validateWildcardChild` governs it via the GLOBAL's CTA type table (a skip open wildcard exempt). The
+    STATIC check SUFFICES; the DYNAMIC EDC enforces a DIFFERENT constraint (governing-type DEFINITION
+    substitutability), not type-table equivalence.
+  - DYNAMIC check (`validate_elem.go` `validateWildcardElementConsistent` + `edcLocalDecls`): walks the
+    matched type's BASE chain (`vc.edcType`, set/restored by `validateContentByType`) in addition to the
+    current content model — a restriction that drops a base's local element declaration but admits the name
+    through a wildcard must have its wildcard governing type validly substitutable for the base's local type
+    AND not blocked by the base-local's EFFECTIVE `{disallowed substitutions}` — the UNION of the element
+    declaration's block and its declared TYPE's `{prohibited substitutions}` masked to the DERIVATION bits
+    (`(decl.Block | localType.prohibitedSubstitutions()) & (BlockExtension | BlockRestriction)`, cvc-elt.4.3)
+    — else invalid. Open-content-admitted children get the SAME check: `validateOpenChildren` threads the
+    declared content model as the edcScope into `matchWildcardParticle` (NOT nil), so an interleave-refined
+    declared-name child moved into open is checked against the same-named local declaration's type.

--- a/.claude/docs/xsd11-doc-walks.md
+++ b/.claude/docs/xsd11-doc-walks.md
@@ -1,17 +1,70 @@
 # XSD 1.1 — Document-Wide Walks
 
-> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
+> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the
+> 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the
+> governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
 
 - **document-wide xs:ID/xs:IDREF/xs:IDREFS validation** (`validate_id.go`): a third validation walk, run in BOTH XSD 1.0 and 1.1 (cvc-id is version-INDEPENDENT), enforcing ID uniqueness and IDREF referential integrity.
-  - Ownership: an attribute ID belongs to its element, an element-content ID to its PARENT. On the DOCUMENT ROOT an element-content ID has no parent, denoting NO element — `idOwner` nil, `recordID` skips it, the value never enters the table, any xs:IDREF to it dangles (W3C idIDREF s3_3_4ii26/ii27).
-  - 1.1 multiple-ID relaxation: a value may recur while each occurrence identifies ONE element (two ID attributes of one element, or two ID element-content children of one parent) — `recordID` `prev == owner`, Version11. XSD 1.0 has NO relaxation: each distinct ID-bearing item MUST be unique; a repeat is a duplicate even on one owner (W3C elemZ016 / idconstrdefs00301m2_n).
-  - XSD 1.0 allows AT MOST ONE xs:ID-typed attribute per element (Version10-only — W3C attZ014a/attZ014b); 1.1 removed it. An attribute counts iff `collectIDFromValue` records at least one xs:ID leaf — the SAME value-dependent list/union active-member decomposition as the uniqueness collection (`union(xs:int, xs:ID)` counts only when its value selects the xs:ID member; a list of xs:ID counts with ID tokens). Enforces the INSTANCE manifestation (>1 ID-typed attribute PRESENT; covers attZ014a/b's wildcard-supplied globals).
-  - Companion XSD 1.0 COMPILE-TIME Schema Component Constraint (Part 1 §3.4.6, W3C ctM004): a complex type must not have more than one attribute USE whose {type definition} is or derives from xs:ID, even when one/both are optional and never both present — `checkIDAttributeUses` (`check_id_attributes.go`, from `compile.go` after `resolveRefs`, so effective attribute uses — including those from xs:attributeGroup refs and inherited via extension/restriction, folded into `td.Attributes` by the 1.0 merge — are finalized). `attrUseIsIDType` counts iff the resolved type is atomic (`resolveVariety == TypeVarietyAtomic`) with builtin base xs:ID; a list of xs:ID or a union with an xs:ID member does NOT count. Gated to Version10.
+  - Ownership: an attribute ID belongs to its element, an element-content ID to its PARENT. On the DOCUMENT
+    ROOT an element-content ID has no parent, denoting NO element — `idOwner` nil, `recordID` skips it, the
+    value never enters the table, any xs:IDREF to it dangles (W3C idIDREF s3_3_4ii26/ii27).
+  - 1.1 multiple-ID relaxation: a value may recur while each occurrence identifies ONE element (two ID
+    attributes of one element, or two ID element-content children of one parent) — `recordID` `prev == owner`,
+    Version11. XSD 1.0 has NO relaxation: each distinct ID-bearing item MUST be unique; a repeat is a
+    duplicate even on one owner (W3C elemZ016 / idconstrdefs00301m2_n).
+  - XSD 1.0 allows AT MOST ONE xs:ID-typed attribute per element (Version10-only — W3C attZ014a/attZ014b); 1.1
+    removed it. An attribute counts iff `collectIDFromValue` records at least one xs:ID leaf — the SAME
+    value-dependent list/union active-member decomposition as the uniqueness collection (`union(xs:int,
+    xs:ID)` counts only when its value selects the xs:ID member; a list of xs:ID counts with ID tokens).
+    Enforces the INSTANCE manifestation (>1 ID-typed attribute PRESENT; covers attZ014a/b's wildcard-supplied
+    globals).
+  - Companion XSD 1.0 COMPILE-TIME Schema Component Constraint (Part 1 §3.4.6, W3C ctM004): a complex type
+    must not have more than one attribute USE whose {type definition} is or derives from xs:ID, even when
+    one/both are optional and never both present — `checkIDAttributeUses` (`check_id_attributes.go`, from
+    `compile.go` after `resolveRefs`, so effective attribute uses — including those from xs:attributeGroup
+    refs and inherited via extension/restriction, folded into `td.Attributes` by the 1.0 merge — are
+    finalized). `attrUseIsIDType` counts iff the resolved type is atomic (`resolveVariety ==
+    TypeVarietyAtomic`) with builtin base xs:ID; a list of xs:ID or a union with an xs:ID member does NOT
+    count. Gated to Version10.
   - DEFERRED gap: the full "wild IDs" rule, where a declared ID attribute use plus a wildcard-admitted global ID attribute is invalid even with the declared use absent.
-  - list/union values decompose to atomic ID/IDREF leaves via the active-member resolver. Element-content collection is SKIPPED when the element has CHILD ELEMENTS (`hasChildElement`; simple content forbids them, so pass 1 already rejected it structurally; `elemTextContent` ignores children, and a default/fixed must not substitute for non-empty content — else a spurious duplicate/dangling).
-  - A default/fixed value applies only to genuinely-empty content, NEVER a CONFIRMED nilled element — a DECLARED nillable (`idcHostDecl(elem).Nillable`) carrying `xsi:nil="true"` (else a fabricated duplicate ID or dangling IDREF). By DECLARATION, not raw `xsi:nil`: a lax no-declaration element with `xsi:nil` is NOT validly nilled, so its real (assessed) content is still collected. Attribute IDs always apply on a nilled element.
-  - Element typing uses ONLY `assessedElemType` (attribute typing ONLY `actualAttrType`), recorded at genuine pass-1 ASSESSMENT sites — NEVER `actualElemType` (also written `assessed=false` for `processContents="skip"`/lax-no-declaration subtrees, pass-2 IDC canonicalization only), NEVER `actualElemDecl` (written by `recordElemDecl` at the particle-MATCH scan BEFORE content validation, so a matched-but-unassessed child — e.g. an unsatisfied `minOccurs` — would misclassify into a spurious duplicate/dangling), NEVER a global fallback. `idcHostDecl` (default/fixed/nillable metadata) is consulted only AFTER an assessed type exists.
-  - A `processContents="lax"` element with no declaration but a RESOLVABLE `xsi:type` is laxly assessed by `assessLaxElement` (validated against that type, `assessed=true`) — for a directly wildcard-matched lax element (`matchWildcardParticle`), an xs:anyType/lax descendant (`annotateAnyTypeChildren`), AND the VALIDATION ROOT (`validateRootElement`, cvc-assess-elt.1.2: a root with no matching global element declaration but a resolvable `xsi:type` is governed by that type — scoped to a lax fragment-validating caller via `cfg.skipDatatypeIntegrity`, the xslt3 source-validation path; a full standalone document validation keeps the strict "no matching global declaration" root policy for libxml2 parity). Its `xsi:type="xs:ID"`/`xs:IDREF` content then participates in the ID/IDREF pass.
-  - An undeclared element has no nillable declaration, so `xsi:nil="true"` does NOT exempt it: content is still checked against the governing type (a nilled lax element with invalid/forbidden content is rejected). `skip` content is NEVER assessed (even one carrying `xsi:type="xs:ID"` is not mis-typed). A STRICT wildcard FAILURE (no global declaration) is likewise NOT assessed — `validateWildcardChild` walks its subtree with `annotateSkipChildren` (canonicalization-only), NOT `annotateAnyTypeChildren` (which would laxly ASSESS globally-declared/xsi:typed descendants and fabricate a spurious duplicate-ID/dangling atop the real strict error).
+  - list/union values decompose to atomic ID/IDREF leaves via the active-member resolver. Element-content
+    collection is SKIPPED when the element has CHILD ELEMENTS (`hasChildElement`; simple content forbids them,
+    so pass 1 already rejected it structurally; `elemTextContent` ignores children, and a default/fixed must
+    not substitute for non-empty content — else a spurious duplicate/dangling).
+  - A default/fixed value applies only to genuinely-empty content, NEVER a CONFIRMED nilled element — a
+    DECLARED nillable (`idcHostDecl(elem).Nillable`) carrying `xsi:nil="true"` (else a fabricated duplicate ID
+    or dangling IDREF). By DECLARATION, not raw `xsi:nil`: a lax no-declaration element with `xsi:nil` is NOT
+    validly nilled, so its real (assessed) content is still collected. Attribute IDs always apply on a nilled
+    element.
+  - Element typing uses ONLY `assessedElemType` (attribute typing ONLY `actualAttrType`), recorded at genuine
+    pass-1 ASSESSMENT sites — NEVER `actualElemType` (also written `assessed=false` for
+    `processContents="skip"`/lax-no-declaration subtrees, pass-2 IDC canonicalization only), NEVER
+    `actualElemDecl` (written by `recordElemDecl` at the particle-MATCH scan BEFORE content validation, so a
+    matched-but-unassessed child — e.g. an unsatisfied `minOccurs` — would misclassify into a spurious
+    duplicate/dangling), NEVER a global fallback. `idcHostDecl` (default/fixed/nillable metadata) is consulted
+    only AFTER an assessed type exists.
+  - A `processContents="lax"` element with no declaration but a RESOLVABLE `xsi:type` is laxly assessed by
+    `assessLaxElement` (validated against that type, `assessed=true`) — for a directly wildcard-matched lax
+    element (`matchWildcardParticle`), an xs:anyType/lax descendant (`annotateAnyTypeChildren`), AND the
+    VALIDATION ROOT (`validateRootElement`, cvc-assess-elt.1.2: a root with no matching global element
+    declaration but a resolvable `xsi:type` is governed by that type — scoped to a lax fragment-validating
+    caller via `cfg.skipDatatypeIntegrity`, the xslt3 source-validation path; a full standalone document
+    validation keeps the strict "no matching global declaration" root policy for libxml2 parity). Its
+    `xsi:type="xs:ID"`/`xs:IDREF` content then participates in the ID/IDREF pass.
+  - An undeclared element has no nillable declaration, so `xsi:nil="true"` does NOT exempt it: content is
+    still checked against the governing type (a nilled lax element with invalid/forbidden content is
+    rejected). `skip` content is NEVER assessed (even one carrying `xsi:type="xs:ID"` is not mis-typed). A
+    STRICT wildcard FAILURE (no global declaration) is likewise NOT assessed — `validateWildcardChild` walks
+    its subtree with `annotateSkipChildren` (canonicalization-only), NOT `annotateAnyTypeChildren` (which
+    would laxly ASSESS globally-declared/xsi:typed descendants and fabricate a spurious duplicate-ID/dangling
+    atop the real strict error).
 
-- **document-wide xs:ENTITY/xs:ENTITIES value-space validation** (`validate_entity.go`): `validateEntities`, a fourth validation walk gated to 1.1, called from `validate.go` right after `validateIDIDREF`, enforces cvc-id/§3.3.11 — every xs:ENTITY token MUST name an external general UNPARSED entity declared in the instance's DTD (`doc.GetEntity(tok)` found && `EntityType()==enum.ExternalGeneralUnparsedEntity`). It mirrors `validateIDIDREF`'s structure (`entityFamilyType` like `idFamilyType`; `checkEntityValue` clones `collectIDFromValue`'s list/union/active-member decomposition; the same `elementTypeForID`/`attrTypeForID`, default/fixed substitution, nilled-element, and `hasChildElement` guards) but needs no cross-element table since the DTD entity table is known up front. Fixes saxonData/Id id017-021 (ENTITY/ENTITIES attribute defaults, a union(ENTITY,integer), and ENTITY/ENTITIES element content). 1.0 stays byte-identical.
+- **document-wide xs:ENTITY/xs:ENTITIES value-space validation** (`validate_entity.go`): `validateEntities`, a
+  fourth validation walk gated to 1.1, called from `validate.go` right after `validateIDIDREF`, enforces
+  cvc-id/§3.3.11 — every xs:ENTITY token MUST name an external general UNPARSED entity declared in the
+  instance's DTD (`doc.GetEntity(tok)` found && `EntityType()==enum.ExternalGeneralUnparsedEntity`). It
+  mirrors `validateIDIDREF`'s structure (`entityFamilyType` like `idFamilyType`; `checkEntityValue` clones
+  `collectIDFromValue`'s list/union/active-member decomposition; the same `elementTypeForID`/`attrTypeForID`,
+  default/fixed substitution, nilled-element, and `hasChildElement` guards) but needs no cross-element table
+  since the DTD entity table is known up front. Fixes saxonData/Id id017-021 (ENTITY/ENTITIES attribute
+  defaults, a union(ENTITY,integer), and ENTITY/ENTITIES element content). 1.0 stays byte-identical.

--- a/.claude/docs/xsd11-identity-constraints.md
+++ b/.claude/docs/xsd11-identity-constraints.md
@@ -1,20 +1,112 @@
 # XSD 1.1 — Identity Constraints
 
-> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
+> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the
+> 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the
+> governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
 
-- **identity-constraint @xpathDefaultNamespace** — a local value on xs:selector/xs:field resolves via `resolveXPathDefaultNSToken`; else the schema-level value is inherited, but ONLY when absent (PRESENCE via `hasAttr`), so `xpathDefaultNamespace=""` means "no default element namespace" and does NOT inherit. Supports `##targetNamespace`/`##defaultNamespace`/`##local`/URI via the opt-in `xpath1.Evaluator.DefaultElementNamespace`, affecting only unprefixed ELEMENT name tests, never attributes. The schema-level default (`schemaXPathDefaultNS`) is pre-resolved to a URI against the SCHEMA ROOT at root-read time (so an inherited `##defaultNamespace` uses the ROOT's default namespace, not a selector/field that may redeclare `xmlns`) and is PER-document: like elementFormDefault/blockDefault/finalDefault, saved/set/restored across `xs:include`/`xs:redefine` and set on the import sub-compiler in `compile_imports.go`, so an included/imported schema's IDCs use ITS root's value.
-- **identity-constraint @ref** (`resolveConstraintRefs`, `compile.go`) — a key/unique/keyref with `@ref` reuses a same-kind referenced constraint's selector/fields (and a keyref's refer), adopting its QName identity. `@ref` detected by PRESENCE (`hasAttr`, so `ref=""` is recognized). Fatal schema error: dangling ref, empty `@ref`, malformed non-`xs:QName` `@ref`/`@refer` (e.g. `:u`; validated via `validateQName` before prefix resolution, so a leading colon isn't resolved as unprefixed), unbound `@ref` prefix, kind mismatch, or a `@ref` also carrying name/selector/field/refer. `name`/`refer` companions detected by PRESENCE (`hasAttr`, so empty-but-present `name=""`/`refer=""` is still rejected); `refer` is rejected for EVERY kind, not just keyref.
+- **identity-constraint @xpathDefaultNamespace** — a local value on xs:selector/xs:field resolves via
+  `resolveXPathDefaultNSToken`; else the schema-level value is inherited, but ONLY when absent (PRESENCE via
+  `hasAttr`), so `xpathDefaultNamespace=""` means "no default element namespace" and does NOT inherit.
+  Supports `##targetNamespace`/`##defaultNamespace`/`##local`/URI via the opt-in
+  `xpath1.Evaluator.DefaultElementNamespace`, affecting only unprefixed ELEMENT name tests, never attributes.
+  The schema-level default (`schemaXPathDefaultNS`) is pre-resolved to a URI against the SCHEMA ROOT at
+  root-read time (so an inherited `##defaultNamespace` uses the ROOT's default namespace, not a selector/field
+  that may redeclare `xmlns`) and is PER-document: like elementFormDefault/blockDefault/finalDefault,
+  saved/set/restored across `xs:include`/`xs:redefine` and set on the import sub-compiler in
+  `compile_imports.go`, so an included/imported schema's IDCs use ITS root's value.
+- **identity-constraint @ref** (`resolveConstraintRefs`, `compile.go`) — a key/unique/keyref with `@ref`
+  reuses a same-kind referenced constraint's selector/fields (and a keyref's refer), adopting its QName
+  identity. `@ref` detected by PRESENCE (`hasAttr`, so `ref=""` is recognized). Fatal schema error: dangling
+  ref, empty `@ref`, malformed non-`xs:QName` `@ref`/`@refer` (e.g. `:u`; validated via `validateQName` before
+  prefix resolution, so a leading colon isn't resolved as unprefixed), unbound `@ref` prefix, kind mismatch,
+  or a `@ref` also carrying name/selector/field/refer. `name`/`refer` companions detected by PRESENCE
+  (`hasAttr`, so empty-but-present `name=""`/`refer=""` is still rejected); `refer` is rejected for EVERY
+  kind, not just keyref.
 - **identity-constraint structural rules** (version-INDEPENDENT — BOTH XSD 1.0 and 1.1):
   - `parseIDConstraint` (`read_elements.go`) rejects a constraint `@name` that is not a valid `xs:NCName` (`xmlchar.IsValidNCName`, so `a:b`/`1foo` fail) and a `@refer` on a non-keyref (key/unique).
   - `checkKeyRefRefers` (`compile.go`) rejects a keyref whose `{fields}` cardinality differs from the referenced key/unique's.
-  - `checkIDConstraintPlacement` (`check_idc.go`, a DOM walk over the entry document and every included/imported/redefined/overridden document) enforces schema-for-schemas placement: `xs:key`/`xs:unique`/`xs:keyref` valid ONLY as a child of an `xs:element` declaration (elsewhere — top level or inside `xs:attribute`/`xs:group`/`xs:attributeGroup`/`xs:complexType`/`xs:simpleType`/a model group/`xs:selector`/`xs:field` — a schema error, else silently dropped); `xs:selector`/`xs:field` valid ONLY as a child of an identity constraint, content model `(annotation?)` with only `{id?, xpath, xpathDefaultNamespace?}` attributes (a stray non-annotation child, a second annotation, or an unexpected unqualified attribute such as `name` is a schema error).
-  - IDC selector/field `@xpath` restricted-subset validation IS implemented (§3.11.6): `compileIDCXPath`/`validateIDCXPathLexical`/`validateIDCLocationPath` (`read_elements.go`, version-INDEPENDENT) reject a spelled-out node-type test (any `(`, e.g. `self::node()`), a `//` other than the single whitespace-tolerant path-leading `.//` (so `. //.`/`.// .` valid; `.//.//x`, `a/.//b` rejected), insignificant whitespace ADJACENT to the single `:` of a name-test QName (`validateIDCQNameColons`: `xpns: *`/`xpns: id`/`xpns :id` split the prefix from the local part — a QName is one lexical token — but the `::` axis separator is exempt so `child :: item`/`attribute :: id` stay tolerated), and a name-test prefix unbound in the SELECTOR/FIELD element's OWN in-scope namespaces (`collectNSContext(ce)`; `xml` always bound; compile-time scope per selector/field element, `idc.Namespaces` runtime unchanged).
+  - `checkIDConstraintPlacement` (`check_idc.go`, a DOM walk over the entry document and every
+    included/imported/redefined/overridden document) enforces schema-for-schemas placement:
+    `xs:key`/`xs:unique`/`xs:keyref` valid ONLY as a child of an `xs:element` declaration (elsewhere — top
+    level or inside `xs:attribute`/`xs:group`/`xs:attributeGroup`/`xs:complexType`/`xs:simpleType`/a model
+    group/`xs:selector`/`xs:field` — a schema error, else silently dropped); `xs:selector`/`xs:field` valid
+    ONLY as a child of an identity constraint, content model `(annotation?)` with only `{id?, xpath,
+    xpathDefaultNamespace?}` attributes (a stray non-annotation child, a second annotation, or an unexpected
+    unqualified attribute such as `name` is a schema error).
+  - IDC selector/field `@xpath` restricted-subset validation IS implemented (§3.11.6):
+    `compileIDCXPath`/`validateIDCXPathLexical`/`validateIDCLocationPath` (`read_elements.go`,
+    version-INDEPENDENT) reject a spelled-out node-type test (any `(`, e.g. `self::node()`), a `//` other than
+    the single whitespace-tolerant path-leading `.//` (so `. //.`/`.// .` valid; `.//.//x`, `a/.//b`
+    rejected), insignificant whitespace ADJACENT to the single `:` of a name-test QName
+    (`validateIDCQNameColons`: `xpns: *`/`xpns: id`/`xpns :id` split the prefix from the local part — a QName
+    is one lexical token — but the `::` axis separator is exempt so `child :: item`/`attribute :: id` stay
+    tolerated), and a name-test prefix unbound in the SELECTOR/FIELD element's OWN in-scope namespaces
+    (`collectNSContext(ce)`; `xml` always bound; compile-time scope per selector/field element,
+    `idc.Namespaces` runtime unchanged).
   - Known remaining IDC gap (still accepted): a `fixed` value on a repeating `xs:ID` attribute.
-- **identity-constraint field-node classification** (cvc-identity-constraint.3 / XSD 1.1 §3.11.4): `evaluateIDC` (`validate_idc.go`) classifies each `xs:key`/`xs:unique`/`xs:keyref` `<xs:field>` result node via ONE helper `classifyFieldNode` → `fieldGoverned` | `fieldSkipped` | `fieldViolation` (the empty node-set / a string-or-number result contributes a value with no node, unaffected). Based ONLY on assessment records `assessedElemType` (elements)/`assessedAttrs` (attributes), written EXCLUSIVELY at pass-1 assessment sites — NEVER the canonicalization-only `actualElemType`/`actualAttrType` maps (also written for `processContents="skip"`/lax-no-declaration subtrees) nor a schema-declaration/content-model fallback. `assessedAttrs`, the presence-only companion of `actualAttrType`, is recorded by `annotateAttrUse` (a declared use, typed OR untyped; a default/fixed insertion; a strict/lax wildcard WITH a matching global) and `validateWildcardAttr`, so an UNTYPED assessed attribute ({type definition} = xs:anySimpleType) is assessed though it records no `*TypeDef`. A field node is:
+- **identity-constraint field-node classification** (cvc-identity-constraint.3 / XSD 1.1 §3.11.4):
+  `evaluateIDC` (`validate_idc.go`) classifies each `xs:key`/`xs:unique`/`xs:keyref` `<xs:field>` result node
+  via ONE helper `classifyFieldNode` → `fieldGoverned` | `fieldSkipped` | `fieldViolation` (the empty node-set
+  / a string-or-number result contributes a value with no node, unaffected). Based ONLY on assessment records
+  `assessedElemType` (elements)/`assessedAttrs` (attributes), written EXCLUSIVELY at pass-1 assessment sites —
+  NEVER the canonicalization-only `actualElemType`/`actualAttrType` maps (also written for
+  `processContents="skip"`/lax-no-declaration subtrees) nor a schema-declaration/content-model fallback.
+  `assessedAttrs`, the presence-only companion of `actualAttrType`, is recorded by `annotateAttrUse` (a
+  declared use, typed OR untyped; a default/fixed insertion; a strict/lax wildcard WITH a matching global) and
+  `validateWildcardAttr`, so an UNTYPED assessed attribute ({type definition} = xs:anySimpleType) is assessed
+  though it records no `*TypeDef`. A field node is:
   - **GOVERNED** (contributes its typed value): an assessed attribute (always simple; untyped = xs:anySimpleType) OR an assessed element whose type is simple (`!IsComplex`) or complex with SIMPLE content (`ContentType == ContentTypeSimple`).
-  - **VIOLATION** (a cvc-identity-constraint.3 non-simple error): an assessed COMPLEX element with element-only/mixed/empty content (idG006/idK012) — BOTH versions — OR, in XSD 1.0 (no skipped-node relaxation), ANY unassessed/unresolved node (idZ015: a skip/lax-without-global-admitted attribute, an attribute whose ancestor element is skip content, or an element whose type could not be assessed).
-  - **SKIPPED** (contributes NO value; drops out of the qualified node-set, so a `key` field left absent surfaces as a normal keyMissing violation, not a non-simple error): EVERY unassessed field node in XSD 1.1 — a `processContents="skip"` wildcard-matched element (also excluded at the selector via `skipContentNodes`), an attribute admitted only by a skip/lax-without-global `xs:anyAttribute` wildcard or whose ancestor element is skipped, and any node with no PSVI type. A matching GLOBAL attribute declaration does NOT make a wildcard-skip-admitted attribute assessed.
+  - **VIOLATION** (a cvc-identity-constraint.3 non-simple error): an assessed COMPLEX element with
+    element-only/mixed/empty content (idG006/idK012) — BOTH versions — OR, in XSD 1.0 (no skipped-node
+    relaxation), ANY unassessed/unresolved node (idZ015: a skip/lax-without-global-admitted attribute, an
+    attribute whose ancestor element is skip content, or an element whose type could not be assessed).
+  - **SKIPPED** (contributes NO value; drops out of the qualified node-set, so a `key` field left absent
+    surfaces as a normal keyMissing violation, not a non-simple error): EVERY unassessed field node in XSD 1.1
+    — a `processContents="skip"` wildcard-matched element (also excluded at the selector via
+    `skipContentNodes`), an attribute admitted only by a skip/lax-without-global `xs:anyAttribute` wildcard or
+    whose ancestor element is skipped, and any node with no PSVI type. A matching GLOBAL attribute declaration
+    does NOT make a wildcard-skip-admitted attribute assessed.
 
-  An xsi:type actual type recorded purely for canonicalization does NOT count as an assessment (a skip-content field is SKIPPED in 1.1 / VIOLATION in 1.0, whatever its xsi:type). `classifyFieldNode` applies to EVERY node of a multi-member result: §3.11.4 DROPS all SKIPPED nodes, then any VIOLATION makes the field a non-simple error, and of the remaining GOVERNED nodes at most ONE may survive — ZERO is an absent field, EXACTLY ONE contributes its value, MORE THAN ONE is the cardinality error (`table.fieldError`, "a node-set with more than one member"). So `<xs:field xpath="*">` selecting two `processContents="skip"` children contributes NO value in 1.1 (both skipped), so the >1-member check never fires, while two GOVERNED nodes still fail it in BOTH versions. The single-node path is the one-member case. `table.fieldType` surfaces a VIOLATION as a validation failure.
-- **identity-constraint field-value canonicalization** (version-INDEPENDENT — cvc-identity-constraint.3 value equality is "same value in the same PRIMITIVE datatype"): `canonicalFieldKey`→`canonicalValueKey`→`canonicalAtomicKey` (`validate_idc.go`) maps each `<xs:field>` value to a canonical key so lexically-distinct value-equal inputs collide (`5`/`+5` for xs:integer) while cross-primitive equal-looking values do NOT. `canonicalAtomicKey` TAGS every atomic key with the value's XSD PRIMITIVE base (`atomicPrimitiveLocal(builtinBaseLocal(td))`): the XSD 1.1 derived builtins fold via `builtinType11Bases` (xs:dayTimeDuration/xs:yearMonthDuration → `duration`, xs:dateTimeStamp → `dateTime`), the xs:decimal/integer family → `decimal`, the xs:string-derived family → `string`, each of the 19 XSD primitives its own; joined to the value by `primitiveKeySeparator` (`\x01`, absent from every NCName primitive name and from `formatKeySequence`'s `\x00` field separator, so `primitive\x01value` splits unambiguously). So a boolean `1`, an xs:decimal/xs:integer/xs:int `1`, an xs:float `1`, and an xs:string `1` are FOUR distinct keys (idF012/idF013/idF014/idL090), while types sharing a primitive collide by value — xs:int vs xs:integer; xs:duration `PT24H` vs xs:dayTimeDuration `P1D`; xs:dateTime vs xs:dateTimeStamp (derived folds to primitive). xs:QName and xs:NOTATION tag distinct primitives (same-Clark-name values stay apart); float vs double / decimal vs float / date vs dateTime stay distinct. The tag derives from the field's ASSESSED type (`assessedElemType`/`assessedAttrs`, e.g. an xsi:type actual type). The QName/NOTATION Clark-name key and the `value.CanonicalKey` value form are unchanged — only the primitive prefix is added. A list canonicalizes each item and a union its active member through `canonicalValueKey` (each atomic leaf carrying its own primitive tag); an unresolvable type or QName falls back to the untagged raw value (colliding only with equally-unresolvable raw values). In **XSD 1.1** a SINGLETON list (`len(fields) == 1`) is UNWRAPPED by `canonicalListKey` to its single item's atomic key, leaving the length-tagged `list\x01…` form for everything else, because an IDC field's actual value is a SEQUENCE and a one-item list is the same sequence as that item's atomic value — so a singleton keyref list equals an atomic key of the same value (cvc-identity-constraint / §3.11.4, W3C saxonData Id id022: an xs:Name key field and a `xs:list itemType="xs:Name"` keyref field match on a one-token ref). A multi-item (or empty) list keeps the length-tagged list key, so it can never equal an atomic or a differently-sized list. Version11-gated: XSD 1.0 keeps the list wrapper for EVERY list (byte-identical to origin), so a singleton list and an atomic stay distinct.
-- **Skip-wildcard IDC selector scoping**: `annotateSkipChildren` records every element inside a `processContents="skip"` subtree in `vc.skipContentNodes`, and `evaluateIDC` drops those nodes from the selector node-set, so an un-assessed skip-content element is never constrained by an ancestor `xs:key`/`xs:unique`/`xs:keyref` (the pass-3 ID/IDREF pass already excluded skip content; this fixes pass-2). 1.1 only — the set is empty in 1.0, byte-identical. `resolveOpenContentDefinedSiblings` resolves the `xs:defaultOpenContent` schema-level default `##definedSibling` interleave case.
+  An xsi:type actual type recorded purely for canonicalization does NOT count as an assessment (a skip-content
+  field is SKIPPED in 1.1 / VIOLATION in 1.0, whatever its xsi:type). `classifyFieldNode` applies to EVERY
+  node of a multi-member result: §3.11.4 DROPS all SKIPPED nodes, then any VIOLATION makes the field a
+  non-simple error, and of the remaining GOVERNED nodes at most ONE may survive — ZERO is an absent field,
+  EXACTLY ONE contributes its value, MORE THAN ONE is the cardinality error (`table.fieldError`, "a node-set
+  with more than one member"). So `<xs:field xpath="*">` selecting two `processContents="skip"` children
+  contributes NO value in 1.1 (both skipped), so the >1-member check never fires, while two GOVERNED nodes
+  still fail it in BOTH versions. The single-node path is the one-member case. `table.fieldType` surfaces a
+  VIOLATION as a validation failure.
+- **identity-constraint field-value canonicalization** (version-INDEPENDENT — cvc-identity-constraint.3 value
+  equality is "same value in the same PRIMITIVE datatype"):
+  `canonicalFieldKey`→`canonicalValueKey`→`canonicalAtomicKey` (`validate_idc.go`) maps each `<xs:field>`
+  value to a canonical key so lexically-distinct value-equal inputs collide (`5`/`+5` for xs:integer) while
+  cross-primitive equal-looking values do NOT. `canonicalAtomicKey` TAGS every atomic key with the value's XSD
+  PRIMITIVE base (`atomicPrimitiveLocal(builtinBaseLocal(td))`): the XSD 1.1 derived builtins fold via
+  `builtinType11Bases` (xs:dayTimeDuration/xs:yearMonthDuration → `duration`, xs:dateTimeStamp → `dateTime`),
+  the xs:decimal/integer family → `decimal`, the xs:string-derived family → `string`, each of the 19 XSD
+  primitives its own; joined to the value by `primitiveKeySeparator` (`\x01`, absent from every NCName
+  primitive name and from `formatKeySequence`'s `\x00` field separator, so `primitive\x01value` splits
+  unambiguously). So a boolean `1`, an xs:decimal/xs:integer/xs:int `1`, an xs:float `1`, and an xs:string `1`
+  are FOUR distinct keys (idF012/idF013/idF014/idL090), while types sharing a primitive collide by value —
+  xs:int vs xs:integer; xs:duration `PT24H` vs xs:dayTimeDuration `P1D`; xs:dateTime vs xs:dateTimeStamp
+  (derived folds to primitive). xs:QName and xs:NOTATION tag distinct primitives (same-Clark-name values stay
+  apart); float vs double / decimal vs float / date vs dateTime stay distinct. The tag derives from the
+  field's ASSESSED type (`assessedElemType`/`assessedAttrs`, e.g. an xsi:type actual type). The QName/NOTATION
+  Clark-name key and the `value.CanonicalKey` value form are unchanged — only the primitive prefix is added. A
+  list canonicalizes each item and a union its active member through `canonicalValueKey` (each atomic leaf
+  carrying its own primitive tag); an unresolvable type or QName falls back to the untagged raw value
+  (colliding only with equally-unresolvable raw values). In **XSD 1.1** a SINGLETON list (`len(fields) == 1`)
+  is UNWRAPPED by `canonicalListKey` to its single item's atomic key, leaving the length-tagged `list\x01…`
+  form for everything else, because an IDC field's actual value is a SEQUENCE and a one-item list is the same
+  sequence as that item's atomic value — so a singleton keyref list equals an atomic key of the same value
+  (cvc-identity-constraint / §3.11.4, W3C saxonData Id id022: an xs:Name key field and a `xs:list
+  itemType="xs:Name"` keyref field match on a one-token ref). A multi-item (or empty) list keeps the
+  length-tagged list key, so it can never equal an atomic or a differently-sized list. Version11-gated: XSD
+  1.0 keeps the list wrapper for EVERY list (byte-identical to origin), so a singleton list and an atomic stay
+  distinct.
+- **Skip-wildcard IDC selector scoping**: `annotateSkipChildren` records every element inside a
+  `processContents="skip"` subtree in `vc.skipContentNodes`, and `evaluateIDC` drops those nodes from the
+  selector node-set, so an un-assessed skip-content element is never constrained by an ancestor
+  `xs:key`/`xs:unique`/`xs:keyref` (the pass-3 ID/IDREF pass already excluded skip content; this fixes
+  pass-2). 1.1 only — the set is empty in 1.0, byte-identical. `resolveOpenContentDefinedSiblings` resolves
+  the `xs:defaultOpenContent` schema-level default `##definedSibling` interleave case.

--- a/.claude/docs/xsd11-representation.md
+++ b/.claude/docs/xsd11-representation.md
@@ -1,66 +1,550 @@
 # XSD 1.1 — Representation & Composition
 
-> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
+> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the
+> 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the
+> governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
 
-- XSD 1.1 **xsi: attribute references** (`validate.go` `validateAttributes`, gated Version11, 1.0 byte-identical): an xsi: processor attribute (xsi:type/xsi:nil/xsi:schemaLocation/xsi:noNamespaceSchemaLocation) referenced explicitly as an attribute use (any use: optional/required/prohibited) participates in ordinary attribute-use validation instead of being skipped — a present xsi:type satisfies a required use, absence reports missing, and `use="prohibited"` REJECTS a present xsi:type (detected via both allowed and prohibited use maps). Applies ONLY to the four real processor attributes (`isKnownXsiProcessorAttr`); a declared ref to any other xsi: local name (xsi:foo) stays skipped so a required use is never satisfied. A present non-prohibited use validates its value against the fixed built-in type (`validateDeclaredXsiAttrValue`: xsi:type→non-empty namespace-resolvable xs:QName; xsi:nil→xs:boolean; xsi:schemaLocation→non-empty even list of xs:anyURI tokenized via `value.XSDFields`, NBSP not a separator; xsi:noNamespaceSchemaLocation→xs:anyURI), since `ref="xsi:*"` resolves to no typed global attribute — so xsi:type="" / a malformed QName / a non-boolean xsi:nil is a validity error that does NOT satisfy a required use. The use is associated with its built-in SCALAR type in the ref-resolution loop (`link_refs.go` `xsiProcessorAttrBuiltinType`: xsi:type→xs:QName, xsi:nil→xs:boolean, xsi:noNamespaceSchemaLocation→xs:anyURI), so a fixed/default is validated at compile time (`checkAttrUseConstraints`: `ref="xsi:nil" fixed="notbool"` is a schema error) and compared in VALUE space at runtime (`fixedValueMatches`: xsi:nil="1" satisfies fixed="true"; a different-prefix/same-namespace xsi:type satisfies a QName fixed). The value is validated once by `validateDeclaredXsiAttrValue`; the generic type-based check is skipped for the declared use (`declaredXsiValueChecked`), but the fixed-value comparison still runs against the built-in type. xsi:schemaLocation (a LIST of xs:anyURI) has no scalar built-in, so its fixed/default uses list helpers (`validateXsiSchemaLocationValue`/`xsiSchemaLocationValueEqual`/`xsiSchemaLocationTokens`): the literal is validated at compile time (`checkAttrUseConstraints`: non-empty even list; odd/empty is a schema error), the runtime fixed comparison is by token-list equality (`isDeclaredXsiSchemaLocationUse` routes around `fixedValueMatches`), so `" urn:a   loc.xsd "` satisfies `fixed="urn:a loc.xsd"`. (anyURI lexical space is unrestricted, so the per-token check never fails; even/non-empty is the only reachable literal-validity constraint.) Undeclared/implicit xsi processing unchanged — Saxon Complex complex009/complex010.
-- **prohibited-attribute / special-attribute vs wildcard fallthrough** (`validate.go` `validateAttributes`, version-specific): an instance attribute matching a `use="prohibited"` declared use is rejected OUTRIGHT (never re-admitted by `<xs:anyAttribute>`) only in XSD 1.1, which retains the prohibited use in `{attribute uses}` to forbid the name (§3.4.4.2). In XSD 1.0 a prohibited use is ABSENT from `{attribute uses}`, so the attribute falls through to the `{attribute wildcard}` (or the "is not allowed" report) per cvc-complex-type.3 (W3C addB034/addB136/attZ002 — valid via the wildcard; the reject branch is gated `vc.version == Version11`). Separately, XSD 1.0 blanket-skips every XML-namespace attribute (`isSpecialAttr` treats xml:base/xml:lang/xml:space/xml:id as always-allowed), but an EXPLICITLY declared one (`declaredXML`: its QName is in the allowed/prohibited maps) participates in ordinary validation and satisfies a required use (W3C addC001 — `ref="xml:base" use="required"`). The governing type is associated at compile time by `xmlNamespaceAttrType` (`validate.go`, wired into `link_refs.go` alongside `xsiProcessorAttrBuiltinType`): a `ref="xml:*"` resolves to no user global attribute, so the built-in type is set onto the `AttrUse` per the standard xml: schema — xml:base→xs:anyURI, xml:id→xs:ID, xml:space→a restriction of xs:NCName enumerated {default, preserve}, xml:lang→a union of xs:language and the empty string — so xml:space="bogus"/an invalid xml:lang is a validity error (not silently accepted), and the value feeds the compile-time default/fixed constraint check. A declared `ref="xml:id"` (xs:ID) also participates in the document-wide ID pass (`validate_id.go`): the loop skips a special attribute only when NOT genuinely assessed (`assessedAttrs`), so a DECLARED xml:id (assessed via `annotateAttrUse`) is collected (a duplicate is a validity error) while an UNDECLARED xml:id/xmlns/unassessed xsi: attr stays skipped. The declaredXML path does NOT run `validateDeclaredXsiAttrValue` (gated to `declaredXSI`). Both the runtime participation and type association are gated to Version10 (1.1 handles `ref="xml:*"` through the ordinary ref path). DEFERRED gap: XSD 1.1 declared-XML-namespace-attribute VALUE validation (and xml:id ID-integrity) — a 1.1 declared xml: ref stays untyped, byte-identical (xml:space="bogus" accepted in 1.1).
-- **attribute `use` representation rules** (version-INDEPENDENT): `checkAttributeUse` (`check_elements.go`) rejects `@use`/`@form` on a GLOBAL attribute declaration (`isGlobalAttributeDecl` — `topLevelAttribute` omits both), requires a local `@use` in `{optional, prohibited, required}` and a local `@form` in `formChoice` `{qualified, unqualified}` (any other, including empty, is a schema error). A GLOBAL attribute declaration REQUIRES `@name` (`topLevelAttribute` makes `@name` mandatory, omits `@ref`): an absent `@name` on a top-level `<xs:attribute>` is a schema-representation error (W3C attQ005). Also enforces the `@name` NCName: a non-`ref` `<xs:attribute>` with a present `@name` that is not a valid `xs:NCName` (`xmlchar.IsValidNCName` — empty, leading digit, colon-bearing `a:b`) is a schema-representation error (§3.2.2); the `xmlns` reserved-name check takes precedence so the two do not double-fire. The "default requires use=optional" rule is version-INDEPENDENT and also enforced on a `use="prohibited"` attribute declared directly inside an `<xs:attributeGroup>` (`parseNamedAttributeGroup`/the redefine attributeGroup-override loop, `read_particles.go`/`compile_imports.go`) — the use itself is skipped as pointless but the `default` value-constraint defect is still reported (W3C attKb005); the parallel `fixed`-on-prohibited defect stays Version11-gated there.
-- **global attribute no-xsi** (version-INDEPENDENT): `parseGlobalAttribute` (`read_elements.go`) rejects a GLOBAL `<xs:attribute>` whose `{target namespace}` (the schema targetNamespace) is the XSI namespace (`lexicon.NamespaceXSI`) — the XSI namespace is reserved for the four processor attributes and a schema may not add to it (W3C attKa015). The `checkAttributeUse` XSI check (`check_elements.go`) covers the LOCAL qualified-attribute form.
-- **element `@name` NCName** (version-INDEPENDENT): `checkGlobalElement`/`checkLocalElement` (`check_elements.go`) reject an `<xs:element>` (global or local NAMED, not a `ref`) whose present `@name` is not a valid `xs:NCName` (`xmlchar.IsValidNCName` — empty/whitespace, leading digit/`-`, colon-bearing `foo:bar`) per §3.3.2. A global element's empty/missing `@name` is reported as `name` required and does NOT also fire the NCName error.
-- **NCName/QName schema-attribute whitespace collapse** (version-INDEPENDENT): xs:NCName, xs:QName, and QName lists fix whiteSpace "collapse", so every such schema attribute is whitespace-COLLAPSED at its canonical read point via `collapsedAttr(elem, attr)` (`compile.go`, `normalizeWhiteSpace(getAttr(...), "collapse")`). "Present-empty" means a present `@x` collapsing to empty (`""` or whitespace-only `"   "`); presence keyed on `hasAttr`.
-  - **NCName `@name`** reads through it at each store/register site (so a ref to the trimmed name resolves): `parseNamedComplexType`/`parseNamedSimpleType` (`read_types.go`), `parseNamedGroup`/`parseNamedAttributeGroup` (`read_particles.go`), `parseGlobalAttribute`/`parseAttributeUse`/`parseIDConstraint`/`parseGlobalElement`/`parseLocalElement` (`read_elements.go`), the notation store (`compile.go`) and `collectNotation` (`override.go`), the redefine-target and override-child keys (`compile_imports.go`/`override.go`). `checkGlobalElement`/`checkLocalElement` collapse before `xmlchar.IsValidNCName`: absent `@name` = "required", present-empty = invalid (empty) NCName (`checkLocalElement` dispatches on `hasAttr`; `parseLocalElement` uses a recovery name for present-empty). The `@targetNamespace`-requires-`@name` secondary (`checkLocalElementTargetNamespace`/`checkLocalAttributeTargetNamespace`) fires ONLY for absent `@name`.
-  - Every NAME-KEYED dispatch loop — xs:redefine (`processRedefineOverrides`, `compile_imports.go`) and xs:override (`collectOverrideChildren`, `override.go`); complexType/simpleType/group/attributeGroup, plus element/attribute/notation for override — validates a child's `@name` through `validateComponentChildName` (`compile_imports.go`) BEFORE keying: a present-but-invalid `xs:NCName` after collapse (`""`, `"   "`, `"a b"`/`"1x"`/`"a:b"`) reports (with the child's own component label) and drops the child; absent keeps the silent skip. The MATCHING key builder `overrideChildKey` stays pure (a target component's own `@name` is validated by its named parser or `checkNotations`).
-  - `checkAttributeUse` reads `@name` collapsed (`name="sub2-elem "` accepted, `name="a b"` fails NCName). Every STRUCTURAL `@name`-PROHIBITION gate (with-ref/local/inline) is present-empty symmetric via `ncnameCompanionUsable(elem, xsdElem)` (`check_elements.go`, xs:NCName counterpart of `qnameCompanionUsable`): fires the prohibition only for a genuinely-present `@name`; for present-empty reports exactly the invalid-NCName diagnostic and suppresses the structural secondary. Gates: `checkAttrGroupRef`, `checkContentModelGroupRef`, `parseModelGroup` (`read_particles.go`); `parseComplexType`/`parseSimpleType` local-type prohibition (`read_types.go`); the `checkGlobalElement`/`checkLocalElement`/`checkAttributeUse` ref/name dispatch + prohibition gates.
-  - In both reference forms `@ref` is PRIMARY, so present-empty `@ref` (`refPresentEmpty`, `read_particles.go`) is the invalid-QName diagnostic and the `@name`-prohibition secondary is SUPPRESSED (`checkContentModelGroupRef` reports and returns false; `checkAttrGroupRef` suppresses, caller's `resolveQName` reports). QName MUTUAL-EXCLUSION gates are present-empty symmetric too: the derivation-body `@base`/`@itemType`-vs-inline-`<xs:simpleType>` gates (`checkSimpleTypeDerivationBody`, `read_types.go`) fire only for a `baseUsable`/`itemTypeUsable` value (`!hasBase`/`!hasItemType` keep the presence gate so present-empty still counts as a source), and the `xs:alternative` `@type`-vs-inline-type gate (`parseTypeAlternative`, `alternative.go`) orders the collapsed-empty invalid-QName FIRST — so present-empty `@base`/`@itemType`/`@type` emits only its value diagnostic, no `must not have both …` secondary.
-  - **QName** `@base`/`@type`/`@ref`/`@itemType`/`@substitutionGroup`/`@refer` and per-token `@memberTypes`/`@substitutionGroup` members funnel through `resolveQName` (`link_refs.go`): collapse then `xmlchar.IsValidQName` (`base="    xsd:string "` resolves, `base="a b"`/`:u` is a fatal error). An UNPREFIXED name resolves via the in-scope default namespace (`xmlns="..."`) when one is declared; with NO in-scope default it is in NO namespace `{}` per XML Namespaces — it does NOT silently adopt the schema `targetNamespace` (W3C msMeta addB009: `type="CatalogData"` with no `xmlns` default does not bind `{targetNamespace}CatalogData`, so the reference is unresolved and the schema invalid) — EXCEPT under a chameleon include: when the owning schema document declares no `@targetNamespace` of its own (`elementDocDeclaresTargetNS(elem)` is false), its unqualified declarations and refs are coerced into the including namespace as a unit, so `resolveQName` keeps the coerced targetNamespace, mirroring the unprefixed attribute `@ref` rule in `parseAttributeUse`. The §5.3 unused-missing-component deferral for a NO-namespace `{}` missing type (`deferMissingTypeRef`) is correspondingly gated to a schema with NO `targetNamespace` (Saxon Missing missing001/003/006): in a schema that DOES declare a `targetNamespace`, an unresolved `{}` type reference is a genuine unresolved-type defect, not a deferrable unused component. A value collapsing to EMPTY (present-empty `type=""`/`ref=""`/`base=""`) is not a valid QName, so `resolveQName` reports it (one diagnostic, sentinel returned) and treats it as present. Every QName store site routes through a presence-gated reader (`link_refs.go`): `resolveQNameRef(elem, attr) (QName, bool)` for a SINGLE QName (`!hasAttr → (QName{}, false)`, else `resolveQName(getAttr(...))`), `resolveQNameListRef(elem, attr) ([]QName, bool)` for a LIST (collapsed-empty → `reportInvalidQNameValue` once and `(nil, true)`; else `splitSpace` + per-token `resolveQName`, order-preserving, NOT deduped). Single-QName sites via `resolveQNameRef`: `xs:element/@type` and attribute-use `@type`, local `xs:element/@ref`, `xs:attribute/@ref`, element `@substitutionGroup` in XSD 1.0 (`read_elements.go`); simpleType `xs:restriction/@base`, complexContent restriction/extension `@base` (`recordDerivationBaseRef`), simpleContent `@base` (`dispatchSimpleContentDerivation`) (`read_types.go`); the redefine attributeGroup-override nested `@ref` (`compile_imports.go`). Content-model `xs:group/@ref` dispatches on presence (`checkContentModelGroupRef` returns true for a present ref). LIST sites: element `@substitutionGroup` in XSD 1.1 (`resolveSubstitutionGroupHeads`, deduped) via `resolveQNameListRef`, and `@memberTypes` (`read_types.go`, keeping its own `hasAttr` gate + shared empty-report since each token carries its own chameleon eligibility). An ABSENT attribute keeps its default.
-  - A sentinel-collapsed `@base` EXCLUDES its type from the derivation loops (`link_refs.go`, `isInvalidQName(td.BaseType.Name)`), no spurious cos-ct-extends/restriction follow-on. The union `hasMemberTypes` check keys on `hasAttr` (present-empty `memberTypes=""` reported only by the parse loop). A sentinel `@substitutionGroup` installs NO head. List `@itemType` keeps its non-empty gate: present-empty reported once by `checkSimpleTypeDerivationBody` ("must be a valid QName; it must not be empty"), the resolveQName call gated on the collapsed value; attribute `@type`/`@ref` present-empty reported by `checkAttributeUse` (dedups on `(element, attr, value)`). The IDC `@ref`/`@refer` (`read_elements.go`) collapse at read (`refer=" k "` resolves); a keyref `@refer` dispatches on presence, so present-empty is reported once as invalid (empty) QName (marking `referUnbound` so `checkKeyRefRefers` does not also emit "no refer attribute"), absent keeps "no refer attribute naming a key or unique".
-  - On a malformed value `resolveQName` returns a SENTINEL (`invalidQName`/`isInvalidQName`, ns `\x00urn:x-helium:invalid-qname`) instead of a plausible `{targetNamespace}ref` key, so downstream SKIPS it — every "does not resolve to a(n) …" site guards on `isInvalidQName` (`reportUnresolvedTypeRef` for base/itemType/member; the element ref/type, group-ref, attributeGroup-ref, attribute-ref loops in `link_refs.go`), so `type="a b"` emits one invalid-QName error with no follow-on. A recovery placeholder is installed so downstream never dereferences nil. `reportInvalidQNameValue` DEDUPS by (element POINTER, attribute name, value): the pointer (not source/line/local name, shared by siblings minified onto one line) keeps one attribute validated at two points reported once, while two same-line siblings each report; the attribute name distinguishes two invalid-QName attributes on one element (`substitutionGroup=":bad" type=":bad"`).
-- **xs:notation structural rules** (version-INDEPENDENT): `checkNotations` (`check_notations.go`, a DOM walk on the entry and every included/imported/redefined/overridden document with a fresh per-document seen set, mirroring `checkSchemaComponentIDs`/`checkIDConstraintPlacement`, skipping `xs:appinfo`/`xs:documentation` payload) enforces the §3.14.2 rules `parseSchemaChildren` (which records only each notation's `@name`) cannot see: an `<xs:notation>` is valid ONLY as a child of `xs:schema` or (XSD 1.1) `xs:override` (nested elsewhere, e.g. `xs:redefine`, is a schema error); `@name` valid as `xs:NCName` after collapse (missing/empty/`foo:bar`/`-2.5foo` fail); at least one of `@public`/`@system` (either may be empty — presence via `hasAttr`); content model `(annotation?)` (no other element children, no non-whitespace character content); only unqualified attributes `id`/`name`/`public`/`system` (an XSD-namespaced or unknown-unqualified one is an error, foreign-namespaced is fine); `@name` unique among the document's notations.
-  - The separate `checkEnumQNameAndNotation`/`checkNotationOnDeclarations` enforce (version-INDEPENDENT per §3.14.6) that a used `xs:NOTATION` type is enumeration-derived and each `enumeration` value NAMES a declared `<xs:notation>`. The match (`checkEnumQNameAndNotation`, keyed on `compiler.notations`) resolves an UNPREFIXED value against the schema's in-scope DEFAULT namespace (`png` under a target-namespace default names `{tns}png`), rejecting a value naming no declared notation (W3C name00101m1 valid / name00101m2 invalid). It covers a NOTATION carrier in any of three enum-literal contexts — atomic `xs:NOTATION` restriction, list `itemType`, union `memberType` — via one recursive helper `enumLiteralNamesUndeclaredNotation` (mirroring `enumLiteralHasUnboundQName`): a list literal is split into whitespace tokens each checked against the item type; a union literal is typed by the FIRST member whose value space accepts it (active-member selection), so only a NOTATION-carrier member is judged.
-  - The RUNTIME xs:NOTATION enumeration facet comparison is CONSISTENT: an UNPREFIXED value on both sides — the LITERAL (against `EnumerationNS[""]`) and the instance VALUE (against `valueNS[""]`) — picks up the in-scope default namespace, both naming `{tns}png`; a prefixed same-namespace value matches, a no-default-namespace value resolves to no namespace and does not (W3C stZ075). Applied uniformly via `resolveNotationOrQNameValue` (`simplevalue_facets.go`, `builtinLocal == TypeNotation`-gated) across: the atomic enum path (`checkFacets`); the shared bottom `fixedAtomicMatches` (`validate.go`) reached by the LIST-item path (`checkListEnumeration`→`fixedListMatches`→`fixedValueMatches`) and UNION-member path (`checkUnionEnumeration`→`fixedUnionMatches`→`fixedValueMatches`); the cross-active-member branch of `crossMemberValueEqual`; and the IDC key-canonicalization path (`canonicalAtomicKey`, `validate_idc.go`) — so an `xs:unique`/`xs:key`/`xs:keyref` field over an `xs:NOTATION` value canonicalizes unprefixed `jpeg` (default ns urn:p) and prefixed `p:jpeg` to the same `{urn:p}jpeg` key. xs:QName keeps the no-namespace value-space rule (`resolveLexicalQName` never consults the default; the helper's NOTATION gate leaves the QName path unchanged).
-  - The enumeration-derived requirement (`notationUsedWithoutEnumeration`/`checkNotationOnDeclarations`) fires on a direct `xs:NOTATION` RESTRICTION base and a `type="xs:NOTATION"` element/attribute in both versions; the BARE built-in `xs:NOTATION` used directly as a list `itemType`/union `memberType` is PERMITTED in XSD 1.0 (W3C particlesZ007) and REJECTED in XSD 1.1 (W3C simple092/simple093) — `notationCarrierNotEnumeratedVisit` exempts the bare built-in only under `Version10`.
-- **xs:simpleType structural rules** (version-INDEPENDENT): `parseSimpleType` (`read_types.go`) enforces content `(annotation?, (restriction | list | union))` — at most one annotation first, exactly one derivation, no other XSD child (report-and-continue). `checkSimpleTypeDerivationBody` enforces each body: **restriction** `(annotation?, (simpleType?, facet*))` — annotation first/at-most-one, at most one simpleType before the facets, `base` XOR nested simpleType (one required), and a stray XSD child that is not a recognized facet (`isSimpleTypeFacetElement`)/simpleType/annotation rejected (a non-existent facet like `<xs:whitespace>`/`<xs:duration>`/`<xs:period>`/`<xs:precision>`/`<xs:scale>`/`<xs:encoding>`, or an `<xs:attribute>`/`<xs:attributeGroup>`/`<xs:anyAttribute>` inside a simpleType restriction); **list** `(annotation?, simpleType?)` — `itemType` XOR nested simpleType (one required, empty `itemType=""` rejected), no other element children; **union** `(annotation?, simpleType*)` — `memberTypes` and/or ≥1 simpleType child required, annotation first/at-most-one. The `@name` rules are SEPARATE and version-INDEPENDENT: a GLOBAL simpleType `@name` must be a valid `xs:NCName` (`parseNamedSimpleType` via `xmlchar.IsValidNCName`; colon/leading digit drops the type), and a LOCAL (inline) simpleType must NOT carry a `@name` (`parseSimpleType`'s `local` parameter, true for every caller except `parseNamedSimpleType`). Type-resolution failures (base/itemType/memberType naming a complexType, a list itemType naming a list, restriction of `xs:anyType`) are a SEPARATE check, not yet implemented.
-- **named model group definition content model** (version-INDEPENDENT, §3.7.2): `parseNamedGroup` (`read_particles.go`) enforces `<xs:group name="...">` content `(annotation?, (all | choice | sequence))` — exactly one model group child, at most one annotation preceding it, no other element children (a direct `<xs:element>`/`<xs:complexType>`/`<xs:simpleType>`/`<xs:attribute>`/`<xs:group ref>` is a stray-child error; a missing/second model group or second/misplaced annotation is an error). The single model group is recorded so references resolve, and the missing-model-group diagnostic is suppressed when a stray/misplaced child already reported one. (A group *reference* `<xs:group ref="...">` is a distinct construct with content `(annotation?)`.) Neither the definition nor its child compositor may carry `minOccurs`/`maxOccurs` (§3.7.2/§3.8.2 — the definition uses the "simpleExplicitGroup"/named-group "all" content model, unlike the inline "explicitGroup" particle and group REFERENCE form which carry them); either carrying them is a schema-representation error (report-and-continue). Its `@name` must be a valid `xs:NCName` (`xmlchar.IsValidNCName`; a colon `a:b` or leading digit `1` drops the group).
-- **schema `elementFormDefault`/`attributeFormDefault` enum** (version-INDEPENDENT): `Compile` (`compile.go`, alongside blockDefault/finalDefault validation) rejects a schema-level value not in `{qualified, unqualified}` (empty, capitalized, or multi-token; presence via `hasAttr`).
-- **xs:pattern XSD 1.0 char-class range-after-range** (`internal/xsdregex` `rejectXSD10CharClassRanges`, from `CompileVersion` ONLY when `xsd11=false`): an XSD 1.0 char-class range operator `-` following a completed range (`[a-d-b-c]`, Part 2 2nd-Edition Appendix F prods 15/16) is rejected; xpath3 `Translate`/`Validate` (never call `CompileVersion`) and XSD 1.1 stay permissive; relaxng (XSD 1.0 datatype library) inherits the rejection.
-- **xs:attributeGroup XML representation** (version-INDEPENDENT, §3.6.2): a global `<xs:attributeGroup>` `@name` must be a valid `xs:NCName` (`parseNamedAttributeGroup`); a nested attributeGroup (child of a definition/complexType/derivation body) is a REFERENCE — the shared `checkAttrGroupRef` (`read_particles.go`) rejects a `@name` (definition form) and any non-annotation element child (content model `(annotation?)`); a definition rejects stray element children. The 1.1 circular self-reference uses the ref form and is unaffected.
-- **attribute `@type`/`@ref` QName** (§3.2.2, version-INDEPENDENT): `checkAttributeUse` rejects a present-but-malformed `@type`/`@ref` (leading colon/digit, empty `ref=""`) via `xmlchar.IsValidQName`/`reportInvalidQNameValue`, and rejects `@ref` on a GLOBAL attribute declaration (`topLevelAttribute` omits `ref`, like `use`/`form`); a valid-but-unbound prefix still yields the normal unbound-prefix diagnostic.
-- **simple-type type-resolution kind rules** (version-INDEPENDENT): `checkSimpleTypeResolution` (`check_facets.go`, after `checkCircularSimpleTypes`) rejects a simpleType whose restriction `base`, list `itemType`, or union `memberType` resolves to a complexType (`TypeDef.IsComplex`, incl. `xs:anyType`), and a list `itemType` whose `resolveVariety` is a list (§3.14.6 / Part 2 §2.4); walks `typeDefSources` (incl. inline anonymous), skips complex types and the synthetic simpleContent content-simple-type marked `TypeDef.syntheticComplexBase`.
-- **xs:annotation XML representation** (version-INDEPENDENT, §3.13.2): `checkAnnotations` (`check_annotations.go`, a DOM walk on the entry and every included/imported/redefined/overridden document, mirroring `checkNotations`, not descending into `xs:appinfo`/`xs:documentation` payload): an `<xs:annotation>` content model is `(appinfo | documentation)*` (a stray element child or non-whitespace character content is a schema error) with only `@id`; `<xs:appinfo>` allows only `@source`; `<xs:documentation>` allows only `@source`/`@xml:lang` (a valid `xs:language` after collapse; empty/whitespace-only invalid); every XSD element admits AT MOST ONE annotation child EXCEPT `xs:schema`/`xs:redefine`/`xs:override` (open `(annotation | component)*`).
-- **simpleContent base kind** (src-ct.2, version-INDEPENDENT): `checkSimpleContentBase` (`link_refs.go`, in `resolveRefs`) rejects an `<xs:simpleContent>` EXTENSION whose base is neither a simple type nor a complex type with simple content, and a RESTRICTION whose base is not a complex type with simple content (nor a mixed+emptiable complex type carrying a nested `<xs:simpleType>`, clause 2.3); `xs:anySimpleType` is an accepted restriction base.
-- **attribute `@type`/`@ref` kind resolution** (src-resolve §3.2.2, version-INDEPENDENT): `checkAttributeResolution` (`link_refs.go`, in `resolveRefs`) rejects an `<xs:attribute>` whose `@type` resolves to a complexType (incl. `xs:anyType`) OR to NO type at all (a missing type reference — e.g. `xs:strong`, `xsd:undefined`), UNLESS the miss is a deferrable §5.3 unused-missing-component (`deferMissingTypeRef`: an absent-namespace user type, mirroring the element/item/union deferral) or a malformed/deprecated-namespace QName already reported at its read point. A qualified (prefixed / target-namespace) missing `@type` is never deferrable, so it is reported (`ctZ002`, `xsd003b.e`); a name that already carries a missing-type PLACEHOLDER (installed+reported by a base/item/union reference) is left to that owner (no double-report). And a `@ref` resolving to an EXISTING wrong-symbol-space component (a named type / global element / attribute group, via `qnameNamesNonAttribute`'s exact `{ns}local` lookup). A `@ref` resolving to NOTHING is an error UNLESS its namespace was import-DECLARED — recorded in `importDeclaredNS` (populated at the top of `processImport` for EVERY `<xs:import namespace>` regardless of load outcome; unioned up from import sub-compilers). A ref into a NEVER-imported namespace (including the schema's own `targetNamespace` and the absent namespace) is illegal. The built-in XML namespace (xml:lang/base/space/id) and XSI are exempt. `resolveNamedType` (the `@type` path) tries the exact `{ns}local` first and falls back to `{}local` only on a miss (a chameleon/no-namespace-target `@type` still resolves while a same-named wrong-symbol-space component is not masked). `attrRefSources` records `@ref` sites (merged from import sub-compilers). An UNPREFIXED attribute `@ref` with no in-scope default namespace resolves to NO namespace (`parseAttributeUse`, `read_elements.go`): an attribute reference does not fall back to the schema `targetNamespace` the way `resolveQName` defaults a bare name, so `ref="a"` does NOT bind a same-`targetNamespace` global attribute `{T}a` (`AU_attrDecl00101m1_n`) — EXCEPT when the owning document declares no `@targetNamespace` of its own (`elementDocDeclaresTargetNS`), i.e. a chameleon include whose unqualified declarations and refs are coerced into the including namespace as a unit (`include1_0`).
-- **model-group ref resolution** (src-resolve §3.7.2, version-INDEPENDENT): the `resolveRefs` group-ref loop (`link_refs.go`) rejects an `<xs:group ref="...">` not resolving to a globally declared model group (wrong symbol space — a complexType/attributeGroup of the same name — or declared nowhere), mirroring `checkAttrGroupRefsResolve` (symbol-space-only lookup, `qn.NS != ""` empty-ns fallback for chameleon/no-namespace imports, `(source, line, local)` sort). A permitted 1.1 circular ref is cut by `checkCircularGroupRefs` and `continue`d before this dangling check.
-- **src-redefine.6.1** (§4.2.3, version-INDEPENDENT): `processRedefineOverrides`' group case (`compile_imports.go`) enforces 6.1.1/6.1.2 — a `<xs:group>` child of `<xs:redefine>` referencing its own name must do so EXACTLY ONCE with `minOccurs=maxOccurs=1` (schR3/schR4). A group with no self-reference is a clause-6.2 restriction gap (accepted, not enforced).
-- **ID value-constraint prohibition** (au-props-correct.3 §3.2.6, XSD 1.0 ONLY): `checkAttrUseConstraints` (`link_refs.go`) rejects an attribute whose type is or derives from `xs:ID` (`builtinBaseLocal(td) == "ID"`) carrying a default/fixed. Gated to `Version10` — XSD 1.1 removed the rule (W3C bug 4077).
-- **inline model group content model** (§3.8.2): `parseModelGroup` (`read_particles.go`) enforces an inline `<xs:sequence>`/`<xs:choice>`/`<xs:all>` content `(annotation?, particle*)`: at most one annotation preceding every particle, no `@name` (only `id`/`minOccurs`/`maxOccurs`), no non-particle XSD child (all version-INDEPENDENT; foreign-namespace children untouched). Admissible PARTICLE kinds are version-split ONLY for `xs:all`: XSD 1.0 admits `element` only (a nested `group`/`sequence`/`choice`, or an `<xs:any>` wildcard, is a stray — W3C sunData particles00104m1), Version11 additionally admits `any` and a `group` ref (nested-all-group relaxation, gated downstream in `checkAllGroupRef`). `xs:sequence`/`xs:choice` admit `(element | group | choice | sequence | any)` in both versions; a nested `xs:all` inside a sequence/choice stays a cos-all-limited error.
-- **xs:redefine type self-derivation** (version-INDEPENDENT, §4.2.3 src-redefine.5): `checkRedefineSelfDerivation` (`compile_imports.go`, from the `processRedefineOverrides` complexType/simpleType cases) requires a `<simpleType>`/`<complexType>` child of `<xs:redefine>` to have a `<restriction>` (or, for a complexType, `<extension>`) whose resolved `base` names the redefined type ITSELF — present iff the replacement's recorded base ref (`c.typeRefs[newType]`) equals its own name `qn`. A base naming a different type, a same-local base in another namespace (an imported `foo:b-st`), or no derivation is a schema error, and the self-reference patch (redirecting the base ref to the original Phase-A type) is skipped. The patch stashes the original type under a UNIQUE synthetic key `\x00redefine:<seq>:<name>` (`compiler.redefineOrigSeq`, a monotonic counter) so a CHAIN of `<xs:redefine>` targeting the SAME type name (a schema redefining a document that itself redefines the type — W3C stZ033/stZ034, addB007) does not collide: a per-name key would let an outer level overwrite the stash the inner level's patched base still points at, looping the base onto itself (a spurious circular-type / duplicate-attribute error). Group/attributeGroup redefine children are NOT covered (a group without self-reference is valid iff it validly restricts the original per src-redefine.6.2, and an attributeGroup redefinition needs no self-reference — both a documented gap).
-- **xs:redefine closed attribute vocabulary** (version-INDEPENDENT): `checkRedefineAttrs` (`compile_imports.go`, from the `processNestedIncludes`/`parseSchemaChildren` redefine dispatch) rejects any UNQUALIFIED attribute on `<xs:redefine>` outside the schema-for-schemas set `{id, schemaLocation}` — a foreign-namespaced attribute is admitted, but a no-namespace `namespace` attribute (which belongs to `<xs:import>`, not `<xs:redefine>`) is a schema-representation error (W3C msMeta/Schema_w3c.xml schH4).
-- **xs:redefine closed child vocabulary** (version-INDEPENDENT): the `processRedefineOverrides` child dispatch (`compile_imports.go`) has a `default` arm rejecting any XSD-namespace child of `<xs:redefine>` outside its content model `(annotation | (simpleType | complexType | group | attributeGroup))*` — an `<xs:element>` (W3C sunData xsd003-1.e) or an `<xs:attribute>` (xsd003-2.e) is a schema-representation error; foreign-namespace children are ignored.
-- **built-in FIXED facet restriction** (version-INDEPENDENT): `checkBuiltinFixedFacetRestriction` (`check_facets.go`) rejects a restriction changing a facet the built-in base fixes — the `collapse` `whiteSpace` and `explicitTimezone` on the date/time family, and `fractionDigits=0` on the `xs:integer` family (`value.IsIntegerFamily`: the `xs:decimal` family minus `xs:decimal`). A non-zero `fractionDigits` on `xs:integer` or a derived type (long/int/short/byte, the (non)positive/(non)negative integers, the unsigned family, positiveInteger) is a schema error; explicit `fractionDigits="0"` is permitted; `xs:decimal` (not fixing `fractionDigits`) still accepts a non-zero value.
-- **built-in INTRINSIC facets** (version-INDEPENDENT): `registerBuiltinTypes` (`compile.go`, via `intrinsicBuiltinFacets`) records each built-in's spec-mandated INTRINSIC facets on `TypeDef.Facets` — `xs:NMTOKENS`/`xs:IDREFS`/`xs:ENTITIES` carry `minLength=1` (Part 2 §4.3.2), `xs:positiveInteger` carries `minInclusive=1` (§3.3.25) — so the facet-restriction checks (`check_facets.go`) see them when a user type restricts the built-in. Instance validation is byte-identical (the value space already rejects an empty NMTOKENS list and positiveInteger < 1 in `validateBuiltinValue`/`validateListValue`). A restriction DROPPING below an intrinsic bound is a schema error. The length family (length/minLength/maxLength) narrowing and cross-consistency (`length`↔`minLength`/`maxLength`, `minLength`≤`maxLength`) run in `checkLengthFacetRestriction` (`check_facets.go`) against the EFFECTIVE inherited bound over the WHOLE base chain — tightest inherited `minLength` (max), `maxLength` (min), any inherited `length`, via `effectiveInheritedMinLength`/`effectiveInheritedMaxLength`/`effectiveInheritedLength` (each `baseChain(td.BaseType)`, `td` excluded) — NOT the nearest ancestor's `baseFacets`, so an intermediate restriction carrying only a pattern cannot HIDE an inherited bound. Scoped to length-applicable varieties (a list or length-applicable atomic primitive) so an inapplicable length facet (reported by `checkFacetApplicability`) is not double-flagged; each cross-consistency comparison pairs a DERIVED facet against an INHERITED bound so it never double-reports the own-vs-own cases (`checkFacetMutualExclusion`, `checkFacetSameTypeConsistency`). A `maxExclusive`/`maxInclusive` violating the inherited `minInclusive` is caught by `effectiveInheritedRangeBounds`/`checkUpper` (also whole-chain). The digit facets (`totalDigits`/`fractionDigits`) keep the nearest-ancestor `baseFacets` comparison. `checkFacetMutualExclusion` (passed `td`) is INHERITANCE-AWARE for the `length` + `minLength`/`maxLength` co-occurrence (§4.3.1.4 / W3C bug 6446, `lengthConflictsWithMinMax`): `length` may co-occur with a `minLength`/`maxLength` on the SAME step ONLY when that facet is genuinely INHERITED — own value equals the effective inherited value over PROPER ancestors (a mere RESTATEMENT) AND value-consistent with `length` (minLength ≤ length ≤ maxLength). So `xs:IDREFS` restricted to `length=5`,`minLength=1` is permitted (own 1 == inherited intrinsic 1), while a fresh tighter bound — `length=5`,`minLength=2` (own 2 ≠ 1) or base `maxLength=10` restated as `length=5`,`maxLength=8` (own 8 ≠ 10) — stays an error.
+- XSD 1.1 **xsi: attribute references** (`validate.go` `validateAttributes`, gated Version11, 1.0
+  byte-identical): an xsi: processor attribute
+  (xsi:type/xsi:nil/xsi:schemaLocation/xsi:noNamespaceSchemaLocation) referenced explicitly as an attribute
+  use (any use: optional/required/prohibited) participates in ordinary attribute-use validation instead of
+  being skipped — a present xsi:type satisfies a required use, absence reports missing, and `use="prohibited"`
+  REJECTS a present xsi:type (detected via both allowed and prohibited use maps). Applies ONLY to the four
+  real processor attributes (`isKnownXsiProcessorAttr`); a declared ref to any other xsi: local name (xsi:foo)
+  stays skipped so a required use is never satisfied. A present non-prohibited use validates its value against
+  the fixed built-in type (`validateDeclaredXsiAttrValue`: xsi:type→non-empty namespace-resolvable xs:QName;
+  xsi:nil→xs:boolean; xsi:schemaLocation→non-empty even list of xs:anyURI tokenized via `value.XSDFields`,
+  NBSP not a separator; xsi:noNamespaceSchemaLocation→xs:anyURI), since `ref="xsi:*"` resolves to no typed
+  global attribute — so xsi:type="" / a malformed QName / a non-boolean xsi:nil is a validity error that does
+  NOT satisfy a required use. The use is associated with its built-in SCALAR type in the ref-resolution loop
+  (`link_refs.go` `xsiProcessorAttrBuiltinType`: xsi:type→xs:QName, xsi:nil→xs:boolean,
+  xsi:noNamespaceSchemaLocation→xs:anyURI), so a fixed/default is validated at compile time
+  (`checkAttrUseConstraints`: `ref="xsi:nil" fixed="notbool"` is a schema error) and compared in VALUE space
+  at runtime (`fixedValueMatches`: xsi:nil="1" satisfies fixed="true"; a different-prefix/same-namespace
+  xsi:type satisfies a QName fixed). The value is validated once by `validateDeclaredXsiAttrValue`; the
+  generic type-based check is skipped for the declared use (`declaredXsiValueChecked`), but the fixed-value
+  comparison still runs against the built-in type. xsi:schemaLocation (a LIST of xs:anyURI) has no scalar
+  built-in, so its fixed/default uses list helpers
+  (`validateXsiSchemaLocationValue`/`xsiSchemaLocationValueEqual`/`xsiSchemaLocationTokens`): the literal is
+  validated at compile time (`checkAttrUseConstraints`: non-empty even list; odd/empty is a schema error), the
+  runtime fixed comparison is by token-list equality (`isDeclaredXsiSchemaLocationUse` routes around
+  `fixedValueMatches`), so `" urn:a loc.xsd "` satisfies `fixed="urn:a loc.xsd"`. (anyURI lexical space is
+  unrestricted, so the per-token check never fails; even/non-empty is the only reachable literal-validity
+  constraint.) Undeclared/implicit xsi processing unchanged — Saxon Complex complex009/complex010.
+- **prohibited-attribute / special-attribute vs wildcard fallthrough** (`validate.go` `validateAttributes`,
+  version-specific): an instance attribute matching a `use="prohibited"` declared use is rejected OUTRIGHT
+  (never re-admitted by `<xs:anyAttribute>`) only in XSD 1.1, which retains the prohibited use in `{attribute
+  uses}` to forbid the name (§3.4.4.2). In XSD 1.0 a prohibited use is ABSENT from `{attribute uses}`, so the
+  attribute falls through to the `{attribute wildcard}` (or the "is not allowed" report) per
+  cvc-complex-type.3 (W3C addB034/addB136/attZ002 — valid via the wildcard; the reject branch is gated
+  `vc.version == Version11`). Separately, XSD 1.0 blanket-skips every XML-namespace attribute (`isSpecialAttr`
+  treats xml:base/xml:lang/xml:space/xml:id as always-allowed), but an EXPLICITLY declared one (`declaredXML`:
+  its QName is in the allowed/prohibited maps) participates in ordinary validation and satisfies a required
+  use (W3C addC001 — `ref="xml:base" use="required"`). The governing type is associated at compile time by
+  `xmlNamespaceAttrType` (`validate.go`, wired into `link_refs.go` alongside `xsiProcessorAttrBuiltinType`): a
+  `ref="xml:*"` resolves to no user global attribute, so the built-in type is set onto the `AttrUse` per the
+  standard xml: schema — xml:base→xs:anyURI, xml:id→xs:ID, xml:space→a restriction of xs:NCName enumerated
+  {default, preserve}, xml:lang→a union of xs:language and the empty string — so xml:space="bogus"/an invalid
+  xml:lang is a validity error (not silently accepted), and the value feeds the compile-time default/fixed
+  constraint check. A declared `ref="xml:id"` (xs:ID) also participates in the document-wide ID pass
+  (`validate_id.go`): the loop skips a special attribute only when NOT genuinely assessed (`assessedAttrs`),
+  so a DECLARED xml:id (assessed via `annotateAttrUse`) is collected (a duplicate is a validity error) while
+  an UNDECLARED xml:id/xmlns/unassessed xsi: attr stays skipped. The declaredXML path does NOT run
+  `validateDeclaredXsiAttrValue` (gated to `declaredXSI`). Both the runtime participation and type association
+  are gated to Version10 (1.1 handles `ref="xml:*"` through the ordinary ref path). DEFERRED gap: XSD 1.1
+  declared-XML-namespace-attribute VALUE validation (and xml:id ID-integrity) — a 1.1 declared xml: ref stays
+  untyped, byte-identical (xml:space="bogus" accepted in 1.1).
+- **attribute `use` representation rules** (version-INDEPENDENT): `checkAttributeUse` (`check_elements.go`)
+  rejects `@use`/`@form` on a GLOBAL attribute declaration (`isGlobalAttributeDecl` — `topLevelAttribute`
+  omits both), requires a local `@use` in `{optional, prohibited, required}` and a local `@form` in
+  `formChoice` `{qualified, unqualified}` (any other, including empty, is a schema error). A GLOBAL attribute
+  declaration REQUIRES `@name` (`topLevelAttribute` makes `@name` mandatory, omits `@ref`): an absent `@name`
+  on a top-level `<xs:attribute>` is a schema-representation error (W3C attQ005). Also enforces the `@name`
+  NCName: a non-`ref` `<xs:attribute>` with a present `@name` that is not a valid `xs:NCName`
+  (`xmlchar.IsValidNCName` — empty, leading digit, colon-bearing `a:b`) is a schema-representation error
+  (§3.2.2); the `xmlns` reserved-name check takes precedence so the two do not double-fire. The "default
+  requires use=optional" rule is version-INDEPENDENT and also enforced on a `use="prohibited"` attribute
+  declared directly inside an `<xs:attributeGroup>` (`parseNamedAttributeGroup`/the redefine
+  attributeGroup-override loop, `read_particles.go`/`compile_imports.go`) — the use itself is skipped as
+  pointless but the `default` value-constraint defect is still reported (W3C attKb005); the parallel
+  `fixed`-on-prohibited defect stays Version11-gated there.
+- **global attribute no-xsi** (version-INDEPENDENT): `parseGlobalAttribute` (`read_elements.go`) rejects a
+  GLOBAL `<xs:attribute>` whose `{target namespace}` (the schema targetNamespace) is the XSI namespace
+  (`lexicon.NamespaceXSI`) — the XSI namespace is reserved for the four processor attributes and a schema may
+  not add to it (W3C attKa015). The `checkAttributeUse` XSI check (`check_elements.go`) covers the LOCAL
+  qualified-attribute form.
+- **element `@name` NCName** (version-INDEPENDENT): `checkGlobalElement`/`checkLocalElement`
+  (`check_elements.go`) reject an `<xs:element>` (global or local NAMED, not a `ref`) whose present `@name` is
+  not a valid `xs:NCName` (`xmlchar.IsValidNCName` — empty/whitespace, leading digit/`-`, colon-bearing
+  `foo:bar`) per §3.3.2. A global element's empty/missing `@name` is reported as `name` required and does NOT
+  also fire the NCName error.
+- **NCName/QName schema-attribute whitespace collapse** (version-INDEPENDENT): xs:NCName, xs:QName, and QName
+  lists fix whiteSpace "collapse", so every such schema attribute is whitespace-COLLAPSED at its canonical
+  read point via `collapsedAttr(elem, attr)` (`compile.go`, `normalizeWhiteSpace(getAttr(...), "collapse")`).
+  "Present-empty" means a present `@x` collapsing to empty (`""` or whitespace-only `" "`); presence keyed on
+  `hasAttr`.
+  - **NCName `@name`** reads through it at each store/register site (so a ref to the trimmed name resolves):
+    `parseNamedComplexType`/`parseNamedSimpleType` (`read_types.go`),
+    `parseNamedGroup`/`parseNamedAttributeGroup` (`read_particles.go`),
+    `parseGlobalAttribute`/`parseAttributeUse`/`parseIDConstraint`/`parseGlobalElement`/`parseLocalElement`
+    (`read_elements.go`), the notation store (`compile.go`) and `collectNotation` (`override.go`), the
+    redefine-target and override-child keys (`compile_imports.go`/`override.go`).
+    `checkGlobalElement`/`checkLocalElement` collapse before `xmlchar.IsValidNCName`: absent `@name` =
+    "required", present-empty = invalid (empty) NCName (`checkLocalElement` dispatches on `hasAttr`;
+    `parseLocalElement` uses a recovery name for present-empty). The `@targetNamespace`-requires-`@name`
+    secondary (`checkLocalElementTargetNamespace`/`checkLocalAttributeTargetNamespace`) fires ONLY for absent
+    `@name`.
+  - Every NAME-KEYED dispatch loop — xs:redefine (`processRedefineOverrides`, `compile_imports.go`) and
+    xs:override (`collectOverrideChildren`, `override.go`); complexType/simpleType/group/attributeGroup, plus
+    element/attribute/notation for override — validates a child's `@name` through `validateComponentChildName`
+    (`compile_imports.go`) BEFORE keying: a present-but-invalid `xs:NCName` after collapse (`""`, `" "`, `"a
+    b"`/`"1x"`/`"a:b"`) reports (with the child's own component label) and drops the child; absent keeps the
+    silent skip. The MATCHING key builder `overrideChildKey` stays pure (a target component's own `@name` is
+    validated by its named parser or `checkNotations`).
+  - `checkAttributeUse` reads `@name` collapsed (`name="sub2-elem "` accepted, `name="a b"` fails NCName).
+    Every STRUCTURAL `@name`-PROHIBITION gate (with-ref/local/inline) is present-empty symmetric via
+    `ncnameCompanionUsable(elem, xsdElem)` (`check_elements.go`, xs:NCName counterpart of
+    `qnameCompanionUsable`): fires the prohibition only for a genuinely-present `@name`; for present-empty
+    reports exactly the invalid-NCName diagnostic and suppresses the structural secondary. Gates:
+    `checkAttrGroupRef`, `checkContentModelGroupRef`, `parseModelGroup` (`read_particles.go`);
+    `parseComplexType`/`parseSimpleType` local-type prohibition (`read_types.go`); the
+    `checkGlobalElement`/`checkLocalElement`/`checkAttributeUse` ref/name dispatch + prohibition gates.
+  - In both reference forms `@ref` is PRIMARY, so present-empty `@ref` (`refPresentEmpty`,
+    `read_particles.go`) is the invalid-QName diagnostic and the `@name`-prohibition secondary is SUPPRESSED
+    (`checkContentModelGroupRef` reports and returns false; `checkAttrGroupRef` suppresses, caller's
+    `resolveQName` reports). QName MUTUAL-EXCLUSION gates are present-empty symmetric too: the derivation-body
+    `@base`/`@itemType`-vs-inline-`<xs:simpleType>` gates (`checkSimpleTypeDerivationBody`, `read_types.go`)
+    fire only for a `baseUsable`/`itemTypeUsable` value (`!hasBase`/`!hasItemType` keep the presence gate so
+    present-empty still counts as a source), and the `xs:alternative` `@type`-vs-inline-type gate
+    (`parseTypeAlternative`, `alternative.go`) orders the collapsed-empty invalid-QName FIRST — so
+    present-empty `@base`/`@itemType`/`@type` emits only its value diagnostic, no `must not have both …`
+    secondary.
+  - **QName** `@base`/`@type`/`@ref`/`@itemType`/`@substitutionGroup`/`@refer` and per-token
+    `@memberTypes`/`@substitutionGroup` members funnel through `resolveQName` (`link_refs.go`): collapse then
+    `xmlchar.IsValidQName` (`base=" xsd:string "` resolves, `base="a b"`/`:u` is a fatal error). An UNPREFIXED
+    name resolves via the in-scope default namespace (`xmlns="..."`) when one is declared; with NO in-scope
+    default it is in NO namespace `{}` per XML Namespaces — it does NOT silently adopt the schema
+    `targetNamespace` (W3C msMeta addB009: `type="CatalogData"` with no `xmlns` default does not bind
+    `{targetNamespace}CatalogData`, so the reference is unresolved and the schema invalid) — EXCEPT under a
+    chameleon include: when the owning schema document declares no `@targetNamespace` of its own
+    (`elementDocDeclaresTargetNS(elem)` is false), its unqualified declarations and refs are coerced into the
+    including namespace as a unit, so `resolveQName` keeps the coerced targetNamespace, mirroring the
+    unprefixed attribute `@ref` rule in `parseAttributeUse`. The §5.3 unused-missing-component deferral for a
+    NO-namespace `{}` missing type (`deferMissingTypeRef`) is correspondingly gated to a schema with NO
+    `targetNamespace` (Saxon Missing missing001/003/006): in a schema that DOES declare a `targetNamespace`,
+    an unresolved `{}` type reference is a genuine unresolved-type defect, not a deferrable unused component.
+    A value collapsing to EMPTY (present-empty `type=""`/`ref=""`/`base=""`) is not a valid QName, so
+    `resolveQName` reports it (one diagnostic, sentinel returned) and treats it as present. Every QName store
+    site routes through a presence-gated reader (`link_refs.go`): `resolveQNameRef(elem, attr) (QName, bool)`
+    for a SINGLE QName (`!hasAttr → (QName{}, false)`, else `resolveQName(getAttr(...))`),
+    `resolveQNameListRef(elem, attr) ([]QName, bool)` for a LIST (collapsed-empty → `reportInvalidQNameValue`
+    once and `(nil, true)`; else `splitSpace` + per-token `resolveQName`, order-preserving, NOT deduped).
+    Single-QName sites via `resolveQNameRef`: `xs:element/@type` and attribute-use `@type`, local
+    `xs:element/@ref`, `xs:attribute/@ref`, element `@substitutionGroup` in XSD 1.0 (`read_elements.go`);
+    simpleType `xs:restriction/@base`, complexContent restriction/extension `@base`
+    (`recordDerivationBaseRef`), simpleContent `@base` (`dispatchSimpleContentDerivation`) (`read_types.go`);
+    the redefine attributeGroup-override nested `@ref` (`compile_imports.go`). Content-model `xs:group/@ref`
+    dispatches on presence (`checkContentModelGroupRef` returns true for a present ref). LIST sites: element
+    `@substitutionGroup` in XSD 1.1 (`resolveSubstitutionGroupHeads`, deduped) via `resolveQNameListRef`, and
+    `@memberTypes` (`read_types.go`, keeping its own `hasAttr` gate + shared empty-report since each token
+    carries its own chameleon eligibility). An ABSENT attribute keeps its default.
+  - A sentinel-collapsed `@base` EXCLUDES its type from the derivation loops (`link_refs.go`,
+    `isInvalidQName(td.BaseType.Name)`), no spurious cos-ct-extends/restriction follow-on. The union
+    `hasMemberTypes` check keys on `hasAttr` (present-empty `memberTypes=""` reported only by the parse loop).
+    A sentinel `@substitutionGroup` installs NO head. List `@itemType` keeps its non-empty gate: present-empty
+    reported once by `checkSimpleTypeDerivationBody` ("must be a valid QName; it must not be empty"), the
+    resolveQName call gated on the collapsed value; attribute `@type`/`@ref` present-empty reported by
+    `checkAttributeUse` (dedups on `(element, attr, value)`). The IDC `@ref`/`@refer` (`read_elements.go`)
+    collapse at read (`refer=" k "` resolves); a keyref `@refer` dispatches on presence, so present-empty is
+    reported once as invalid (empty) QName (marking `referUnbound` so `checkKeyRefRefers` does not also emit
+    "no refer attribute"), absent keeps "no refer attribute naming a key or unique".
+  - On a malformed value `resolveQName` returns a SENTINEL (`invalidQName`/`isInvalidQName`, ns
+    `\x00urn:x-helium:invalid-qname`) instead of a plausible `{targetNamespace}ref` key, so downstream SKIPS
+    it — every "does not resolve to a(n) …" site guards on `isInvalidQName` (`reportUnresolvedTypeRef` for
+    base/itemType/member; the element ref/type, group-ref, attributeGroup-ref, attribute-ref loops in
+    `link_refs.go`), so `type="a b"` emits one invalid-QName error with no follow-on. A recovery placeholder
+    is installed so downstream never dereferences nil. `reportInvalidQNameValue` DEDUPS by (element POINTER,
+    attribute name, value): the pointer (not source/line/local name, shared by siblings minified onto one
+    line) keeps one attribute validated at two points reported once, while two same-line siblings each report;
+    the attribute name distinguishes two invalid-QName attributes on one element (`substitutionGroup=":bad"
+    type=":bad"`).
+- **xs:notation structural rules** (version-INDEPENDENT): `checkNotations` (`check_notations.go`, a DOM walk
+  on the entry and every included/imported/redefined/overridden document with a fresh per-document seen set,
+  mirroring `checkSchemaComponentIDs`/`checkIDConstraintPlacement`, skipping `xs:appinfo`/`xs:documentation`
+  payload) enforces the §3.14.2 rules `parseSchemaChildren` (which records only each notation's `@name`)
+  cannot see: an `<xs:notation>` is valid ONLY as a child of `xs:schema` or (XSD 1.1) `xs:override` (nested
+  elsewhere, e.g. `xs:redefine`, is a schema error); `@name` valid as `xs:NCName` after collapse
+  (missing/empty/`foo:bar`/`-2.5foo` fail); at least one of `@public`/`@system` (either may be empty —
+  presence via `hasAttr`); content model `(annotation?)` (no other element children, no non-whitespace
+  character content); only unqualified attributes `id`/`name`/`public`/`system` (an XSD-namespaced or
+  unknown-unqualified one is an error, foreign-namespaced is fine); `@name` unique among the document's
+  notations.
+  - The separate `checkEnumQNameAndNotation`/`checkNotationOnDeclarations` enforce (version-INDEPENDENT per
+    §3.14.6) that a used `xs:NOTATION` type is enumeration-derived and each `enumeration` value NAMES a
+    declared `<xs:notation>`. The match (`checkEnumQNameAndNotation`, keyed on `compiler.notations`) resolves
+    an UNPREFIXED value against the schema's in-scope DEFAULT namespace (`png` under a target-namespace
+    default names `{tns}png`), rejecting a value naming no declared notation (W3C name00101m1 valid /
+    name00101m2 invalid). It covers a NOTATION carrier in any of three enum-literal contexts — atomic
+    `xs:NOTATION` restriction, list `itemType`, union `memberType` — via one recursive helper
+    `enumLiteralNamesUndeclaredNotation` (mirroring `enumLiteralHasUnboundQName`): a list literal is split
+    into whitespace tokens each checked against the item type; a union literal is typed by the FIRST member
+    whose value space accepts it (active-member selection), so only a NOTATION-carrier member is judged.
+  - The RUNTIME xs:NOTATION enumeration facet comparison is CONSISTENT: an UNPREFIXED value on both sides —
+    the LITERAL (against `EnumerationNS[""]`) and the instance VALUE (against `valueNS[""]`) — picks up the
+    in-scope default namespace, both naming `{tns}png`; a prefixed same-namespace value matches, a
+    no-default-namespace value resolves to no namespace and does not (W3C stZ075). Applied uniformly via
+    `resolveNotationOrQNameValue` (`simplevalue_facets.go`, `builtinLocal == TypeNotation`-gated) across: the
+    atomic enum path (`checkFacets`); the shared bottom `fixedAtomicMatches` (`validate.go`) reached by the
+    LIST-item path (`checkListEnumeration`→`fixedListMatches`→`fixedValueMatches`) and UNION-member path
+    (`checkUnionEnumeration`→`fixedUnionMatches`→`fixedValueMatches`); the cross-active-member branch of
+    `crossMemberValueEqual`; and the IDC key-canonicalization path (`canonicalAtomicKey`, `validate_idc.go`) —
+    so an `xs:unique`/`xs:key`/`xs:keyref` field over an `xs:NOTATION` value canonicalizes unprefixed `jpeg`
+    (default ns urn:p) and prefixed `p:jpeg` to the same `{urn:p}jpeg` key. xs:QName keeps the no-namespace
+    value-space rule (`resolveLexicalQName` never consults the default; the helper's NOTATION gate leaves the
+    QName path unchanged).
+  - The enumeration-derived requirement (`notationUsedWithoutEnumeration`/`checkNotationOnDeclarations`) fires
+    on a direct `xs:NOTATION` RESTRICTION base and a `type="xs:NOTATION"` element/attribute in both versions;
+    the BARE built-in `xs:NOTATION` used directly as a list `itemType`/union `memberType` is PERMITTED in XSD
+    1.0 (W3C particlesZ007) and REJECTED in XSD 1.1 (W3C simple092/simple093) —
+    `notationCarrierNotEnumeratedVisit` exempts the bare built-in only under `Version10`.
+- **xs:simpleType structural rules** (version-INDEPENDENT): `parseSimpleType` (`read_types.go`) enforces
+  content `(annotation?, (restriction | list | union))` — at most one annotation first, exactly one
+  derivation, no other XSD child (report-and-continue). `checkSimpleTypeDerivationBody` enforces each body:
+  **restriction** `(annotation?, (simpleType?, facet*))` — annotation first/at-most-one, at most one
+  simpleType before the facets, `base` XOR nested simpleType (one required), and a stray XSD child that is not
+  a recognized facet (`isSimpleTypeFacetElement`)/simpleType/annotation rejected (a non-existent facet like
+  `<xs:whitespace>`/`<xs:duration>`/`<xs:period>`/`<xs:precision>`/`<xs:scale>`/`<xs:encoding>`, or an
+  `<xs:attribute>`/`<xs:attributeGroup>`/`<xs:anyAttribute>` inside a simpleType restriction); **list**
+  `(annotation?, simpleType?)` — `itemType` XOR nested simpleType (one required, empty `itemType=""`
+  rejected), no other element children; **union** `(annotation?, simpleType*)` — `memberTypes` and/or ≥1
+  simpleType child required, annotation first/at-most-one. The `@name` rules are SEPARATE and
+  version-INDEPENDENT: a GLOBAL simpleType `@name` must be a valid `xs:NCName` (`parseNamedSimpleType` via
+  `xmlchar.IsValidNCName`; colon/leading digit drops the type), and a LOCAL (inline) simpleType must NOT carry
+  a `@name` (`parseSimpleType`'s `local` parameter, true for every caller except `parseNamedSimpleType`).
+  Type-resolution failures (base/itemType/memberType naming a complexType, a list itemType naming a list,
+  restriction of `xs:anyType`) are a SEPARATE check, not yet implemented.
+- **named model group definition content model** (version-INDEPENDENT, §3.7.2): `parseNamedGroup`
+  (`read_particles.go`) enforces `<xs:group name="...">` content `(annotation?, (all | choice | sequence))` —
+  exactly one model group child, at most one annotation preceding it, no other element children (a direct
+  `<xs:element>`/`<xs:complexType>`/`<xs:simpleType>`/`<xs:attribute>`/`<xs:group ref>` is a stray-child
+  error; a missing/second model group or second/misplaced annotation is an error). The single model group is
+  recorded so references resolve, and the missing-model-group diagnostic is suppressed when a stray/misplaced
+  child already reported one. (A group *reference* `<xs:group ref="...">` is a distinct construct with content
+  `(annotation?)`.) Neither the definition nor its child compositor may carry `minOccurs`/`maxOccurs`
+  (§3.7.2/§3.8.2 — the definition uses the "simpleExplicitGroup"/named-group "all" content model, unlike the
+  inline "explicitGroup" particle and group REFERENCE form which carry them); either carrying them is a
+  schema-representation error (report-and-continue). Its `@name` must be a valid `xs:NCName`
+  (`xmlchar.IsValidNCName`; a colon `a:b` or leading digit `1` drops the group).
+- **schema `elementFormDefault`/`attributeFormDefault` enum** (version-INDEPENDENT): `Compile` (`compile.go`,
+  alongside blockDefault/finalDefault validation) rejects a schema-level value not in `{qualified,
+  unqualified}` (empty, capitalized, or multi-token; presence via `hasAttr`).
+- **xs:pattern XSD 1.0 char-class range-after-range** (`internal/xsdregex` `rejectXSD10CharClassRanges`, from
+  `CompileVersion` ONLY when `xsd11=false`): an XSD 1.0 char-class range operator `-` following a completed
+  range (`[a-d-b-c]`, Part 2 2nd-Edition Appendix F prods 15/16) is rejected; xpath3 `Translate`/`Validate`
+  (never call `CompileVersion`) and XSD 1.1 stay permissive; relaxng (XSD 1.0 datatype library) inherits the
+  rejection.
+- **xs:attributeGroup XML representation** (version-INDEPENDENT, §3.6.2): a global `<xs:attributeGroup>`
+  `@name` must be a valid `xs:NCName` (`parseNamedAttributeGroup`); a nested attributeGroup (child of a
+  definition/complexType/derivation body) is a REFERENCE — the shared `checkAttrGroupRef`
+  (`read_particles.go`) rejects a `@name` (definition form) and any non-annotation element child (content
+  model `(annotation?)`); a definition rejects stray element children. The 1.1 circular self-reference uses
+  the ref form and is unaffected.
+- **attribute `@type`/`@ref` QName** (§3.2.2, version-INDEPENDENT): `checkAttributeUse` rejects a
+  present-but-malformed `@type`/`@ref` (leading colon/digit, empty `ref=""`) via
+  `xmlchar.IsValidQName`/`reportInvalidQNameValue`, and rejects `@ref` on a GLOBAL attribute declaration
+  (`topLevelAttribute` omits `ref`, like `use`/`form`); a valid-but-unbound prefix still yields the normal
+  unbound-prefix diagnostic.
+- **simple-type type-resolution kind rules** (version-INDEPENDENT): `checkSimpleTypeResolution`
+  (`check_facets.go`, after `checkCircularSimpleTypes`) rejects a simpleType whose restriction `base`, list
+  `itemType`, or union `memberType` resolves to a complexType (`TypeDef.IsComplex`, incl. `xs:anyType`), and a
+  list `itemType` whose `resolveVariety` is a list (§3.14.6 / Part 2 §2.4); walks `typeDefSources` (incl.
+  inline anonymous), skips complex types and the synthetic simpleContent content-simple-type marked
+  `TypeDef.syntheticComplexBase`.
+- **xs:annotation XML representation** (version-INDEPENDENT, §3.13.2): `checkAnnotations`
+  (`check_annotations.go`, a DOM walk on the entry and every included/imported/redefined/overridden document,
+  mirroring `checkNotations`, not descending into `xs:appinfo`/`xs:documentation` payload): an
+  `<xs:annotation>` content model is `(appinfo | documentation)*` (a stray element child or non-whitespace
+  character content is a schema error) with only `@id`; `<xs:appinfo>` allows only `@source`;
+  `<xs:documentation>` allows only `@source`/`@xml:lang` (a valid `xs:language` after collapse;
+  empty/whitespace-only invalid); every XSD element admits AT MOST ONE annotation child EXCEPT
+  `xs:schema`/`xs:redefine`/`xs:override` (open `(annotation | component)*`).
+- **simpleContent base kind** (src-ct.2, version-INDEPENDENT): `checkSimpleContentBase` (`link_refs.go`, in
+  `resolveRefs`) rejects an `<xs:simpleContent>` EXTENSION whose base is neither a simple type nor a complex
+  type with simple content, and a RESTRICTION whose base is not a complex type with simple content (nor a
+  mixed+emptiable complex type carrying a nested `<xs:simpleType>`, clause 2.3); `xs:anySimpleType` is an
+  accepted restriction base.
+- **attribute `@type`/`@ref` kind resolution** (src-resolve §3.2.2, version-INDEPENDENT):
+  `checkAttributeResolution` (`link_refs.go`, in `resolveRefs`) rejects an `<xs:attribute>` whose `@type`
+  resolves to a complexType (incl. `xs:anyType`) OR to NO type at all (a missing type reference — e.g.
+  `xs:strong`, `xsd:undefined`), UNLESS the miss is a deferrable §5.3 unused-missing-component
+  (`deferMissingTypeRef`: an absent-namespace user type, mirroring the element/item/union deferral) or a
+  malformed/deprecated-namespace QName already reported at its read point. A qualified (prefixed /
+  target-namespace) missing `@type` is never deferrable, so it is reported (`ctZ002`, `xsd003b.e`); a name
+  that already carries a missing-type PLACEHOLDER (installed+reported by a base/item/union reference) is left
+  to that owner (no double-report). And a `@ref` resolving to an EXISTING wrong-symbol-space component (a
+  named type / global element / attribute group, via `qnameNamesNonAttribute`'s exact `{ns}local` lookup). A
+  `@ref` resolving to NOTHING is an error UNLESS its namespace was import-DECLARED — recorded in
+  `importDeclaredNS` (populated at the top of `processImport` for EVERY `<xs:import namespace>` regardless of
+  load outcome; unioned up from import sub-compilers). A ref into a NEVER-imported namespace (including the
+  schema's own `targetNamespace` and the absent namespace) is illegal. The built-in XML namespace
+  (xml:lang/base/space/id) and XSI are exempt. `resolveNamedType` (the `@type` path) tries the exact
+  `{ns}local` first and falls back to `{}local` only on a miss (a chameleon/no-namespace-target `@type` still
+  resolves while a same-named wrong-symbol-space component is not masked). `attrRefSources` records `@ref`
+  sites (merged from import sub-compilers). An UNPREFIXED attribute `@ref` with no in-scope default namespace
+  resolves to NO namespace (`parseAttributeUse`, `read_elements.go`): an attribute reference does not fall
+  back to the schema `targetNamespace` the way `resolveQName` defaults a bare name, so `ref="a"` does NOT bind
+  a same-`targetNamespace` global attribute `{T}a` (`AU_attrDecl00101m1_n`) — EXCEPT when the owning document
+  declares no `@targetNamespace` of its own (`elementDocDeclaresTargetNS`), i.e. a chameleon include whose
+  unqualified declarations and refs are coerced into the including namespace as a unit (`include1_0`).
+- **model-group ref resolution** (src-resolve §3.7.2, version-INDEPENDENT): the `resolveRefs` group-ref loop
+  (`link_refs.go`) rejects an `<xs:group ref="...">` not resolving to a globally declared model group (wrong
+  symbol space — a complexType/attributeGroup of the same name — or declared nowhere), mirroring
+  `checkAttrGroupRefsResolve` (symbol-space-only lookup, `qn.NS != ""` empty-ns fallback for
+  chameleon/no-namespace imports, `(source, line, local)` sort). A permitted 1.1 circular ref is cut by
+  `checkCircularGroupRefs` and `continue`d before this dangling check.
+- **src-redefine.6.1** (§4.2.3, version-INDEPENDENT): `processRedefineOverrides`' group case
+  (`compile_imports.go`) enforces 6.1.1/6.1.2 — a `<xs:group>` child of `<xs:redefine>` referencing its own
+  name must do so EXACTLY ONCE with `minOccurs=maxOccurs=1` (schR3/schR4). A group with no self-reference is a
+  clause-6.2 restriction gap (accepted, not enforced).
+- **ID value-constraint prohibition** (au-props-correct.3 §3.2.6, XSD 1.0 ONLY): `checkAttrUseConstraints`
+  (`link_refs.go`) rejects an attribute whose type is or derives from `xs:ID` (`builtinBaseLocal(td) == "ID"`)
+  carrying a default/fixed. Gated to `Version10` — XSD 1.1 removed the rule (W3C bug 4077).
+- **inline model group content model** (§3.8.2): `parseModelGroup` (`read_particles.go`) enforces an inline
+  `<xs:sequence>`/`<xs:choice>`/`<xs:all>` content `(annotation?, particle*)`: at most one annotation
+  preceding every particle, no `@name` (only `id`/`minOccurs`/`maxOccurs`), no non-particle XSD child (all
+  version-INDEPENDENT; foreign-namespace children untouched). Admissible PARTICLE kinds are version-split ONLY
+  for `xs:all`: XSD 1.0 admits `element` only (a nested `group`/`sequence`/`choice`, or an `<xs:any>`
+  wildcard, is a stray — W3C sunData particles00104m1), Version11 additionally admits `any` and a `group` ref
+  (nested-all-group relaxation, gated downstream in `checkAllGroupRef`). `xs:sequence`/`xs:choice` admit
+  `(element | group | choice | sequence | any)` in both versions; a nested `xs:all` inside a sequence/choice
+  stays a cos-all-limited error.
+- **xs:redefine type self-derivation** (version-INDEPENDENT, §4.2.3 src-redefine.5):
+  `checkRedefineSelfDerivation` (`compile_imports.go`, from the `processRedefineOverrides`
+  complexType/simpleType cases) requires a `<simpleType>`/`<complexType>` child of `<xs:redefine>` to have a
+  `<restriction>` (or, for a complexType, `<extension>`) whose resolved `base` names the redefined type ITSELF
+  — present iff the replacement's recorded base ref (`c.typeRefs[newType]`) equals its own name `qn`. A base
+  naming a different type, a same-local base in another namespace (an imported `foo:b-st`), or no derivation
+  is a schema error, and the self-reference patch (redirecting the base ref to the original Phase-A type) is
+  skipped. The patch stashes the original type under a UNIQUE synthetic key `\x00redefine:<seq>:<name>`
+  (`compiler.redefineOrigSeq`, a monotonic counter) so a CHAIN of `<xs:redefine>` targeting the SAME type name
+  (a schema redefining a document that itself redefines the type — W3C stZ033/stZ034, addB007) does not
+  collide: a per-name key would let an outer level overwrite the stash the inner level's patched base still
+  points at, looping the base onto itself (a spurious circular-type / duplicate-attribute error).
+  Group/attributeGroup redefine children are NOT covered (a group without self-reference is valid iff it
+  validly restricts the original per src-redefine.6.2, and an attributeGroup redefinition needs no
+  self-reference — both a documented gap).
+- **xs:redefine closed attribute vocabulary** (version-INDEPENDENT): `checkRedefineAttrs`
+  (`compile_imports.go`, from the `processNestedIncludes`/`parseSchemaChildren` redefine dispatch) rejects any
+  UNQUALIFIED attribute on `<xs:redefine>` outside the schema-for-schemas set `{id, schemaLocation}` — a
+  foreign-namespaced attribute is admitted, but a no-namespace `namespace` attribute (which belongs to
+  `<xs:import>`, not `<xs:redefine>`) is a schema-representation error (W3C msMeta/Schema_w3c.xml schH4).
+- **xs:redefine closed child vocabulary** (version-INDEPENDENT): the `processRedefineOverrides` child dispatch
+  (`compile_imports.go`) has a `default` arm rejecting any XSD-namespace child of `<xs:redefine>` outside its
+  content model `(annotation | (simpleType | complexType | group | attributeGroup))*` — an `<xs:element>` (W3C
+  sunData xsd003-1.e) or an `<xs:attribute>` (xsd003-2.e) is a schema-representation error; foreign-namespace
+  children are ignored.
+- **built-in FIXED facet restriction** (version-INDEPENDENT): `checkBuiltinFixedFacetRestriction`
+  (`check_facets.go`) rejects a restriction changing a facet the built-in base fixes — the `collapse`
+  `whiteSpace` and `explicitTimezone` on the date/time family, and `fractionDigits=0` on the `xs:integer`
+  family (`value.IsIntegerFamily`: the `xs:decimal` family minus `xs:decimal`). A non-zero `fractionDigits` on
+  `xs:integer` or a derived type (long/int/short/byte, the (non)positive/(non)negative integers, the unsigned
+  family, positiveInteger) is a schema error; explicit `fractionDigits="0"` is permitted; `xs:decimal` (not
+  fixing `fractionDigits`) still accepts a non-zero value.
+- **built-in INTRINSIC facets** (version-INDEPENDENT): `registerBuiltinTypes` (`compile.go`, via
+  `intrinsicBuiltinFacets`) records each built-in's spec-mandated INTRINSIC facets on `TypeDef.Facets` —
+  `xs:NMTOKENS`/`xs:IDREFS`/`xs:ENTITIES` carry `minLength=1` (Part 2 §4.3.2), `xs:positiveInteger` carries
+  `minInclusive=1` (§3.3.25) — so the facet-restriction checks (`check_facets.go`) see them when a user type
+  restricts the built-in. Instance validation is byte-identical (the value space already rejects an empty
+  NMTOKENS list and positiveInteger < 1 in `validateBuiltinValue`/`validateListValue`). A restriction DROPPING
+  below an intrinsic bound is a schema error. The length family (length/minLength/maxLength) narrowing and
+  cross-consistency (`length`↔`minLength`/`maxLength`, `minLength`≤`maxLength`) run in
+  `checkLengthFacetRestriction` (`check_facets.go`) against the EFFECTIVE inherited bound over the WHOLE base
+  chain — tightest inherited `minLength` (max), `maxLength` (min), any inherited `length`, via
+  `effectiveInheritedMinLength`/`effectiveInheritedMaxLength`/`effectiveInheritedLength` (each
+  `baseChain(td.BaseType)`, `td` excluded) — NOT the nearest ancestor's `baseFacets`, so an intermediate
+  restriction carrying only a pattern cannot HIDE an inherited bound. Scoped to length-applicable varieties (a
+  list or length-applicable atomic primitive) so an inapplicable length facet (reported by
+  `checkFacetApplicability`) is not double-flagged; each cross-consistency comparison pairs a DERIVED facet
+  against an INHERITED bound so it never double-reports the own-vs-own cases (`checkFacetMutualExclusion`,
+  `checkFacetSameTypeConsistency`). A `maxExclusive`/`maxInclusive` violating the inherited `minInclusive` is
+  caught by `effectiveInheritedRangeBounds`/`checkUpper` (also whole-chain). The digit facets
+  (`totalDigits`/`fractionDigits`) keep the nearest-ancestor `baseFacets` comparison.
+  `checkFacetMutualExclusion` (passed `td`) is INHERITANCE-AWARE for the `length` + `minLength`/`maxLength`
+  co-occurrence (§4.3.1.4 / W3C bug 6446, `lengthConflictsWithMinMax`): `length` may co-occur with a
+  `minLength`/`maxLength` on the SAME step ONLY when that facet is genuinely INHERITED — own value equals the
+  effective inherited value over PROPER ancestors (a mere RESTATEMENT) AND value-consistent with `length`
+  (minLength ≤ length ≤ maxLength). So `xs:IDREFS` restricted to `length=5`,`minLength=1` is permitted (own 1
+  == inherited intrinsic 1), while a fresh tighter bound — `length=5`,`minLength=2` (own 2 ≠ 1) or base
+  `maxLength=10` restated as `length=5`,`maxLength=8` (own 8 ≠ 10) — stays an error.
 - **complexType `@block`/`@final` enum** (version-INDEPENDENT): `parseComplexType` (`read_types.go`, via `isValidFinal`) rejects a `<xs:complexType>` `@block`/`@final` not drawn from `{#all, extension, restriction}`.
-- **content-model group reference representation** (§3.8.2, version-INDEPENDENT): `checkContentModelGroupRef` (`read_particles.go`) enforces that an `<xs:group>` particle in a content model is a REFERENCE — content `(annotation?)` with only `@ref`; a `@name`, a missing `@ref`, or any non-annotation element child is a schema error (a well-formed ref is recorded).
-- **non-reference `<xs:attribute>` content model** (§3.2.2, version-INDEPENDENT): `checkAttributeChildren` (`check_elements.go`) enforces `(annotation?, simpleType?)` — a misplaced/duplicate annotation, a second `simpleType`, or any other XSD child (nested `xs:attribute`/`xs:element`/`xs:complexType`) is reported; foreign-namespace children ignored (the `@type`-vs-`simpleType` mutual exclusion enforced separately).
-- **wildcard XML representation** (version-INDEPENDENT): `checkWildcardAttrs` (`read_elements.go`) restricts `<xs:any>`/`<xs:anyAttribute>` attributes to `{id, namespace, processContents}`, with `{minOccurs, maxOccurs}` on `<xs:any>` only (rejected on `anyAttribute`); `notNamespace`/`notQName` permitted-and-ignored in 1.0, any other attribute a schema error. `checkWildcardChildren` (`read_elements.go`, from `readWildcard`) enforces the `(annotation?)` content model: any XSD-namespace child other than `<xs:annotation>` — e.g. a nested `<xs:group>` reference (W3C groupO026) or an `<xs:element>` — is a schema-representation error; foreign-namespace children are ignored.
-- **whiteSpace valid restriction** (Part 2 §4.3.6, version-INDEPENDENT): `checkWhiteSpaceValidRestriction` (`check_facets.go`) rejects a derived `whiteSpace` that LOOSENS the base's — permitted ordering preserve→replace→collapse (may equal/tighten, never loosen); the builtin-fixed-collapse date/time family is skipped (reported by `checkBuiltinFixedFacetRestriction`).
-- **element default/fixed content-type applicability** (§3.3.6 Element Default Valid clause 2.1, version-INDEPENDENT): `checkElementDeclConstraints` (`link_refs.go`) rejects a default/fixed on an element whose EFFECTIVE type is a complex type with element-only/empty content; simple/simpleContent content is type-validated, mixed content left to its own path.
-- **src-import namespace representation** (§4.2.6.1, version-INDEPENDENT): `processImport` (`compile_imports.go`) rejects an `<xs:import>` with `namespace=""` (the absent namespace is imported by omitting `@namespace`), a `@namespace` matching the importing schema's own `targetNamespace` (src-import.1.1), and a no-`@namespace` import in a schema lacking a `targetNamespace` (src-import.1.2); the invalid import is reported and skipped. `Compile` (`compile.go`) also rejects an empty schema `targetNamespace=""`.
+- **content-model group reference representation** (§3.8.2, version-INDEPENDENT): `checkContentModelGroupRef`
+  (`read_particles.go`) enforces that an `<xs:group>` particle in a content model is a REFERENCE — content
+  `(annotation?)` with only `@ref`; a `@name`, a missing `@ref`, or any non-annotation element child is a
+  schema error (a well-formed ref is recorded).
+- **non-reference `<xs:attribute>` content model** (§3.2.2, version-INDEPENDENT): `checkAttributeChildren`
+  (`check_elements.go`) enforces `(annotation?, simpleType?)` — a misplaced/duplicate annotation, a second
+  `simpleType`, or any other XSD child (nested `xs:attribute`/`xs:element`/`xs:complexType`) is reported;
+  foreign-namespace children ignored (the `@type`-vs-`simpleType` mutual exclusion enforced separately).
+- **wildcard XML representation** (version-INDEPENDENT): `checkWildcardAttrs` (`read_elements.go`) restricts
+  `<xs:any>`/`<xs:anyAttribute>` attributes to `{id, namespace, processContents}`, with `{minOccurs,
+  maxOccurs}` on `<xs:any>` only (rejected on `anyAttribute`); `notNamespace`/`notQName` permitted-and-ignored
+  in 1.0, any other attribute a schema error. `checkWildcardChildren` (`read_elements.go`, from
+  `readWildcard`) enforces the `(annotation?)` content model: any XSD-namespace child other than
+  `<xs:annotation>` — e.g. a nested `<xs:group>` reference (W3C groupO026) or an `<xs:element>` — is a
+  schema-representation error; foreign-namespace children are ignored.
+- **whiteSpace valid restriction** (Part 2 §4.3.6, version-INDEPENDENT): `checkWhiteSpaceValidRestriction`
+  (`check_facets.go`) rejects a derived `whiteSpace` that LOOSENS the base's — permitted ordering
+  preserve→replace→collapse (may equal/tighten, never loosen); the builtin-fixed-collapse date/time family is
+  skipped (reported by `checkBuiltinFixedFacetRestriction`).
+- **element default/fixed content-type applicability** (§3.3.6 Element Default Valid clause 2.1,
+  version-INDEPENDENT): `checkElementDeclConstraints` (`link_refs.go`) rejects a default/fixed on an element
+  whose EFFECTIVE type is a complex type with element-only/empty content; simple/simpleContent content is
+  type-validated, mixed content left to its own path.
+- **src-import namespace representation** (§4.2.6.1, version-INDEPENDENT): `processImport`
+  (`compile_imports.go`) rejects an `<xs:import>` with `namespace=""` (the absent namespace is imported by
+  omitting `@namespace`), a `@namespace` matching the importing schema's own `targetNamespace`
+  (src-import.1.1), and a no-`@namespace` import in a schema lacking a `targetNamespace` (src-import.1.2); the
+  invalid import is reported and skipped. `Compile` (`compile.go`) also rejects an empty schema
+  `targetNamespace=""`.
 - **local complexType `@name` prohibition** (version-INDEPENDENT): `parseComplexType` (`read_types.go`, `local` flag) rejects a `@name` on an inline (non-top-level) `<xs:complexType>`.
-- **required `@schemaLocation`** (src-include.1/src-redefine.1 §4.2.3, version-INDEPENDENT): `processIncludes` (`compile_imports.go`) treats an ABSENT `@schemaLocation` on `<xs:include>`/`<xs:redefine>` as a fatal schema-representation error, distinct from a present-but-unresolvable location hint (a warning).
-- **element/attribute closed attribute vocabulary**: `checkElementAttrVocabulary`/`checkAttrVocabulary` (`check_elements.go`) reject an unknown UNQUALIFIED attribute on `<xs:element>`/`<xs:attribute>` (the schema-for-schemas admits only the declared unqualified attributes plus `anyAttribute namespace="##other"`); foreign-namespace attributes permitted. The `<xs:element>` set is version-INDEPENDENT; the `<xs:attribute>` set is version-SPLIT — `targetNamespace`/`inheritable` are XSD 1.1 additions, so `checkAttrVocabulary` rejects them under `Version10` as unknown attributes (W3C ibmData S3_2_3/s3_2_3si05).
-- **non-imported-namespace reference** (src-resolve §3.3.2, version-INDEPENDENT): `checkNonImportedNamespaceRefs` (`link_refs.go`) rejects an ENTRY-document `<xs:element>` `@type`/`@ref` into a namespace the entry document did not DIRECTLY import (tracked per document in `docImportedNS[c.filename]`), even when another document imported it — transitive import does not make a namespace referenceable. Deliberately CONSERVATIVE: only for a reference resolving to a real loaded component in a genuinely import-requiring namespace.
-- **element content-model ordering** (§3.3.2, version-INDEPENDENT): `checkElementContentOrder` (`check_elements.go`) enforces the `(annotation?, ((simpleType | complexType)?, alternative*, (unique | key | keyref)*))` order by requiring recognized content children to appear in non-decreasing grammar position (`elementContentOrdinal`: annotation=0, simpleType/complexType=1, alternative=2, unique/key/keyref=3). So an `<xs:annotation>` may not follow any content child, and a type definition (`simpleType`/`complexType`) may not follow an `alternative` or an identity constraint (a `<unique>` before the `<complexType>` is rejected). It also enforces the CLOSED vocabulary: an XSD-namespace child outside that set (a compositor like `<xs:sequence>`, an `<xs:attribute>`, or an `<xs:group>` reference — W3C attQ002/groupO024) is a schema-representation error; foreign-namespace children are ignored. Cardinality (at-most-one annotation/type) is enforced separately.
-- **schema-namespace attribute prohibition** (version-INDEPENDENT): `checkSchemaNamespaceAttrs` (`check_schema_attrs.go`, a DOM walk not descending into `xs:appinfo`/`xs:documentation` payload) rejects any attribute in the XSD namespace (e.g. `xsd:type`) on an XSD-namespace schema element — only unqualified schema attributes and non-XSD foreign attributes are admissible.
-- **element ID value-constraint prohibition** (§3.3.6 Element Declaration Properties Correct, XSD 1.0 ONLY): `checkElementDeclConstraints` (`link_refs.go`) rejects an element whose EFFECTIVE type is or derives from `xs:ID` (`builtinBaseLocal == "ID"`) carrying a default/fixed — the element analog of au-props-correct.3. Gated to `Version10`; XSD 1.1 removed it (W3C bug 4077).
-- **attributeGroup definition annotation order** (§3.6.2, version-INDEPENDENT): `parseNamedAttributeGroup` (`read_particles.go`) rejects an `<xs:annotation>` FOLLOWING any content particle in an `<xs:attributeGroup>` DEFINITION — content model `(annotation?, ((attribute | attributeGroup)*, anyAttribute?))`.
-- **conditional inclusion** (`conditional_inclusion.go`: a PRE-PASS before `parseSchemaChildren` in both versions, pruning any element with its subtree excluded by its version-control (`vc:`) attributes from `http://www.w3.org/2007/XMLSchema-versioning`). `vc:minVersion`/`vc:maxVersion` keep iff `minVersion <= processorVersion < maxVersion`; `vc:typeAvailable`/`vc:facetAvailable` keep iff EVERY listed QName is available; `vc:typeUnavailable`/`vc:facetUnavailable` keep iff at least one is UNavailable (empty `*Unavailable` = unconditional exclude, empty `*Available` = no-op). "Available" is a fixed per-version PROCESSOR-CAPABILITY check against immutable built-in sets (NOT `c.schema.types`): an XSD-namespace built-in type for the active version (xs:error/1.1-only types only in 1.1) or an XSD-namespace facet name recognized by the version (`xs:assertion`/`xs:explicitTimezone` are 1.1-only); non-XSD QNames unavailable. A vc-excluded ROOT `<xs:schema>` makes the whole document empty. The pre-pass also runs on every included/imported/redefined document. Because it UNLINKS nodes, `Compile` keeps the caller's document immutable: it pre-scans for any vc attribute and, only when one is present, prunes a `helium.CopyDoc` clone (URL preserved) — so `Compile` is idempotent across versions; a vc-free schema keeps the no-copy fast path. Malformed `vc:` values (bad decimal, invalid/unbound-prefix QName) are fatal schema errors ONLY under 1.1; under 1.0 tolerated and the condition skipped. Misspelt versioning-namespace attributes (`vc:minversion`) are foreign attributes with no effect.
-- **Circular attribute group definitions** are permitted in 1.1 (W3C bug 15795 / attgC010-D015): a DIRECT self-reference (`read_particles.go`) and an INDIRECT cycle (`link_refs.go` `checkCircularAttrGroupRefs`) are silently dropped/cut (the back-edge is still CUT so flatten/expand walks terminate). XSD 1.0 rejects both (src-attribute_group.3).
-- **attributeGroup ref resolution** (version-INDEPENDENT, src-resolve / Attribute Group Definition Representation OK 3): `checkAttrGroupRefsResolve` (`link_refs.go`, in `resolveRefs` before the circular check) rejects every `<xs:attributeGroup ref="...">` — a nested child of a global group (`attrGroupRefChildren`) or a member of a complex type / derivation body (`attrGroupRefs`) — not resolving to a globally-declared attribute group: wrong symbol space (a complexType or global attribute of the same name), declared nowhere, or an empty/absent ref (the four ref-recording sites in `read_types.go`/`read_particles.go` record a present-empty `ref=""` via `hasAttr`). An unprefixed ref resolving to the schema targetNamespace but whose group comes from a NO-namespace imported schema falls back to the empty-namespace lookup (mirroring the element/type chameleon fallback). A permitted 1.1 circular ref resolves to an existing group and is unaffected. Diagnostics sorted by (source, line, local).
-- **xs:pattern regex 1.1 edges** (`internal/xsdregex`, `CompileVersion(pattern, xsd11)` threaded from `read_types.go` as `c.version == Version11`): an unrecognized `\p{Is...}` block name is VALID and matches every character (XSD 1.1 test bug 13670; the negation matches none), instead of a FORX0002 compile error — a character class whose only members are negated-unknown-block contributions (`[\P{IsFoo}]`) denotes the empty set and `processCharClass` emits a never-matching construct (`[^` all `]`; the complement `[^\P{IsFoo}]` emits match-any), since RE2 cannot parse an empty `[]`. `\c`/`\C` (XML NameChar) admit the full XML 1.1 / XML 1.0 5th-edition combining range U+0300–U+036F, INCLUDING U+0346, via `xmlNameCharRange`. The `\c`/`\C` full range is gated on the `xsdPattern` flavor, NOT the version: EVERY XSD pattern-facet path (`Compile`/`CompileVersion`, `xsdPattern=true` — 1.0 and 1.1, including relaxng, which passes xsd11=false) uses the 5th-edition NameChar (W3C regex test reZ006i / bug 13606). Only xpath3's `Translate`/`Validate` (`xsdPattern=false`) keeps the U+0346-carved `\c` range. The `\p{Is...}` FORX0002 rejection stays version-gated: XSD 1.0 (`Compile`, xsd11=false) keeps it.
-- **xs:override** (`override.go`, §4.2.5/§F): WHOLESALE replacement of any top-level component — element/attribute/simpleType/complexType/group/attributeGroup/notation — in the referenced document by an xs:override child of the same (expanded-name, symbol space); simpleType and complexType share ONE type-definition symbol space (over013). Gated to Version11; 1.0 ignores xs:override entirely.
-  - An override child matching NOTHING in the referenced closure is DROPPED, not added (a dangling reference to it is an error — over026; conformance-verified, NOT the literal §4.2.5 "add all children" reading — registering unmatched children makes over026 the only failing case); a matched component is SUPPRESSED during load and the override child registered in its place via the normal named-component parsers (a matched notation override is a no-op — notations not modeled).
-  - TRANSITIVE: the referenced document's own xs:include/xs:override are re-applied under the SAME cascaded override set, OUTER override winning on a name+symbol-space collision (double override over009); a nested xs:include is treated as an xs:override carrying the active set (indirect chameleon over020), and a chameleon no-targetNamespace target adopts the overriding schema's namespace like include (over018-020). The active set is BRANCH-LOCAL: a nested xs:override builds a FRESH map (inherited ∪ its own children, outer-precedence, `activeFromEntries`) so its children never leak into a later SIBLING target's suppression set; `overrideLoadTarget` RETURNS the matched subset and each xs:override REGISTERS its matched children IMMEDIATELY (`registerMatchedChildren`/`registerOverrideChild`) while the DECLARING document's context (form/block/final defaults, xpathDefaultNamespace, base URI, includeFile) is active.
-  - EXCEPTION — schema-level `@defaultAttributes`: per §4.2.5 a replacement is COPIED INTO the transformed TARGET document, so the TARGET document's `@defaultAttributes` governs its implicit default attribute-group ref. `overrideLoadTarget` resolves the target root's `@defaultAttributes` (via `resolveSchemaDefaultAttributes`, shared with `readSchemaDefaultAttributes`), applies it while parsing the target (surviving target complex types governed too — save/reset/restore alongside form defaults) and RETURNS the `schemaDefaultAttrsState`; the owner (`loadOverride`/`overrideProcessNested`) reapplies it around `registerMatchedChildren` so the replacement records the target's implicit ref or none (an override target lacking `@defaultAttributes` does not inherit the overriding schema's group — s3_4_2_4ii08). A replacement matched in a NESTED INCLUDED document of the target is registered under THAT document's per-document @defaultAttributes and default open content (`overrideMatchCtx` threads each matched key's declaring-document defaults; `registerMatchedChildren` applies the per-key context).
-  - Termination/cycles: loads tracked in a SEPARATE `overrideVisited` set (distinct from plain-include `includeVisited`) keyed by (path + active-set FINGERPRINT `overrideActiveFingerprint` — sorted symbol/name/replacement-element identity), plus the overriding document's `rootKey`. A back-edge to the root, or a re-reach under the SAME active set, terminates without re-loading (permissible circular override over023); the SAME document under a DIFFERENT active set is a distinct transformed document and IS loaded again (keying by path alone would over-terminate and drop a sibling's replacements — a real collision then surfaces via the duplicate-component check). A disallowed cycle over024 surfaces as a dangling-reference error.
-  - A document pulled in by BOTH plain xs:include/xs:redefine AND xs:override is a FATAL conflict (`reportOverrideIncludeConflict`, in `overrideLoadTarget` and symmetrically in loadInclude/loadRedefine). A document overridden twice within one schema document is rejected (over022, per-document target set in processIncludes/overrideProcessNested); two override children targeting the same component is rejected (over021). xs:import inside a referenced document is processed via the SHARED `processImport` (NOT transformed — over025/over029), emitting the same already-imported / load-failure WARNINGS as a top-level import; override children may reference components imported only by the overriding schema (over029). Override+xs:redefine interplay is not exercised by the suite and processes redefine normally without cascade — a documented gap.
-  - **Element/attribute default/fixed value validity against the declared type at compile time** (version-INDEPENDENT, §3.3.6 Element Default Valid): `checkAttrUseConstraints` validates attribute uses and `checkElementDeclConstraints` (`link_refs.go`, in `resolveRefs`) validates element declarations — an EXPLICIT default/fixed is checked against the element's EFFECTIVE declared type (`effectiveDeclType`, so a no-type substitution-group member is validated against its inherited head type; a default/fixed on an element-only/empty complex-content type is a §3.3.6 clause-2.1 schema error, mixed content left to its own path) through the shared `validateSimpleContentValue` (effective content simple type PLUS inherited base-content facets via `validateNestedSimpleContentBases`) on the version-/schema-aware `validateValue`, so an invalid list/union/builtin default (decimal `"XII"`, boolean `"Yes"`, float `"1.0F-2"`) — or one violating an inherited simpleContent base facet — is a fatal schema error in both versions (W3C idIDREF s3_3_4si07/si08). `elemDeclConstraintSources` is recorded unconditionally and merged from import sub-compilers. The IDC-field `typeAcceptsValue` threads the live validation's `version`/`schema` into its diagnostic-suppressing throwaway context (`vc.typeAcceptsValue`), so IDC union active-member selection and 1.1-only lexical forms (`+INF`, year `0000`, xs:dateTimeStamp) resolve under the schema's real version; only the standalone `TypeDef.Validate` remains on the Version10/nil-schema default — a documented Phase-1 gap.
+- **required `@schemaLocation`** (src-include.1/src-redefine.1 §4.2.3, version-INDEPENDENT): `processIncludes`
+  (`compile_imports.go`) treats an ABSENT `@schemaLocation` on `<xs:include>`/`<xs:redefine>` as a fatal
+  schema-representation error, distinct from a present-but-unresolvable location hint (a warning).
+- **element/attribute closed attribute vocabulary**: `checkElementAttrVocabulary`/`checkAttrVocabulary`
+  (`check_elements.go`) reject an unknown UNQUALIFIED attribute on `<xs:element>`/`<xs:attribute>` (the
+  schema-for-schemas admits only the declared unqualified attributes plus `anyAttribute namespace="##other"`);
+  foreign-namespace attributes permitted. The `<xs:element>` set is version-INDEPENDENT; the `<xs:attribute>`
+  set is version-SPLIT — `targetNamespace`/`inheritable` are XSD 1.1 additions, so `checkAttrVocabulary`
+  rejects them under `Version10` as unknown attributes (W3C ibmData S3_2_3/s3_2_3si05).
+- **non-imported-namespace reference** (src-resolve §3.3.2, version-INDEPENDENT):
+  `checkNonImportedNamespaceRefs` (`link_refs.go`) rejects an ENTRY-document `<xs:element>` `@type`/`@ref`
+  into a namespace the entry document did not DIRECTLY import (tracked per document in
+  `docImportedNS[c.filename]`), even when another document imported it — transitive import does not make a
+  namespace referenceable. Deliberately CONSERVATIVE: only for a reference resolving to a real loaded
+  component in a genuinely import-requiring namespace.
+- **element content-model ordering** (§3.3.2, version-INDEPENDENT): `checkElementContentOrder`
+  (`check_elements.go`) enforces the `(annotation?, ((simpleType | complexType)?, alternative*, (unique | key
+  | keyref)*))` order by requiring recognized content children to appear in non-decreasing grammar position
+  (`elementContentOrdinal`: annotation=0, simpleType/complexType=1, alternative=2, unique/key/keyref=3). So an
+  `<xs:annotation>` may not follow any content child, and a type definition (`simpleType`/`complexType`) may
+  not follow an `alternative` or an identity constraint (a `<unique>` before the `<complexType>` is rejected).
+  It also enforces the CLOSED vocabulary: an XSD-namespace child outside that set (a compositor like
+  `<xs:sequence>`, an `<xs:attribute>`, or an `<xs:group>` reference — W3C attQ002/groupO024) is a
+  schema-representation error; foreign-namespace children are ignored. Cardinality (at-most-one
+  annotation/type) is enforced separately.
+- **schema-namespace attribute prohibition** (version-INDEPENDENT): `checkSchemaNamespaceAttrs`
+  (`check_schema_attrs.go`, a DOM walk not descending into `xs:appinfo`/`xs:documentation` payload) rejects
+  any attribute in the XSD namespace (e.g. `xsd:type`) on an XSD-namespace schema element — only unqualified
+  schema attributes and non-XSD foreign attributes are admissible.
+- **element ID value-constraint prohibition** (§3.3.6 Element Declaration Properties Correct, XSD 1.0 ONLY):
+  `checkElementDeclConstraints` (`link_refs.go`) rejects an element whose EFFECTIVE type is or derives from
+  `xs:ID` (`builtinBaseLocal == "ID"`) carrying a default/fixed — the element analog of au-props-correct.3.
+  Gated to `Version10`; XSD 1.1 removed it (W3C bug 4077).
+- **attributeGroup definition annotation order** (§3.6.2, version-INDEPENDENT): `parseNamedAttributeGroup`
+  (`read_particles.go`) rejects an `<xs:annotation>` FOLLOWING any content particle in an
+  `<xs:attributeGroup>` DEFINITION — content model `(annotation?, ((attribute | attributeGroup)*,
+  anyAttribute?))`.
+- **conditional inclusion** (`conditional_inclusion.go`: a PRE-PASS before `parseSchemaChildren` in both
+  versions, pruning any element with its subtree excluded by its version-control (`vc:`) attributes from
+  `http://www.w3.org/2007/XMLSchema-versioning`). `vc:minVersion`/`vc:maxVersion` keep iff `minVersion <=
+  processorVersion < maxVersion`; `vc:typeAvailable`/`vc:facetAvailable` keep iff EVERY listed QName is
+  available; `vc:typeUnavailable`/`vc:facetUnavailable` keep iff at least one is UNavailable (empty
+  `*Unavailable` = unconditional exclude, empty `*Available` = no-op). "Available" is a fixed per-version
+  PROCESSOR-CAPABILITY check against immutable built-in sets (NOT `c.schema.types`): an XSD-namespace built-in
+  type for the active version (xs:error/1.1-only types only in 1.1) or an XSD-namespace facet name recognized
+  by the version (`xs:assertion`/`xs:explicitTimezone` are 1.1-only); non-XSD QNames unavailable. A
+  vc-excluded ROOT `<xs:schema>` makes the whole document empty. The pre-pass also runs on every
+  included/imported/redefined document. Because it UNLINKS nodes, `Compile` keeps the caller's document
+  immutable: it pre-scans for any vc attribute and, only when one is present, prunes a `helium.CopyDoc` clone
+  (URL preserved) — so `Compile` is idempotent across versions; a vc-free schema keeps the no-copy fast path.
+  Malformed `vc:` values (bad decimal, invalid/unbound-prefix QName) are fatal schema errors ONLY under 1.1;
+  under 1.0 tolerated and the condition skipped. Misspelt versioning-namespace attributes (`vc:minversion`)
+  are foreign attributes with no effect.
+- **Circular attribute group definitions** are permitted in 1.1 (W3C bug 15795 / attgC010-D015): a DIRECT
+  self-reference (`read_particles.go`) and an INDIRECT cycle (`link_refs.go` `checkCircularAttrGroupRefs`) are
+  silently dropped/cut (the back-edge is still CUT so flatten/expand walks terminate). XSD 1.0 rejects both
+  (src-attribute_group.3).
+- **attributeGroup ref resolution** (version-INDEPENDENT, src-resolve / Attribute Group Definition
+  Representation OK 3): `checkAttrGroupRefsResolve` (`link_refs.go`, in `resolveRefs` before the circular
+  check) rejects every `<xs:attributeGroup ref="...">` — a nested child of a global group
+  (`attrGroupRefChildren`) or a member of a complex type / derivation body (`attrGroupRefs`) — not resolving
+  to a globally-declared attribute group: wrong symbol space (a complexType or global attribute of the same
+  name), declared nowhere, or an empty/absent ref (the four ref-recording sites in
+  `read_types.go`/`read_particles.go` record a present-empty `ref=""` via `hasAttr`). An unprefixed ref
+  resolving to the schema targetNamespace but whose group comes from a NO-namespace imported schema falls back
+  to the empty-namespace lookup (mirroring the element/type chameleon fallback). A permitted 1.1 circular ref
+  resolves to an existing group and is unaffected. Diagnostics sorted by (source, line, local).
+- **xs:pattern regex 1.1 edges** (`internal/xsdregex`, `CompileVersion(pattern, xsd11)` threaded from
+  `read_types.go` as `c.version == Version11`): an unrecognized `\p{Is...}` block name is VALID and matches
+  every character (XSD 1.1 test bug 13670; the negation matches none), instead of a FORX0002 compile error — a
+  character class whose only members are negated-unknown-block contributions (`[\P{IsFoo}]`) denotes the empty
+  set and `processCharClass` emits a never-matching construct (`[^` all `]`; the complement `[^\P{IsFoo}]`
+  emits match-any), since RE2 cannot parse an empty `[]`. `\c`/`\C` (XML NameChar) admit the full XML 1.1 /
+  XML 1.0 5th-edition combining range U+0300–U+036F, INCLUDING U+0346, via `xmlNameCharRange`. The `\c`/`\C`
+  full range is gated on the `xsdPattern` flavor, NOT the version: EVERY XSD pattern-facet path
+  (`Compile`/`CompileVersion`, `xsdPattern=true` — 1.0 and 1.1, including relaxng, which passes xsd11=false)
+  uses the 5th-edition NameChar (W3C regex test reZ006i / bug 13606). Only xpath3's `Translate`/`Validate`
+  (`xsdPattern=false`) keeps the U+0346-carved `\c` range. The `\p{Is...}` FORX0002 rejection stays
+  version-gated: XSD 1.0 (`Compile`, xsd11=false) keeps it.
+- **xs:override** (`override.go`, §4.2.5/§F): WHOLESALE replacement of any top-level component —
+  element/attribute/simpleType/complexType/group/attributeGroup/notation — in the referenced document by an
+  xs:override child of the same (expanded-name, symbol space); simpleType and complexType share ONE
+  type-definition symbol space (over013). Gated to Version11; 1.0 ignores xs:override entirely.
+  - An override child matching NOTHING in the referenced closure is DROPPED, not added (a dangling reference
+    to it is an error — over026; conformance-verified, NOT the literal §4.2.5 "add all children" reading —
+    registering unmatched children makes over026 the only failing case); a matched component is SUPPRESSED
+    during load and the override child registered in its place via the normal named-component parsers (a
+    matched notation override is a no-op — notations not modeled).
+  - TRANSITIVE: the referenced document's own xs:include/xs:override are re-applied under the SAME cascaded
+    override set, OUTER override winning on a name+symbol-space collision (double override over009); a nested
+    xs:include is treated as an xs:override carrying the active set (indirect chameleon over020), and a
+    chameleon no-targetNamespace target adopts the overriding schema's namespace like include (over018-020).
+    The active set is BRANCH-LOCAL: a nested xs:override builds a FRESH map (inherited ∪ its own children,
+    outer-precedence, `activeFromEntries`) so its children never leak into a later SIBLING target's
+    suppression set; `overrideLoadTarget` RETURNS the matched subset and each xs:override REGISTERS its
+    matched children IMMEDIATELY (`registerMatchedChildren`/`registerOverrideChild`) while the DECLARING
+    document's context (form/block/final defaults, xpathDefaultNamespace, base URI, includeFile) is active.
+  - EXCEPTION — schema-level `@defaultAttributes`: per §4.2.5 a replacement is COPIED INTO the transformed
+    TARGET document, so the TARGET document's `@defaultAttributes` governs its implicit default
+    attribute-group ref. `overrideLoadTarget` resolves the target root's `@defaultAttributes` (via
+    `resolveSchemaDefaultAttributes`, shared with `readSchemaDefaultAttributes`), applies it while parsing the
+    target (surviving target complex types governed too — save/reset/restore alongside form defaults) and
+    RETURNS the `schemaDefaultAttrsState`; the owner (`loadOverride`/`overrideProcessNested`) reapplies it
+    around `registerMatchedChildren` so the replacement records the target's implicit ref or none (an override
+    target lacking `@defaultAttributes` does not inherit the overriding schema's group — s3_4_2_4ii08). A
+    replacement matched in a NESTED INCLUDED document of the target is registered under THAT document's
+    per-document @defaultAttributes and default open content (`overrideMatchCtx` threads each matched key's
+    declaring-document defaults; `registerMatchedChildren` applies the per-key context).
+  - Termination/cycles: loads tracked in a SEPARATE `overrideVisited` set (distinct from plain-include
+    `includeVisited`) keyed by (path + active-set FINGERPRINT `overrideActiveFingerprint` — sorted
+    symbol/name/replacement-element identity), plus the overriding document's `rootKey`. A back-edge to the
+    root, or a re-reach under the SAME active set, terminates without re-loading (permissible circular
+    override over023); the SAME document under a DIFFERENT active set is a distinct transformed document and
+    IS loaded again (keying by path alone would over-terminate and drop a sibling's replacements — a real
+    collision then surfaces via the duplicate-component check). A disallowed cycle over024 surfaces as a
+    dangling-reference error.
+  - A document pulled in by BOTH plain xs:include/xs:redefine AND xs:override is a FATAL conflict
+    (`reportOverrideIncludeConflict`, in `overrideLoadTarget` and symmetrically in loadInclude/loadRedefine).
+    A document overridden twice within one schema document is rejected (over022, per-document target set in
+    processIncludes/overrideProcessNested); two override children targeting the same component is rejected
+    (over021). xs:import inside a referenced document is processed via the SHARED `processImport` (NOT
+    transformed — over025/over029), emitting the same already-imported / load-failure WARNINGS as a top-level
+    import; override children may reference components imported only by the overriding schema (over029).
+    Override+xs:redefine interplay is not exercised by the suite and processes redefine normally without
+    cascade — a documented gap.
+  - **Element/attribute default/fixed value validity against the declared type at compile time**
+    (version-INDEPENDENT, §3.3.6 Element Default Valid): `checkAttrUseConstraints` validates attribute uses
+    and `checkElementDeclConstraints` (`link_refs.go`, in `resolveRefs`) validates element declarations — an
+    EXPLICIT default/fixed is checked against the element's EFFECTIVE declared type (`effectiveDeclType`, so a
+    no-type substitution-group member is validated against its inherited head type; a default/fixed on an
+    element-only/empty complex-content type is a §3.3.6 clause-2.1 schema error, mixed content left to its own
+    path) through the shared `validateSimpleContentValue` (effective content simple type PLUS inherited
+    base-content facets via `validateNestedSimpleContentBases`) on the version-/schema-aware `validateValue`,
+    so an invalid list/union/builtin default (decimal `"XII"`, boolean `"Yes"`, float `"1.0F-2"`) — or one
+    violating an inherited simpleContent base facet — is a fatal schema error in both versions (W3C idIDREF
+    s3_3_4si07/si08). `elemDeclConstraintSources` is recorded unconditionally and merged from import
+    sub-compilers. The IDC-field `typeAcceptsValue` threads the live validation's `version`/`schema` into its
+    diagnostic-suppressing throwaway context (`vc.typeAcceptsValue`), so IDC union active-member selection and
+    1.1-only lexical forms (`+INF`, year `0000`, xs:dateTimeStamp) resolve under the schema's real version;
+    only the standalone `TypeDef.Validate` remains on the Version10/nil-schema default — a documented Phase-1
+    gap.

--- a/.claude/docs/xsd11-types.md
+++ b/.claude/docs/xsd11-types.md
@@ -1,42 +1,237 @@
 # XSD 1.1 — Type System
 
-> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
+> Convention: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the
+> 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the
+> governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
 
 - the 1.1-only lexical forms (`+INF` for xs:double/xs:float; year `0000` on the date types — both gated in `internal/xsd/value` via a `value.Version` argument; relaxng is pinned to `value.Version10`);
 - the 1.1 built-in datatypes (xs:dateTimeStamp, xs:dayTimeDuration, xs:yearMonthDuration, xs:anyAtomicType, xs:error);
 - **xs:assert on complex types** (`assert.go`): parsed from complexType/restriction/extension AND simpleContent extension/restriction; pre-compiled via xpath3; evaluated after content validation (EBV false → invalid); inherited down the base chain.
   - `$value`: the element's TYPED simple value for a simpleContent complex type (empty sequence for complex content); an EMPTY element's default/fixed effective value is substituted before typing → `$value` schema-normalized.
-  - Isolated tree: deep copy rooted in NO document, comment/PI stripped → `/`/`//` raises XPDY0050. In-scope namespaces re-declared (incl. an inherited default-namespace prefix "" so `namespace-uri-for-prefix('', .)` resolves); PSVI annotations onto DESCENDANT elements + ALL attributes but NOT the assertion ROOT (type unassigned during its assert → `data(.)` untyped; matches Saxon/conformance tests).
-  - `xpath3.SchemaDeclarations` adapter (`schema_decls.go`, `schemaDecls`, carries the schema version): a NAMED user simple type atomizes through its builtin base; a user `cast`/`castable` validates at the schema version (1.1-only lexical year `0000` castable).
-  - SINGLETON-OPERAND evaluators — `cast`/`castable` (`eval_types.go`), binary arithmetic + unary minus (`eval_arithmetic.go`), range `to` bounds (`eval_operators.go`) — atomize through the typed-value stream via `atomizeSingletonOperand` (caps at two atoms), cardinality on the ATOMIZED result not the raw count, so a list/union typed value expands like `data()`/`$value`; a multi-atom operand is XPTY0004. Fast-paths a single atomic item; function-call args coerce via `coerceToSequenceTypeE` (typed-value-aware atomization through `atomizeStreamCont`+`typedValueItemCheckFor`, cardinality applied after atomization); `instance of`/`treat as` do NOT atomize.
-  - `castable`/`cast` (`xpath3/eval_types.go`) namespace-aware for QName/NOTATION-derived user types: validates via `ValidateCastWithNS`, returns the namespace-RESOLVED value carrying the user type (only when context-free `CastAtomic` fails and SchemaDeclarations present). `(local, ns)` from the ALREADY-RESOLVED target type (`Q{ns}local` via `schemaAnnotationParts`) not the lexical prefix → an UNPREFIXED user type via `xpathDefaultNamespace` resolves. An ALREADY-RESOLVED QName cast SOURCE (prefix declared only on the INSTANCE node) is re-validated by `qnameCastLexical` using the value's OWN URI.
+  - Isolated tree: deep copy rooted in NO document, comment/PI stripped → `/`/`//` raises XPDY0050. In-scope
+    namespaces re-declared (incl. an inherited default-namespace prefix "" so `namespace-uri-for-prefix('',
+    .)` resolves); PSVI annotations onto DESCENDANT elements + ALL attributes but NOT the assertion ROOT (type
+    unassigned during its assert → `data(.)` untyped; matches Saxon/conformance tests).
+  - `xpath3.SchemaDeclarations` adapter (`schema_decls.go`, `schemaDecls`, carries the schema version): a
+    NAMED user simple type atomizes through its builtin base; a user `cast`/`castable` validates at the schema
+    version (1.1-only lexical year `0000` castable).
+  - SINGLETON-OPERAND evaluators — `cast`/`castable` (`eval_types.go`), binary arithmetic + unary minus
+    (`eval_arithmetic.go`), range `to` bounds (`eval_operators.go`) — atomize through the typed-value stream
+    via `atomizeSingletonOperand` (caps at two atoms), cardinality on the ATOMIZED result not the raw count,
+    so a list/union typed value expands like `data()`/`$value`; a multi-atom operand is XPTY0004. Fast-paths a
+    single atomic item; function-call args coerce via `coerceToSequenceTypeE` (typed-value-aware atomization
+    through `atomizeStreamCont`+`typedValueItemCheckFor`, cardinality applied after atomization); `instance
+    of`/`treat as` do NOT atomize.
+  - `castable`/`cast` (`xpath3/eval_types.go`) namespace-aware for QName/NOTATION-derived user types:
+    validates via `ValidateCastWithNS`, returns the namespace-RESOLVED value carrying the user type (only when
+    context-free `CastAtomic` fails and SchemaDeclarations present). `(local, ns)` from the ALREADY-RESOLVED
+    target type (`Q{ns}local` via `schemaAnnotationParts`) not the lexical prefix → an UNPREFIXED user type
+    via `xpathDefaultNamespace` resolves. An ALREADY-RESOLVED QName cast SOURCE (prefix declared only on the
+    INSTANCE node) is re-validated by `qnameCastLexical` using the value's OWN URI.
   - QName/NOTATION atomization (`resolveQNameFromNode`) predeclares `xml` → the XML namespace with no node binding (matching `xsd.resolveLexicalQName`) → `xml:lang`/`xml:space` atomizes.
-  - A list-typed node splits on XSD whitespace ONLY (space/tab/CR/LF via `xsdListFields`; NBSP/other Unicode whitespace NOT separators), each token via `atomizeListTokenAt`. A UNION item type → each token through its value-resolved ACTIVE member (`nodeItemFor` → per-token leaf in `NodeItem.ListItemLeaves` via `resolveActiveUnionLeafForValue`); else `atomizeListToken` on the declared item type — an `xs:QName`/`xs:NOTATION` item type (or user type whose builtin base is one, in `ListItemAtomized`) resolves each token against in-scope namespaces; a NON-QName USER item type (a `Q{...}` name `CastFromString` can't resolve) casts through its `ListItemAtomized` builtin base typed as the user type. So `xs:list itemType="xs:QName"` atomizes and an `xs:int`-derived item type yields numeric atoms for `sum()`.
-  - INLINE ANONYMOUS list/union types are recorded under STABLE SYNTHETIC annotation names (`vc.assertAnnotationName`/`assertRegisterAnon`/`assertAnonTypes`/`assertAnonNames`, ns `urn:x-helium:assert-anon`); `schemaDecls` resolves list-item/union-member metadata from the registered `*TypeDef`. RECURSIVE for ANY variety incl. an inline anonymous ATOMIC (faceted) member, named enclosing or not, so `ValidateCastWithNS` validates the ACTUAL faceted member not a collapsed builtin ancestor. A standalone anonymous ATOMIC node type keeps `xsdTypeName`.
-  - `schemaDecls.IsSubtypeOf` resolves a synthetic anonymous annotation via the registry (`lookupTypeName`, walking bases via `d.typeName`) and treats EVERY simple type as a subtype of `xs:anySimpleType` (even with a nil list/union `BaseType`), so `instance of attribute(v, xs:anySimpleType)` holds.
-  - A UNION node's ACTIVE member is resolved VALUE-DEPENDENTLY: `nodeItemFor` precomputes `NodeItem.ActiveUnionMember` (`*NodeItemUnionMember`, nil when not a union) via `resolveActiveUnionLeaf` — the FIRST declaration-order member the value FULLY validates against: the lexical/value cast (a list member: every token + list structure; an EMPTY zero-token list accepted lexically — `unionMemberCastOK` does NOT reject — leaving a minLength facet to `ValidateCastWithNS`, so an empty list value resolves to the EMPTY list not a later member) AND the member's facets/assertions via `SchemaDeclarations.ValidateCastWithNS`. A union member DESCENDS recursively (mirroring `fixedUnionActiveMember`), terminating via a VISITED-SET cycle guard keyed by union type name (NOT a depth cap). Facet-aware selection matches `$value` (an xs:list member failing a length facet falls through to a later member).
-  - `atomizeUnionItems` (stream + comparison atom paths) atomizes through that leaf: a LIST leaf → per-item atoms; an ATOMIC leaf → one atom TYPED AS THE MEMBER. Eval ctx threads through `nodeItemFor` (not `context.Background()`). Active only with union/list metadata.
-  - The assert evaluator sets `Evaluator.QNameValueNoDefaultNamespace()`: an UNPREFIXED xs:QName/xs:NOTATION VALUE atomizes to NO namespace (XSD value-space; a prefixed value still resolves); under it `castToQName` also skips the default-namespace fallback for an unprefixed cast target. Default xpath3 (flag off) unchanged.
+  - A list-typed node splits on XSD whitespace ONLY (space/tab/CR/LF via `xsdListFields`; NBSP/other Unicode
+    whitespace NOT separators), each token via `atomizeListTokenAt`. A UNION item type → each token through
+    its value-resolved ACTIVE member (`nodeItemFor` → per-token leaf in `NodeItem.ListItemLeaves` via
+    `resolveActiveUnionLeafForValue`); else `atomizeListToken` on the declared item type — an
+    `xs:QName`/`xs:NOTATION` item type (or user type whose builtin base is one, in `ListItemAtomized`)
+    resolves each token against in-scope namespaces; a NON-QName USER item type (a `Q{...}` name
+    `CastFromString` can't resolve) casts through its `ListItemAtomized` builtin base typed as the user type.
+    So `xs:list itemType="xs:QName"` atomizes and an `xs:int`-derived item type yields numeric atoms for
+    `sum()`.
+  - INLINE ANONYMOUS list/union types are recorded under STABLE SYNTHETIC annotation names
+    (`vc.assertAnnotationName`/`assertRegisterAnon`/`assertAnonTypes`/`assertAnonNames`, ns
+    `urn:x-helium:assert-anon`); `schemaDecls` resolves list-item/union-member metadata from the registered
+    `*TypeDef`. RECURSIVE for ANY variety incl. an inline anonymous ATOMIC (faceted) member, named enclosing
+    or not, so `ValidateCastWithNS` validates the ACTUAL faceted member not a collapsed builtin ancestor. A
+    standalone anonymous ATOMIC node type keeps `xsdTypeName`.
+  - `schemaDecls.IsSubtypeOf` resolves a synthetic anonymous annotation via the registry (`lookupTypeName`,
+    walking bases via `d.typeName`) and treats EVERY simple type as a subtype of `xs:anySimpleType` (even with
+    a nil list/union `BaseType`), so `instance of attribute(v, xs:anySimpleType)` holds.
+  - A UNION node's ACTIVE member is resolved VALUE-DEPENDENTLY: `nodeItemFor` precomputes
+    `NodeItem.ActiveUnionMember` (`*NodeItemUnionMember`, nil when not a union) via `resolveActiveUnionLeaf` —
+    the FIRST declaration-order member the value FULLY validates against: the lexical/value cast (a list
+    member: every token + list structure; an EMPTY zero-token list accepted lexically — `unionMemberCastOK`
+    does NOT reject — leaving a minLength facet to `ValidateCastWithNS`, so an empty list value resolves to
+    the EMPTY list not a later member) AND the member's facets/assertions via
+    `SchemaDeclarations.ValidateCastWithNS`. A union member DESCENDS recursively (mirroring
+    `fixedUnionActiveMember`), terminating via a VISITED-SET cycle guard keyed by union type name (NOT a depth
+    cap). Facet-aware selection matches `$value` (an xs:list member failing a length facet falls through to a
+    later member).
+  - `atomizeUnionItems` (stream + comparison atom paths) atomizes through that leaf: a LIST leaf → per-item
+    atoms; an ATOMIC leaf → one atom TYPED AS THE MEMBER. Eval ctx threads through `nodeItemFor` (not
+    `context.Background()`). Active only with union/list metadata.
+  - The assert evaluator sets `Evaluator.QNameValueNoDefaultNamespace()`: an UNPREFIXED xs:QName/xs:NOTATION
+    VALUE atomizes to NO namespace (XSD value-space; a prefixed value still resolves); under it `castToQName`
+    also skips the default-namespace fallback for an unprefixed cast target. Default xpath3 (flag off)
+    unchanged.
   - A self-referential cast (`cast`/`castable as t:T` inside t:T's OWN assertion) is guarded by a per-validation `(type, value)` cast stack in the context (`castGuardKey` in `schema_decls.go`): a repeat fails closed.
-  - An EMPTY DEFAULTED/FIXED DESCENDANT element's schema value is materialized: `validateSimpleContent` records each empty element's effective default/fixed value (plus the DECLARATION namespace context for a QName/NOTATION prefix) in `vc.assertEffectiveValues`; `isolatedAssertTree`/`mapAssertAnnotations` MATERIALIZE it onto the copy (`materializeAssertDefault`/`materializeAssertText` append as text; a QName/NOTATION default declares its prefix from the declaration context, mirroring `materializeQNameAttrValue` collision handling — a prefix bound to a DIFFERENT URI mints a fresh one and rewrites the text), so a defaulted element atomizes its default. The asserted ROOT is excluded (`$value` substitutes it; `data(.)` untyped); defaulted ATTRIBUTES need no handling (`SetAttributeNS` inserts them).
-  - A QName/NOTATION fixed/default in an EMPTY element resolves its prefix against the DECLARATION's namespace context (`ElementDecl.FixedNS`/`DefaultNS` via `effectiveValueNS`) not the instance's, for validation and `$value`; a materialized QName/NOTATION DEFAULT attribute declares its prefix on the element (`materializeQNameAttrValue` whitespace-COLLAPSES before extracting the prefix, resolves a UNION type's ACTIVE member via `fixedUnionActiveMember`, minting a fresh prefix on conflict), so a later xs:assert/IDC atomizes it in schema value space — gated to 1.1; XSD 1.0 inserts the default as authored, no namespace-declaration rewrite (byte-identical serialization).
-- the **xs:assertion simple-type facet** (`assertion_facet.go`): parsed by `parseFacets`, stored on `FacetSet.Assertions`, evaluated at simple-value validation with `$value` bound to the TYPED atomic value — a sequence for a list (each item typed by its active member), a union resolved to its active member FIRST in `buildValueSequence` (a union active on a LIST member yields the list-item sequence, not one untypedAtomic).
-  - SCHEMA-AWARE: `typedAtomic`/`buildValueSequence` thread `vc.schema` into `fixedUnionActiveMember` so a member whose assertion needs `castable as t:T` is selectable; `fixedValueMatches`/`fixedUnionMatches`/`crossMemberValueEqual` also thread `vc.schema` (`c.schema` at compile time) so fixed/enumeration comparisons resolve the active member in the right value space.
-  - A QName/NOTATION lexical resolves against in-scope namespaces into an `xpath3.QNameValue` (built by `buildValueSequence`/`typedAtomic`/`atomicForType`) PRESERVING a NAMED user type's identity (user type name as `TypeName`, builtin cast type as `BaseType`, mirroring `AtomizeItem`/`data()`) across the atomic, QName/NOTATION, list-item, and union-leaf paths, so `$value instance of t:MyInt` holds.
+  - An EMPTY DEFAULTED/FIXED DESCENDANT element's schema value is materialized: `validateSimpleContent`
+    records each empty element's effective default/fixed value (plus the DECLARATION namespace context for a
+    QName/NOTATION prefix) in `vc.assertEffectiveValues`; `isolatedAssertTree`/`mapAssertAnnotations`
+    MATERIALIZE it onto the copy (`materializeAssertDefault`/`materializeAssertText` append as text; a
+    QName/NOTATION default declares its prefix from the declaration context, mirroring
+    `materializeQNameAttrValue` collision handling — a prefix bound to a DIFFERENT URI mints a fresh one and
+    rewrites the text), so a defaulted element atomizes its default. The asserted ROOT is excluded (`$value`
+    substitutes it; `data(.)` untyped); defaulted ATTRIBUTES need no handling (`SetAttributeNS` inserts them).
+  - A QName/NOTATION fixed/default in an EMPTY element resolves its prefix against the DECLARATION's namespace
+    context (`ElementDecl.FixedNS`/`DefaultNS` via `effectiveValueNS`) not the instance's, for validation and
+    `$value`; a materialized QName/NOTATION DEFAULT attribute declares its prefix on the element
+    (`materializeQNameAttrValue` whitespace-COLLAPSES before extracting the prefix, resolves a UNION type's
+    ACTIVE member via `fixedUnionActiveMember`, minting a fresh prefix on conflict), so a later xs:assert/IDC
+    atomizes it in schema value space — gated to 1.1; XSD 1.0 inserts the default as authored, no
+    namespace-declaration rewrite (byte-identical serialization).
+- the **xs:assertion simple-type facet** (`assertion_facet.go`): parsed by `parseFacets`, stored on
+  `FacetSet.Assertions`, evaluated at simple-value validation with `$value` bound to the TYPED atomic value —
+  a sequence for a list (each item typed by its active member), a union resolved to its active member FIRST in
+  `buildValueSequence` (a union active on a LIST member yields the list-item sequence, not one untypedAtomic).
+  - SCHEMA-AWARE: `typedAtomic`/`buildValueSequence` thread `vc.schema` into `fixedUnionActiveMember` so a
+    member whose assertion needs `castable as t:T` is selectable;
+    `fixedValueMatches`/`fixedUnionMatches`/`crossMemberValueEqual` also thread `vc.schema` (`c.schema` at
+    compile time) so fixed/enumeration comparisons resolve the active member in the right value space.
+  - A QName/NOTATION lexical resolves against in-scope namespaces into an `xpath3.QNameValue` (built by
+    `buildValueSequence`/`typedAtomic`/`atomicForType`) PRESERVING a NAMED user type's identity (user type
+    name as `TypeName`, builtin cast type as `BaseType`, mirroring `AtomizeItem`/`data()`) across the atomic,
+    QName/NOTATION, list-item, and union-leaf paths, so `$value instance of t:MyInt` holds.
   - The context item is ABSENT, so `.`/`position()`/`last()` raise a dynamic error → unsatisfied; assertions ANDed along the restriction chain; same SchemaDeclarations adapter.
-  - `validateValue` evaluates these facets, so the COMPILE-TIME throwaway contexts reaching it — the attribute default/fixed check (`checkAttrUseConstraints`, `link_refs.go`) and the facet value-against-base / enumeration / union-member checks (`check_facets.go`) — are built with `schema: c.schema` so a schema-aware cast doesn't fail closed and reject a VALID schema.
-  - The IDC-field `typeAcceptsValue` threads the live validation's `version`/`schema` into its diagnostic-suppressing throwaway context (`vc.typeAcceptsValue`) so IDC union active-member selection and 1.1-only lexical forms (`+INF`, year `0000`, xs:dateTimeStamp) resolve at the schema's real version; only the standalone `TypeDef.Validate` remains on the Version10/nil-schema default — a documented Phase-1 gap.
-  - `xpathDefaultNamespace` on xs:assert/xs:assertion and the root `<xs:schema>`: `resolveXPathDefaultNS` whitespace-COLLAPSES the raw value (element-local OR schema-level) before the empty check and the sentinel switch, so `" ##targetNamespace "` resolves like the sentinel; `##targetNamespace`/`##defaultNamespace`/`##local` resolved, chameleon-include aware; an IMPORTED schema's root value is carried into the import sub-compiler (`compile_imports.go` sets `impC.schemaXPathDefaultNS`) so imported assertions resolve their own default namespace.
-- XSD 1.1 **attribute inheritance** (`finalizeEffectiveAttrs`): a complex type inherits every base attribute use it does not redeclare, for ALL 1.1 derived types — `checkRestrictionAttrs` does not flag a non-redeclared required base attribute as "missing" in 1.1, so the merge enforces the inherited requirement. TOPOLOGICAL across BOTH extension AND restriction derivations: the base is finalized first (memoized, cycle-guarded recursion), then `checkRestrictionAttrs`/`checkExtensionAttrDuplicates` runs against td's OWN declarations and the finalized base, then td inherits — so an extension of a restriction (or vice versa, any depth) reads a complete base attribute set regardless of source order. In 1.1 the extension/restriction passes DEFER all attribute work to `finalizeEffectiveAttrs`. XSD 1.0 also finalizes effective attribute USES topologically across BOTH extension and restriction (`finalizeAttrUses10`, §3.4.2.2), after the extension loop's in-loop attribute snapshot and `checkRestrictionAttrs` (which still runs against each restriction base's OWN declarations, is NOT repeated in the pass, and keeps the historical 1.0 rule that a required base attribute must be explicitly redeclared). The pass folds non-redeclared base uses into restriction types and re-folds any uses a restriction base gained onto extensions that copied a stale snapshot, so an extension of a restriction inherits undeclared grandbase attributes. It also RE-RUNS the ct-props-correct.4 extension check (`checkExtensionAttrDuplicates`) against the FINALIZED base, so an extension that redeclares an attribute its base merely INHERITS is rejected in 1.0 as it is in 1.1 (xmllint rejects both the complexContent and the simpleContent shape). The check compares the extension's OWN uses — `extOwnAttrUses`, snapshotted in the extension loop before the base's uses are folded in — because td.Attributes already carries the base's uses by then, and `extAttrDupReported` keeps a collision the in-loop check already reported from being emitted twice. The in-loop snapshot builds a FRESH slice (`concatAttrUses`): `append(base.Attributes, own...)` would park the derived type's own uses in the base slice's spare capacity, where a sibling derivation's snapshot or this pass's inheriting append then overwrites them. A 1.0 restriction deliberately does NOT inherit the base {attribute wildcard} (complete wildcard from own content only — sunData combined/008).
-- **simpleContent content-type narrowing** (`TypeDef.ContentSimpleType`): derived from a nested `<xs:simpleType>` AND/OR the restriction's direct facets — `parseSimpleContentRestrictionType` COMPOSES them (a restriction of the inline type carrying the sibling facets when both are present, dropping neither). `TypeDef.ContentSimpleType` is built in BOTH versions (`read_types.go`) and each synthetic restriction is RECORDED in `typeDefSources`, so `checkFacetConsistency` runs applicability/value checks in 1.0 as well as 1.1 — an inapplicable direct facet is a compile error in both (e.g. `minLength` on a simpleContent restriction of `xs:anySimpleType` content, whose length facets are inapplicable to the ur-type).
-  - **cos-st-restricts (Derivation Valid, Restriction, Simple)** — version-INDEPENDENT, `checkSimpleContentRestrictionDerivation` (`link_refs.go`, run from `resolveRefs` after `checkSimpleContentBase`): a simpleContent RESTRICTION whose base is a simpleContent complex type must have its derived effective content simple type (`effectiveContentSimpleType(td)`) validly RESTRICT the base's effective content simple type (`effectiveContentSimpleType(base)`). The predicate `simpleContentContentValidlyRestricts` is CONSERVATIVE (accepts by default, rejects only provable widenings of a concrete ATOMIC base): a LIST/UNION derived variety over an atomic base (its primitive base is `xs:anySimpleType`, which does not descend from e.g. `xs:decimal` — W3C particlesZ018), or an atomic derived type whose builtin primitive does not `builtinDerivesFrom` the base's (an `xs:string` base narrowed to an `xs:date` type, or `xs:int` widened back to `xs:integer`). EXEMPTION: when the base's effective content simple type is the simple ur-type `xs:anySimpleType`/`xs:anyType`, ANY derived simple type is valid (§3.16.3 clause 2.2.3) and the check is skipped — so a list restricting an `xs:anySimpleType`-content base is accepted. The conservative default preserves the lenient nested-`<xs:simpleType>` narrowing model (a nested type authored on a shared builtin ancestor of the base content still composes the inherited base facets). Enforced in both 1.0 and 1.1.
-  - The EFFECTIVE content simple type is composed across the WHOLE derivation chain by `effectiveContentSimpleType`, recursing through simpleContent complex types (marked `TypeDef.IsSimpleContent`) to the underlying simpleType/builtin, re-basing a facet-only narrowing on the effective base content type so ancestor and derived facets compose. In XSD 1.1 `validateSimpleContent` validates the instance text against it whenever any chain step has facets/assertions or a non-string builtin (`simpleContentNeedsValidation`), so a restriction enumeration / `xs:float` narrowing is enforced and inherited through further restriction/extension; `$value` uses the same composed type. In XSD 1.0 `validateSimpleContent` validates the text against the declared type `td` (not the narrowed `ContentSimpleType`) but its gate is also `simpleContentNeedsValidation(td)` — which reports a facet ANYWHERE along td's base chain — so a simpleContent EXTENSION of a named faceted simple type enforces that base's facets (minLength/maxLength/etc.) in 1.0 too. (A direct facet on a simpleContent RESTRICTION lives on `ContentSimpleType`, not `td`, so it is compile-checked but not yet instance-enforced in 1.0.)
-  - The assert adapter `schemaDecls` resolves a simpleContent COMPLEX type through `effectiveContentSimpleType` (via `lookupAtomizationType`) in `LookupSchemaType`/`ListItemType`/`UnionMemberTypes`, so `data(c)` on a DESCENDANT element narrowed to `xs:QName`/a list/a union atomizes through the NARROWED content type; `IsSubtypeOf`/`validateCast` keep the raw type (still COMPLEX for node/subtype tests). `UnionMemberTypes` resolves variety and members via `resolveVariety`/`resolveUnionMembers` (walking the base chain) not direct fields, so a synthetic facet-only restriction over a union base still reports union members and resolves the active list member.
-  - A NESTED `<xs:simpleType>` content type is returned as-is (its OWN base chain), so `validateSimpleContent` also validates against `effectiveContentSimpleType(td.BaseType)` whenever `td.ContentSimpleType.BaseType != td` — a nested simpleType RESTRICTS, not REPLACES, the base content type (§3.4.2.2), so an inherited base `maxLength` still rejects an over-long value.
-  - FIXED-value comparison narrows a simpleContent type to its content simple type CENTRALLY inside `fixedValueMatches` (gated `version == Version11`: `td = effectiveContentSimpleType(td)`), consistent for EVERY caller — the runtime non-empty-element fixed check, the attribute fixed checks, and the COMPILE-TIME content-model restriction check (`restriction_particle.go` NameAndTypeOK, base/derived element `fixed` must be value-space equal). A content type restricted to `xs:QName` accepts a different-prefix/same-URI value by QName value-space equality (a non-simpleContent type passes through unchanged; XSD 1.0 keeps the declared-type comparison, byte-identical). The fixed-value narrowing to the content simple type is still 1.1-only; XSD 1.0's fixed comparison uses the declared type's value space (its whiteSpace facet), where `xs:anySimpleType` resolves to whiteSpace="preserve" (`resolveWhiteSpace`), so surrounding whitespace stays significant and a padded value does not match a fixed on an `xs:anySimpleType` element.
-- **conditional type assignment** (`alternative.go`): `<xs:alternative>` on an element declaration selects the governing type via the first @test that holds, else a testless default, else the declared type; xsi:type still takes precedence. Applied at the root AND every per-child match site INCLUDING wildcard-matched lax elements (`validateWildcardChild`) and xs:anyType/lax descendants — CTA selects the governing type FIRST, then the cvc-elt.4.3 derivation-block check and the idc lax-assessment/ID-pass run against the SELECTED type.
-  - Each `<xs:alternative>` may carry an INLINE anonymous `<xs:complexType>`/`<xs:simpleType>` (`parseTypeAlternative`; a present-but-empty `@type` is a governing-type source, so `@type=""` plus an inline type is a conflict and a bare `@type=""` is an invalid QName), `type="xs:error"` (a selected xs:error invalidates the element even through the xsi:nil nilled path), and `@xpathDefaultNamespace` (`effectiveXPathDefaultNS`: locally-present value resolved against the alternative, else inherited from schema-level; affects only unprefixed element name tests).
-  - @test runs against a DETACHED CTA context node (`inherited_attrs.go` `ctaContextNode`): an orphan element with the instance element's own attributes PLUS inheritable attributes from ancestors (`inheritedAttributes`, declaration `inheritable="true"`), its in-scope namespaces, position()=last()=1, an empty `emptyCollectionResolver`, the schema base URI, no children/parent.
-  - A non-default `@type`/inline alternative must be VALIDLY SUBSTITUTABLE for the declared type (`checkAltSubstitutability`, compile time): `strictBuiltinAwareDerivedFrom` (`builtin_hierarchy.go`) accepts a genuine derivation via `isDerivedFrom`, the built-in simple-type hierarchy via `builtinSimpleBase` (1.0 built-ins not BaseType-linked), or the anySimpleType simple-content rule; a union declared type admits any base-chain-resolved member (`resolveVariety`/`resolveUnionMembers`); NO permissive simple-vs-simple fallback. The block check is built-in-aware (`isDerivationBlocked`). Per-document `xpathDefaultNamespace`/base-URI and the `altTypeRefs`/`ctaElems` worklists are saved/restored across include/redefine and seeded onto import sub-compilers (`compile_imports.go`).
-- **union-member element-type restriction** (version-INDEPENDENT, cos-st-derived-ok clause 2.2.4): a complexContent restriction's child element type may be validly derived from a UNION base element type's (transitive) member — `elementTypeValidlyRestricts` (`restriction_particle.go`) falls back to `isXsiTypeDerivedFromDeclared` (`alternative.go`) UNGATED, so narrowing a base element typed `union(xs:decimal, xs:string)` to the member `xs:string` compiles in both 1.0 and 1.1 (W3C addB150 / test93568.xsd, expected-valid with no version qualifier; libxml2 accepts it in 1.0). The member check is strict and recursive (a non-member type deriving from nothing in the union is still rejected).
-- **Simple-type 1.1 edges**: `finalDefault="extension"` reaches a simple type's `{final}` (the simpleType final-default mask in `read_types.go` adds `FinalExtension`, spec bug 2074), so a simpleContent extension of an extension-final simple type is rejected; `checkAnyAtomicTypeUsage` rejects `xs:anyAtomicType` as a user simple type's restriction base / list item type / union member type (W3C bug 11103 — valid as an element/attribute/xsi:type type); `checkAnySimpleTypeUsage` rejects RESTRICTING the simple ur-type `xs:anySimpleType` — as a simpleType restriction base / list item type / union member type, and as a simpleContent complexType RESTRICTION whose effective content simple type (`effectiveContentSimpleType`) is left as `xs:anySimpleType` — per Part 2 §2.4.1 / W3C bug 14559 (valid as an element/attribute/xsi:type type and as the base of a simpleContent EXTENSION). Two arms are **version-INDEPENDENT** (cos-st-restricts requires a restriction base to be atomic/list/union, and libxml2 rejects them in XSD 1.0 too): a simpleType `<xs:restriction>` whose DIRECT base is `xs:anySimpleType`, and a simpleContent `<xs:restriction>` whose DIRECT base is `xs:anySimpleType` AND whose effective content is left as the ur-type (no nested-simpleType/facet narrowing) — W3C stZ005/stZ006/stZ009/stZ011, addB110, invalid in both. The remaining arms stay **Version11-gated** (valid in XSD 1.0): a list item type / union member type of `xs:anySimpleType`, and a simpleContent restriction of a COMPLEX base whose content merely resolves to the ur-type (W3C stZ007/stZ047/stZ055, valid in 1.0, invalid in 1.1). `checkAnySimpleTypeUsage` is called unconditionally (`compile.go`); its item/member/complex-base arms self-gate on `c.version == Version11`, so the 1.0 path is byte-identical apart from the two newly-enforced direct-restriction cases.
+  - `validateValue` evaluates these facets, so the COMPILE-TIME throwaway contexts reaching it — the attribute
+    default/fixed check (`checkAttrUseConstraints`, `link_refs.go`) and the facet value-against-base /
+    enumeration / union-member checks (`check_facets.go`) — are built with `schema: c.schema` so a
+    schema-aware cast doesn't fail closed and reject a VALID schema.
+  - The IDC-field `typeAcceptsValue` threads the live validation's `version`/`schema` into its
+    diagnostic-suppressing throwaway context (`vc.typeAcceptsValue`) so IDC union active-member selection and
+    1.1-only lexical forms (`+INF`, year `0000`, xs:dateTimeStamp) resolve at the schema's real version; only
+    the standalone `TypeDef.Validate` remains on the Version10/nil-schema default — a documented Phase-1 gap.
+  - `xpathDefaultNamespace` on xs:assert/xs:assertion and the root `<xs:schema>`: `resolveXPathDefaultNS`
+    whitespace-COLLAPSES the raw value (element-local OR schema-level) before the empty check and the sentinel
+    switch, so `" ##targetNamespace "` resolves like the sentinel;
+    `##targetNamespace`/`##defaultNamespace`/`##local` resolved, chameleon-include aware; an IMPORTED schema's
+    root value is carried into the import sub-compiler (`compile_imports.go` sets `impC.schemaXPathDefaultNS`)
+    so imported assertions resolve their own default namespace.
+- XSD 1.1 **attribute inheritance** (`finalizeEffectiveAttrs`): a complex type inherits every base attribute
+  use it does not redeclare, for ALL 1.1 derived types — `checkRestrictionAttrs` does not flag a
+  non-redeclared required base attribute as "missing" in 1.1, so the merge enforces the inherited requirement.
+  TOPOLOGICAL across BOTH extension AND restriction derivations: the base is finalized first (memoized,
+  cycle-guarded recursion), then `checkRestrictionAttrs`/`checkExtensionAttrDuplicates` runs against td's OWN
+  declarations and the finalized base, then td inherits — so an extension of a restriction (or vice versa, any
+  depth) reads a complete base attribute set regardless of source order. In 1.1 the extension/restriction
+  passes DEFER all attribute work to `finalizeEffectiveAttrs`. XSD 1.0 also finalizes effective attribute USES
+  topologically across BOTH extension and restriction (`finalizeAttrUses10`, §3.4.2.2), after the extension
+  loop's in-loop attribute snapshot and `checkRestrictionAttrs` (which still runs against each restriction
+  base's OWN declarations, is NOT repeated in the pass, and keeps the historical 1.0 rule that a required base
+  attribute must be explicitly redeclared). The pass folds non-redeclared base uses into restriction types and
+  re-folds any uses a restriction base gained onto extensions that copied a stale snapshot, so an extension of
+  a restriction inherits undeclared grandbase attributes. It also RE-RUNS the ct-props-correct.4 extension
+  check (`checkExtensionAttrDuplicates`) against the FINALIZED base, so an extension that redeclares an
+  attribute its base merely INHERITS is rejected in 1.0 as it is in 1.1 (xmllint rejects both the
+  complexContent and the simpleContent shape). The check compares the extension's OWN uses — `extOwnAttrUses`,
+  snapshotted in the extension loop before the base's uses are folded in — because td.Attributes already
+  carries the base's uses by then, and `extAttrDupReported` keeps a collision the in-loop check already
+  reported from being emitted twice. The in-loop snapshot builds a FRESH slice (`concatAttrUses`):
+  `append(base.Attributes, own...)` would park the derived type's own uses in the base slice's spare capacity,
+  where a sibling derivation's snapshot or this pass's inheriting append then overwrites them. A 1.0
+  restriction deliberately does NOT inherit the base {attribute wildcard} (complete wildcard from own content
+  only — sunData combined/008).
+- **simpleContent content-type narrowing** (`TypeDef.ContentSimpleType`): derived from a nested
+  `<xs:simpleType>` AND/OR the restriction's direct facets — `parseSimpleContentRestrictionType` COMPOSES them
+  (a restriction of the inline type carrying the sibling facets when both are present, dropping neither).
+  `TypeDef.ContentSimpleType` is built in BOTH versions (`read_types.go`) and each synthetic restriction is
+  RECORDED in `typeDefSources`, so `checkFacetConsistency` runs applicability/value checks in 1.0 as well as
+  1.1 — an inapplicable direct facet is a compile error in both (e.g. `minLength` on a simpleContent
+  restriction of `xs:anySimpleType` content, whose length facets are inapplicable to the ur-type).
+  - **cos-st-restricts (Derivation Valid, Restriction, Simple)** — version-INDEPENDENT,
+    `checkSimpleContentRestrictionDerivation` (`link_refs.go`, run from `resolveRefs` after
+    `checkSimpleContentBase`): a simpleContent RESTRICTION whose base is a simpleContent complex type must
+    have its derived effective content simple type (`effectiveContentSimpleType(td)`) validly RESTRICT the
+    base's effective content simple type (`effectiveContentSimpleType(base)`). The predicate
+    `simpleContentContentValidlyRestricts` is CONSERVATIVE (accepts by default, rejects only provable
+    widenings of a concrete ATOMIC base): a LIST/UNION derived variety over an atomic base (its primitive base
+    is `xs:anySimpleType`, which does not descend from e.g. `xs:decimal` — W3C particlesZ018), or an atomic
+    derived type whose builtin primitive does not `builtinDerivesFrom` the base's (an `xs:string` base
+    narrowed to an `xs:date` type, or `xs:int` widened back to `xs:integer`). EXEMPTION: when the base's
+    effective content simple type is the simple ur-type `xs:anySimpleType`/`xs:anyType`, ANY derived simple
+    type is valid (§3.16.3 clause 2.2.3) and the check is skipped — so a list restricting an
+    `xs:anySimpleType`-content base is accepted. The conservative default preserves the lenient
+    nested-`<xs:simpleType>` narrowing model (a nested type authored on a shared builtin ancestor of the base
+    content still composes the inherited base facets). Enforced in both 1.0 and 1.1.
+  - The EFFECTIVE content simple type is composed across the WHOLE derivation chain by
+    `effectiveContentSimpleType`, recursing through simpleContent complex types (marked
+    `TypeDef.IsSimpleContent`) to the underlying simpleType/builtin, re-basing a facet-only narrowing on the
+    effective base content type so ancestor and derived facets compose. In XSD 1.1 `validateSimpleContent`
+    validates the instance text against it whenever any chain step has facets/assertions or a non-string
+    builtin (`simpleContentNeedsValidation`), so a restriction enumeration / `xs:float` narrowing is enforced
+    and inherited through further restriction/extension; `$value` uses the same composed type. In XSD 1.0
+    `validateSimpleContent` validates the text against the declared type `td` (not the narrowed
+    `ContentSimpleType`) but its gate is also `simpleContentNeedsValidation(td)` — which reports a facet
+    ANYWHERE along td's base chain — so a simpleContent EXTENSION of a named faceted simple type enforces that
+    base's facets (minLength/maxLength/etc.) in 1.0 too. (A direct facet on a simpleContent RESTRICTION lives
+    on `ContentSimpleType`, not `td`, so it is compile-checked but not yet instance-enforced in 1.0.)
+  - The assert adapter `schemaDecls` resolves a simpleContent COMPLEX type through
+    `effectiveContentSimpleType` (via `lookupAtomizationType`) in
+    `LookupSchemaType`/`ListItemType`/`UnionMemberTypes`, so `data(c)` on a DESCENDANT element narrowed to
+    `xs:QName`/a list/a union atomizes through the NARROWED content type; `IsSubtypeOf`/`validateCast` keep
+    the raw type (still COMPLEX for node/subtype tests). `UnionMemberTypes` resolves variety and members via
+    `resolveVariety`/`resolveUnionMembers` (walking the base chain) not direct fields, so a synthetic
+    facet-only restriction over a union base still reports union members and resolves the active list member.
+  - A NESTED `<xs:simpleType>` content type is returned as-is (its OWN base chain), so `validateSimpleContent`
+    also validates against `effectiveContentSimpleType(td.BaseType)` whenever `td.ContentSimpleType.BaseType
+    != td` — a nested simpleType RESTRICTS, not REPLACES, the base content type (§3.4.2.2), so an inherited
+    base `maxLength` still rejects an over-long value.
+  - FIXED-value comparison narrows a simpleContent type to its content simple type CENTRALLY inside
+    `fixedValueMatches` (gated `version == Version11`: `td = effectiveContentSimpleType(td)`), consistent for
+    EVERY caller — the runtime non-empty-element fixed check, the attribute fixed checks, and the COMPILE-TIME
+    content-model restriction check (`restriction_particle.go` NameAndTypeOK, base/derived element `fixed`
+    must be value-space equal). A content type restricted to `xs:QName` accepts a different-prefix/same-URI
+    value by QName value-space equality (a non-simpleContent type passes through unchanged; XSD 1.0 keeps the
+    declared-type comparison, byte-identical). The fixed-value narrowing to the content simple type is still
+    1.1-only; XSD 1.0's fixed comparison uses the declared type's value space (its whiteSpace facet), where
+    `xs:anySimpleType` resolves to whiteSpace="preserve" (`resolveWhiteSpace`), so surrounding whitespace
+    stays significant and a padded value does not match a fixed on an `xs:anySimpleType` element.
+- **conditional type assignment** (`alternative.go`): `<xs:alternative>` on an element declaration selects the
+  governing type via the first @test that holds, else a testless default, else the declared type; xsi:type
+  still takes precedence. Applied at the root AND every per-child match site INCLUDING wildcard-matched lax
+  elements (`validateWildcardChild`) and xs:anyType/lax descendants — CTA selects the governing type FIRST,
+  then the cvc-elt.4.3 derivation-block check and the idc lax-assessment/ID-pass run against the SELECTED
+  type.
+  - Each `<xs:alternative>` may carry an INLINE anonymous `<xs:complexType>`/`<xs:simpleType>`
+    (`parseTypeAlternative`; a present-but-empty `@type` is a governing-type source, so `@type=""` plus an
+    inline type is a conflict and a bare `@type=""` is an invalid QName), `type="xs:error"` (a selected
+    xs:error invalidates the element even through the xsi:nil nilled path), and `@xpathDefaultNamespace`
+    (`effectiveXPathDefaultNS`: locally-present value resolved against the alternative, else inherited from
+    schema-level; affects only unprefixed element name tests).
+  - @test runs against a DETACHED CTA context node (`inherited_attrs.go` `ctaContextNode`): an orphan element
+    with the instance element's own attributes PLUS inheritable attributes from ancestors
+    (`inheritedAttributes`, declaration `inheritable="true"`), its in-scope namespaces, position()=last()=1,
+    an empty `emptyCollectionResolver`, the schema base URI, no children/parent.
+  - A non-default `@type`/inline alternative must be VALIDLY SUBSTITUTABLE for the declared type
+    (`checkAltSubstitutability`, compile time): `strictBuiltinAwareDerivedFrom` (`builtin_hierarchy.go`)
+    accepts a genuine derivation via `isDerivedFrom`, the built-in simple-type hierarchy via
+    `builtinSimpleBase` (1.0 built-ins not BaseType-linked), or the anySimpleType simple-content rule; a union
+    declared type admits any base-chain-resolved member (`resolveVariety`/`resolveUnionMembers`); NO
+    permissive simple-vs-simple fallback. The block check is built-in-aware (`isDerivationBlocked`).
+    Per-document `xpathDefaultNamespace`/base-URI and the `altTypeRefs`/`ctaElems` worklists are
+    saved/restored across include/redefine and seeded onto import sub-compilers (`compile_imports.go`).
+- **union-member element-type restriction** (version-INDEPENDENT, cos-st-derived-ok clause 2.2.4): a
+  complexContent restriction's child element type may be validly derived from a UNION base element type's
+  (transitive) member — `elementTypeValidlyRestricts` (`restriction_particle.go`) falls back to
+  `isXsiTypeDerivedFromDeclared` (`alternative.go`) UNGATED, so narrowing a base element typed
+  `union(xs:decimal, xs:string)` to the member `xs:string` compiles in both 1.0 and 1.1 (W3C addB150 /
+  test93568.xsd, expected-valid with no version qualifier; libxml2 accepts it in 1.0). The member check is
+  strict and recursive (a non-member type deriving from nothing in the union is still rejected).
+- **Simple-type 1.1 edges**: `finalDefault="extension"` reaches a simple type's `{final}` (the simpleType
+  final-default mask in `read_types.go` adds `FinalExtension`, spec bug 2074), so a simpleContent extension of
+  an extension-final simple type is rejected; `checkAnyAtomicTypeUsage` rejects `xs:anyAtomicType` as a user
+  simple type's restriction base / list item type / union member type (W3C bug 11103 — valid as an
+  element/attribute/xsi:type type); `checkAnySimpleTypeUsage` rejects RESTRICTING the simple ur-type
+  `xs:anySimpleType` — as a simpleType restriction base / list item type / union member type, and as a
+  simpleContent complexType RESTRICTION whose effective content simple type (`effectiveContentSimpleType`) is
+  left as `xs:anySimpleType` — per Part 2 §2.4.1 / W3C bug 14559 (valid as an element/attribute/xsi:type type
+  and as the base of a simpleContent EXTENSION). Two arms are **version-INDEPENDENT** (cos-st-restricts
+  requires a restriction base to be atomic/list/union, and libxml2 rejects them in XSD 1.0 too): a simpleType
+  `<xs:restriction>` whose DIRECT base is `xs:anySimpleType`, and a simpleContent `<xs:restriction>` whose
+  DIRECT base is `xs:anySimpleType` AND whose effective content is left as the ur-type (no
+  nested-simpleType/facet narrowing) — W3C stZ005/stZ006/stZ009/stZ011, addB110, invalid in both. The
+  remaining arms stay **Version11-gated** (valid in XSD 1.0): a list item type / union member type of
+  `xs:anySimpleType`, and a simpleContent restriction of a COMPLEX base whose content merely resolves to the
+  ur-type (W3C stZ007/stZ047/stZ055, valid in 1.0, invalid in 1.1). `checkAnySimpleTypeUsage` is called
+  unconditionally (`compile.go`); its item/member/complex-base arms self-gate on `c.version == Version11`, so
+  the 1.0 path is byte-identical apart from the two newly-enforced direct-restriction cases.


### PR DESCRIPTION
- Doc paragraphs were single lines up to 44k chars, so any diff of them was unreadable to a bounded reviewer.
- Pure whitespace change: every file verifies content-identical once wrapping is normalized.
- Table rows and fenced code blocks are left alone, since wrapping those breaks them.
