### PR TITLE
fix XPointer whitespace parsing

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -18,7 +18,7 @@ relaxng        → helium, internal/lexicon, internal/iofs, internal/iolimit, in
 schematron     → helium, xpath1, xpath3, internal/xpath, internal/xpath1/number
 xpointer       → helium, xpath1, internal/xmlchar
 c14n           → helium, internal/lexicon, internal/domutil
-xmldsig1       → helium, c14n, xpath1, internal/lexicon, internal/domutil, internal/xmlbase64
+xmldsig1       → helium, c14n, xpath1, internal/lexicon, internal/domutil, internal/xmlbase64, internal/xmlchar
 xmldsig1/transform → helium, xmldsig1, xslt3  (opt-in xslt3-backed XSLTTransformer; kept out of xmldsig1 so the core never imports xslt3)
 xmlenc1        → helium, c14n, internal/domutil, internal/xmlbase64  (c14n converts the node-set a same-document xenc:CipherReference names into octets; c14n imports neither xmlenc1 nor xmldsig1, so the edge is one-way)
 html           → helium, sax, push, internal/xmlchar
@@ -61,7 +61,7 @@ helium (root) → sax, enum, internal/*
 c14n, xpath1, xpath3, html, catalog, relaxng, stream
 
 ## Security layer (depends on processing)
-xmldsig1 (root + c14n + xpath1 + internal/lexicon; xpath1 backs the XPath filter transform), xmlenc1 (root + c14n; c14n converts the node-set a same-document xenc:CipherReference names into octets)
+xmldsig1 (root + c14n + xpath1 + internal/lexicon + internal/xmlchar; xpath1 backs the XPath filter transform), xmlenc1 (root + c14n; c14n converts the node-set a same-document xenc:CipherReference names into octets)
 
 ## Composition layer (depends on processing)
 xsd (root + xpath1 + xpath3 + internal/lexicon), xpointer (root + xpath1 + internal/xmlchar), schematron (root + xpath1 + xpath3 + internal/xpath + internal/xpath1/number; xpath1 backs the XPath 1.0 queryBinding, xpath3 the XPath 3.1 one), xinclude (root + xpointer + internal/encoding + internal/iofs + internal/lexicon), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1404,11 +1404,13 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   through `VerificationError`; empty → `ErrReferenceNotFound`, and a multi-element or non-element node-set →
   `ErrAmbiguousReference`. An id() selector NEVER reaches xpath1's built-in id()
   (`Document.GetElementByID`, which resolves a duplicate id to the last-registered element — an XSW bypass): a
-  whole-expression `id('X')` selector in any whitespace spelling (`id('X')`, `id ('X')`, `id( "X" )`;
+  whole-expression `id('X')` selector in any XML S spelling (`id('X')`, `id ('X')`, `id( "X" )`;
   `parseXPointerIDSelector`) resolves through the duplicate-detecting `domutil.FindElementsByID`
   (`ErrAmbiguousReference` on a duplicate), and ANY other id() use — a wrapping paren, a predicate, a path
   step (`expressionReferencesID`) — is rejected fail-closed as `ErrReferenceNotFound` and never reaches the
-  built-in. The selected element is fed into the existing subtree canonicalization path (comments included).
+  built-in. Before compilation, non-XML-S Unicode whitespace outside quoted XPath literals is rejected, while
+  the same characters inside literals remain data. The selected element is fed into the existing subtree
+  canonicalization path (comments included).
   `here()` is NOT registered for a URI-borne XPointer, so `xpointer(here())` fails closed with
   `ErrHereUnavailable` (preserved as a matchable sentinel through the general-XPointer error path).
 - Comment membership is a property of the reference FORM, not the c14n method: `effectiveC14NMethod`

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1394,8 +1394,10 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
 - **General XPointer resolution (opt-in, verify-only, `transforms.go`)**: `Verifier.AllowXPointer(true)`
   extends same-document resolution to an XPointer framework URI — zero+ `xmlns(prefix=uri)` scheme parts then
   one `xpointer(<expr>)` (`parseGeneralXPointer`, respecting balanced parens and `^(`/`^)`/`^^` circumflex
-  escaping). Default OFF: a general XPointer stays fail-closed as an external reference, so the four-form
-  default is byte-identical. When on, `prepareGeneralXPointer` statically validates the `xpointer()` XPath on
+  escaping). Each `xmlns()` prefix must be an XML NCName; a malformed binding cannot select a same-document
+  target even when the XPath does not use it. Default OFF: a general XPointer stays fail-closed as an external
+  reference, so the four-form default is byte-identical. When on, `prepareGeneralXPointer` statically validates
+  the `xpointer()` XPath on
   the shared bounded evaluator with the document element's in-scope namespaces overlaid by the `xmlns()`
   overrides (`xpointerNamespaces`), so an unresolved variable/function/prefix fails as `ErrReferenceNotFound`
   before evaluation. `resolvePreparedGeneralXPointerTarget` then evaluates the expression and enforces a

--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -211,7 +211,9 @@ By default a `Reference` URI is resolved fail-closed to the four same-document
 forms above. `Verifier.AllowXPointer(true)` additionally resolves a general
 XPointer framework URI — zero or more `xmlns(prefix=uri)` scheme parts followed
 by one `xpointer(<expr>)` part, for example
-`#xmlns(a=urn:x)xpointer(//a:Target)`. It stays fail-closed by default: with
+`#xmlns(a=urn:x)xpointer(//a:Target)`. Each `xmlns()` prefix must be an XML
+NCName; a malformed binding cannot select a same-document target even when the
+XPath does not use it. It stays fail-closed by default: with
 `AllowXPointer` off, a general XPointer URI is treated as an external reference
 and, without a `ReferenceResolver`, rejected with `ErrReferenceNotFound`, so
 default verification is unchanged.

--- a/xmldsig1/reference_interop_internal_test.go
+++ b/xmldsig1/reference_interop_internal_test.go
@@ -63,6 +63,53 @@ func TestReferenceURIForm(t *testing.T) {
 			require.Equal(t, exp.id, id, "id")
 		})
 	}
+
+	for _, tc := range []struct {
+		name string
+		ws   string
+	}{
+		{name: "space", ws: " "},
+		{name: "tab", ws: "\t"},
+		{name: "carriage return", ws: "\r"},
+		{name: "line feed", ws: "\n"},
+	} {
+		t.Run("XPath S accepts "+tc.name, func(t *testing.T) {
+			uri := "#xpointer(" + tc.ws + "id(" + tc.ws + "'e1ID'" + tc.ws + ")" + tc.ws + ")"
+			id, wholeDoc, includeComments, ok := referenceURIForm(uri)
+			require.True(t, ok)
+			require.False(t, wholeDoc)
+			require.True(t, includeComments)
+			require.Equal(t, "e1ID", id)
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		ws   string
+	}{
+		{name: "no-break space", ws: "\u00a0"},
+		{name: "next line", ws: "\u0085"},
+		{name: "line separator", ws: "\u2028"},
+		{name: "ideographic space", ws: "\u3000"},
+	} {
+		t.Run("rejects "+tc.name+" around the expression", func(t *testing.T) {
+			_, _, _, ok := referenceURIForm("#xpointer(" + tc.ws + "id('e1ID')" + tc.ws + ")")
+			require.False(t, ok)
+		})
+		t.Run("rejects "+tc.name+" around the id argument", func(t *testing.T) {
+			_, _, _, ok := referenceURIForm("#xpointer(id(" + tc.ws + "'e1ID'" + tc.ws + "))")
+			require.False(t, ok)
+		})
+	}
+
+	t.Run("quoted id whitespace is preserved", func(t *testing.T) {
+		const want = "\u00a0 e1ID \u3000"
+		id, wholeDoc, includeComments, ok := referenceURIForm("#xpointer(id('" + want + "'))")
+		require.True(t, ok)
+		require.False(t, wholeDoc)
+		require.True(t, includeComments)
+		require.Equal(t, want, id)
+	})
 }
 
 // TestXPointerReferenceDigests locks the same-document Reference URI forms and

--- a/xmldsig1/reference_interop_internal_test.go
+++ b/xmldsig1/reference_interop_internal_test.go
@@ -74,7 +74,7 @@ func TestReferenceURIForm(t *testing.T) {
 		{name: "line feed", ws: "\n"},
 	} {
 		t.Run("XPath S accepts "+tc.name, func(t *testing.T) {
-			uri := "#xpointer(" + tc.ws + "id(" + tc.ws + "'e1ID'" + tc.ws + ")" + tc.ws + ")"
+			uri := "#xpointer(" + tc.ws + "id" + tc.ws + "(" + tc.ws + "'e1ID'" + tc.ws + ")" + tc.ws + ")"
 			id, wholeDoc, includeComments, ok := referenceURIForm(uri)
 			require.True(t, ok)
 			require.False(t, wholeDoc)

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lestrrat-go/helium/c14n"
 	"github.com/lestrrat-go/helium/internal/domutil"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/xpath1"
 
 	helium "github.com/lestrrat-go/helium"
@@ -1320,7 +1321,7 @@ func nextSchemePart(s string) (string, string, string, bool) {
 }
 
 // parseXmlnsPart splits an xmlns() scheme part's data "prefix=uri" into its
-// prefix and namespace URI. A missing "=" or an empty prefix is malformed.
+// prefix and namespace URI. A missing "=" or an invalid NCName prefix is malformed.
 func parseXmlnsPart(data string) (string, string, bool) {
 	rawPrefix, rawNS, ok := strings.Cut(data, "=")
 	if !ok {
@@ -1328,7 +1329,7 @@ func parseXmlnsPart(data string) (string, string, bool) {
 	}
 	// XPointer's xmlns() scheme uses XML S, not all Unicode whitespace.
 	prefix := strings.Trim(rawPrefix, " \t\r\n")
-	if prefix == "" {
+	if !xmlchar.IsValidNCName(prefix) {
 		return "", "", false
 	}
 	return prefix, strings.Trim(rawNS, " \t\r\n"), true

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium/c14n"
@@ -1187,15 +1188,20 @@ func referenceURIForm(uri string) (string, bool, bool, bool) {
 	return "", false, false, false
 }
 
-// parseXPointerID matches the XPointer id() form id('X') or id("X") and returns
-// the quoted id. Anything else (a bare argument, a nested call, an unbalanced or
-// mismatched quote) is rejected so only the two SHOULD-support schemes resolve.
+// parseXPointerID matches the XPointer id() form id('X') or id("X"), allowing
+// XML S before the opening parenthesis, and returns the quoted id. Anything else
+// (a bare argument, a nested call, an unbalanced or mismatched quote) is rejected
+// so only the two SHOULD-support schemes resolve.
 func parseXPointerID(expr string) (string, bool) {
-	if !strings.HasPrefix(expr, "id(") || !strings.HasSuffix(expr, ")") {
+	if !strings.HasPrefix(expr, "id") {
+		return "", false
+	}
+	rest := strings.TrimLeft(expr[len("id"):], " \t\r\n")
+	if !strings.HasPrefix(rest, "(") || !strings.HasSuffix(rest, ")") {
 		return "", false
 	}
 	// XPath S contains only space, tab, carriage return, and line feed.
-	arg := strings.Trim(expr[len("id("):len(expr)-1], " \t\r\n")
+	arg := strings.Trim(rest[1:len(rest)-1], " \t\r\n")
 	if len(arg) < 2 {
 		return "", false
 	}
@@ -1320,11 +1326,12 @@ func parseXmlnsPart(data string) (string, string, bool) {
 	if !ok {
 		return "", "", false
 	}
-	prefix := strings.TrimSpace(rawPrefix)
+	// XPointer's xmlns() scheme uses XML S, not all Unicode whitespace.
+	prefix := strings.Trim(rawPrefix, " \t\r\n")
 	if prefix == "" {
 		return "", "", false
 	}
-	return prefix, strings.TrimSpace(rawNS), true
+	return prefix, strings.Trim(rawNS, " \t\r\n"), true
 }
 
 // unescapeXPointerData reverses the XPointer framework circumflex escaping in a
@@ -1417,6 +1424,9 @@ func singleElementApex(nodes []helium.Node) (*helium.Element, error) {
 // Every remaining expression is statically validated with the merged namespace
 // context, the shared operation limit, and here() disabled (nil bearing node).
 func prepareGeneralXPointer(doc *helium.Document, overrides map[string]string, expr string) (*preparedGeneralXPointer, error) {
+	if containsNonXMLSWhitespaceOutsideLiteral(expr) {
+		return nil, fmt.Errorf("%w: invalid XPointer expression %q", ErrReferenceNotFound, expr)
+	}
 	if id, isIDCall, ok := parseXPointerIDSelector(expr); isIDCall {
 		if !ok {
 			return nil, fmt.Errorf("%w: unsupported XPointer id() selector %q", ErrReferenceNotFound, expr)
@@ -1439,6 +1449,29 @@ func prepareGeneralXPointer(doc *helium.Document, overrides map[string]string, e
 		return nil, fmt.Errorf("%w: invalid XPointer expression %q: %v", ErrReferenceNotFound, expr, err)
 	}
 	return &preparedGeneralXPointer{compiled: compiled, eval: eval}, nil
+}
+
+// containsNonXMLSWhitespaceOutsideLiteral reports whitespace that xpath1's
+// lexer would accept even though XPath 1.0 permits only XML S between tokens.
+// Whitespace inside a quoted string is data and remains untouched.
+func containsNonXMLSWhitespaceOutsideLiteral(expr string) bool {
+	var quote rune
+	for _, r := range expr {
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			}
+			continue
+		}
+		if r == '\'' || r == '"' {
+			quote = r
+			continue
+		}
+		if unicode.IsSpace(r) && r != ' ' && r != '\t' && r != '\r' && r != '\n' {
+			return true
+		}
+	}
+	return false
 }
 
 func resolvePreparedGeneralXPointerTarget(ctx context.Context, doc *helium.Document, prepared *preparedGeneralXPointer) (*helium.Element, error) {

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -1260,7 +1260,8 @@ func parseGeneralXPointer(uri string) (map[string]string, string, bool) {
 				return nil, "", false
 			}
 			haveXPointer = true
-			expr = strings.TrimSpace(unescapeXPointerData(data))
+			// XPath S contains only space, tab, carriage return, and line feed.
+			expr = strings.Trim(unescapeXPointerData(data), " \t\r\n")
 		default:
 			// Any other scheme (element(), xpath1(), ...) is unsupported.
 			return nil, "", false
@@ -1276,9 +1277,9 @@ func parseGeneralXPointer(uri string) (map[string]string, string, bool) {
 // nextSchemePart reads one "scheme(data)" pointer part from the front of s,
 // respecting the XPointer framework's balanced-parenthesis and "^" escape rules
 // inside the data, and returns the scheme name, the raw (still-escaped) data, and
-// the remaining string after the closing ")". Leading whitespace between parts is
-// skipped. It fails (ok=false) on a missing/empty scheme name, a scheme name
-// carrying whitespace or parens, or unbalanced parentheses.
+// the remaining string after the closing ")". Leading XPath S whitespace between
+// parts is skipped. It fails (ok=false) on a missing/empty scheme name, a scheme
+// name carrying XPath S whitespace or parens, or unbalanced parentheses.
 func nextSchemePart(s string) (string, string, string, bool) {
 	s = strings.TrimLeft(s, " \t\r\n")
 	open := strings.IndexByte(s, '(')
@@ -1409,10 +1410,10 @@ func singleElementApex(nodes []helium.Node) (*helium.Element, error) {
 // through Document.GetElementByID, whose ID table overwrites on collision so a
 // duplicate id silently resolves to a single element (an XML Signature Wrapping
 // bypass). Instead, an expression whose whole value is an id('X') selector — in
-// ANY whitespace spelling (id('X'), id ('X'), id( "X" )) — resolves through the
-// duplicate-detecting domutil.FindElementsByID, and ANY other use of id() (a
-// parenthesized or embedded id() call the selector parser cannot reduce to a
-// single literal id) is rejected fail-closed, and never reaches the built-in.
+// ANY XPath S whitespace spelling (id('X'), id ('X'), id( "X" )) — resolves
+// through the duplicate-detecting domutil.FindElementsByID. ANY other use of
+// id() (a parenthesized or embedded id() call the selector parser cannot reduce
+// to a single literal id) is rejected fail-closed and never reaches the built-in.
 // Every remaining expression is statically validated with the merged namespace
 // context, the shared operation limit, and here() disabled (nil bearing node).
 func prepareGeneralXPointer(doc *helium.Document, overrides map[string]string, expr string) (*preparedGeneralXPointer, error) {
@@ -1467,15 +1468,16 @@ func resolvePreparedGeneralXPointerTarget(ctx context.Context, doc *helium.Docum
 }
 
 // parseXPointerIDSelector recognizes a whole-expression id() selector in any
-// whitespace spelling — id('X'), id ("X"), id( 'X' ), with optional surrounding
-// whitespace. isIDCall reports that the trimmed expression IS a top-level
-// id(...) call; ok additionally reports that it cleanly reduces to a single
-// quoted id literal, returned in the first result. A general-XPointer id()
+// XPath S whitespace spelling — id('X'), id ("X"), id( 'X' ), with optional
+// surrounding XPath S whitespace. isIDCall reports that the trimmed expression
+// IS a top-level id(...) call; ok additionally reports that it cleanly reduces
+// to a single quoted id literal, returned in the first result. A general-XPointer id()
 // selector is ALWAYS routed through the duplicate-detecting domutil.FindElementsByID
 // (never xpath1's built-in id()), so an id() call that is not a clean single
 // literal is reported as isIDCall && !ok for the caller to reject fail-closed.
 func parseXPointerIDSelector(expr string) (string, bool, bool) {
-	s := strings.TrimSpace(expr)
+	// XPath S contains only space, tab, carriage return, and line feed.
+	s := strings.Trim(expr, " \t\r\n")
 	if !strings.HasPrefix(s, "id") {
 		return "", false, false
 	}
@@ -1490,7 +1492,7 @@ func parseXPointerIDSelector(expr string) (string, bool, bool) {
 		// id('x')[1]. It IS an id() call, but not a clean selector.
 		return "", true, false
 	}
-	arg := strings.TrimSpace(rest[1 : len(rest)-1])
+	arg := strings.Trim(rest[1:len(rest)-1], " \t\r\n")
 	if len(arg) < 2 {
 		return "", true, false
 	}
@@ -1509,8 +1511,8 @@ func parseXPointerIDSelector(expr string) (string, bool, bool) {
 
 // expressionReferencesID reports whether an XPath expression invokes the id()
 // function anywhere outside a string literal — an id name token immediately
-// followed (modulo whitespace) by "(". The general-XPointer resolver uses it to
-// fail closed on any id() use it does not itself resolve through the
+// followed (modulo XPath S whitespace) by "(". The general-XPointer resolver
+// uses it to fail closed on any id() use it does not itself resolve through the
 // duplicate-detecting domutil.FindElementsByID, since xpath1's built-in id()
 // (Document.GetElementByID) resolves a duplicate id to a single element.
 func expressionReferencesID(expr string) bool {

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -1176,7 +1176,8 @@ func referenceURIForm(uri string) (string, bool, bool, bool) {
 	if !strings.HasSuffix(frag, ")") {
 		return "", false, false, false
 	}
-	expr := strings.TrimSpace(frag[len("xpointer(") : len(frag)-1])
+	// XPath S contains only space, tab, carriage return, and line feed.
+	expr := strings.Trim(frag[len("xpointer("):len(frag)-1], " \t\r\n")
 	if expr == "/" {
 		return "", true, true, true
 	}
@@ -1193,7 +1194,8 @@ func parseXPointerID(expr string) (string, bool) {
 	if !strings.HasPrefix(expr, "id(") || !strings.HasSuffix(expr, ")") {
 		return "", false
 	}
-	arg := strings.TrimSpace(expr[len("id(") : len(expr)-1])
+	// XPath S contains only space, tab, carriage return, and line feed.
+	arg := strings.Trim(expr[len("id("):len(expr)-1], " \t\r\n")
 	if len(arg) < 2 {
 		return "", false
 	}

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -549,6 +549,9 @@ func (v Verifier) MaxDecodedBytes(n int) Verifier {
 // and, without a [ReferenceResolver], rejected with [ErrReferenceNotFound], so
 // default verification is byte-identical.
 //
+// Each xmlns() prefix must be an XML NCName. A malformed binding cannot select a
+// same-document target even when the XPath expression does not use it.
+//
 // When enabled, every top-level xpointer() expression is compiled and statically
 // validated during the all-Reference preflight before any Reference resolver or
 // transformer runs. Its prepared bounded XPath 1.0 evaluator is reused during

--- a/xmldsig1/xpath_features_internal_test.go
+++ b/xmldsig1/xpath_features_internal_test.go
@@ -356,6 +356,48 @@ func TestGeneralXPointerResolution(t *testing.T) {
 		require.ErrorIs(t, err, ErrAmbiguousReference)
 	})
 
+	t.Run("non-XML-S whitespace cannot bypass duplicate detection", func(t *testing.T) {
+		const xml = `<root><a xml:id="dup">A</a><b xml:id="dup">B</b></root>`
+		doc := mustParse(t, xml)
+		ref := xpointerRef("#xpointer(id\u00a0('dup'))")
+		cfg := &verifierConfig{allowXPointer: true}
+		_, _, _, err := canonicalizeReference(t.Context(), cfg, doc, nil, ref)
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+	})
+
+	t.Run("non-XML-S whitespace does not reach the XPath compiler", func(t *testing.T) {
+		doc := mustParse(t, `<root><a/></root>`)
+		ref := xpointerRef("#xpointer(\u00a0/root/a\u00a0)")
+		cfg := &verifierConfig{allowXPointer: true}
+		_, _, _, err := canonicalizeReference(t.Context(), cfg, doc, nil, ref)
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+	})
+
+	t.Run("non-XML-S whitespace in a quoted literal is preserved", func(t *testing.T) {
+		doc := mustParse(t, `<root><a value="&#160;"/></root>`)
+		ref := xpointerRef("#xpointer(//a[@value='\u00a0'])")
+		cfg := &verifierConfig{allowXPointer: true}
+		target, _, _, err := canonicalizeReference(t.Context(), cfg, doc, nil, ref)
+		require.NoError(t, err)
+		require.Equal(t, findLocal(doc.DocumentElement(), "a"), target)
+	})
+
+	for _, tc := range []struct {
+		name string
+		uri  string
+	}{
+		{name: "xmlns prefix boundary", uri: "#xmlns(\u00a0p=urn:t)xpointer(//p:a)"},
+		{name: "xmlns namespace boundary", uri: "#xmlns(p=urn:t\u00a0)xpointer(//p:a)"},
+	} {
+		t.Run("rejects non-XML-S at "+tc.name, func(t *testing.T) {
+			doc := mustParse(t, `<root xmlns="urn:t"><a/></root>`)
+			ref := xpointerRef(tc.uri)
+			cfg := &verifierConfig{allowXPointer: true}
+			_, _, _, err := canonicalizeReference(t.Context(), cfg, doc, nil, ref)
+			require.ErrorIs(t, err, ErrReferenceNotFound)
+		})
+	}
+
 	// Unicode whitespace outside XPath S must remain part of the expression and
 	// fail parsing or strict id-selector recognition instead of selecting an ID.
 	for _, tc := range []struct {

--- a/xmldsig1/xpath_features_internal_test.go
+++ b/xmldsig1/xpath_features_internal_test.go
@@ -356,6 +356,33 @@ func TestGeneralXPointerResolution(t *testing.T) {
 		require.ErrorIs(t, err, ErrAmbiguousReference)
 	})
 
+	// Unicode whitespace outside XPath S must remain part of the expression and
+	// fail parsing or strict id-selector recognition instead of selecting an ID.
+	for _, tc := range []struct {
+		name string
+		uri  string
+	}{
+		{"U+00A0 around selector", "#xpointer(\u00a0id('a')\u00a0)"},
+		{"U+0085 around selector", "#xpointer(\u0085id('a')\u0085)"},
+		{"U+2028 around selector", "#xpointer(\u2028id('a')\u2028)"},
+		{"U+3000 around selector", "#xpointer(\u3000id('a')\u3000)"},
+		{"U+00A0 around argument", "#xpointer(id(\u00a0'a'\u00a0))"},
+		{"U+0085 around argument", "#xpointer(id(\u0085'a'\u0085))"},
+		{"U+2028 around argument", "#xpointer(id(\u2028'a'\u2028))"},
+		{"U+3000 around argument", "#xpointer(id(\u3000'a'\u3000))"},
+	} {
+		t.Run(tc.name+" fails closed", func(t *testing.T) {
+			doc := mustParse(t, `<root><a Id="a"/></root>`)
+			ref := xpointerRef(tc.uri)
+			cfg := &verifierConfig{allowXPointer: true}
+			target, canonical, external, err := canonicalizeReference(t.Context(), cfg, doc, nil, ref)
+			require.ErrorIs(t, err, ErrReferenceNotFound)
+			require.Nil(t, target)
+			require.Nil(t, canonical)
+			require.False(t, external)
+		})
+	}
+
 	// Any id() use that is not the whole-expression selector (a wrapping paren, a
 	// predicate) cannot be routed through domutil.FindElementsByID, so it is rejected
 	// fail-closed and never reaches the built-in id() — under duplicate xml:id

--- a/xmldsig1/xpath_features_internal_test.go
+++ b/xmldsig1/xpath_features_internal_test.go
@@ -382,6 +382,14 @@ func TestGeneralXPointerResolution(t *testing.T) {
 		require.Equal(t, findLocal(doc.DocumentElement(), "a"), target)
 	})
 
+	t.Run("malformed unused xmlns prefix is rejected", func(t *testing.T) {
+		doc := mustParse(t, `<root/>`)
+		ref := xpointerRef("#xmlns(\u00a0p=urn:t)xpointer(/root)")
+		cfg := &verifierConfig{allowXPointer: true}
+		_, _, _, err := canonicalizeReference(t.Context(), cfg, doc, nil, ref)
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+	})
+
 	for _, tc := range []struct {
 		name string
 		uri  string

--- a/xmlenc1/reference.go
+++ b/xmlenc1/reference.go
@@ -129,7 +129,8 @@ func referenceURIForm(uri string) (string, bool, bool) {
 	if !strings.HasSuffix(frag, ")") {
 		return "", false, false
 	}
-	expr := strings.TrimSpace(frag[len("xpointer(") : len(frag)-1])
+	// XPath S contains only space, tab, carriage return, and line feed.
+	expr := strings.Trim(frag[len("xpointer("):len(frag)-1], " \t\r\n")
 	if expr == "/" {
 		return "", true, true
 	}
@@ -146,7 +147,8 @@ func parseXPointerID(expr string) (string, bool) {
 	if !strings.HasPrefix(expr, "id(") || !strings.HasSuffix(expr, ")") {
 		return "", false
 	}
-	arg := strings.TrimSpace(expr[len("id(") : len(expr)-1])
+	// XPath S contains only space, tab, carriage return, and line feed.
+	arg := strings.Trim(expr[len("id("):len(expr)-1], " \t\r\n")
 	if len(arg) < 2 {
 		return "", false
 	}

--- a/xmlenc1/reference.go
+++ b/xmlenc1/reference.go
@@ -140,15 +140,20 @@ func referenceURIForm(uri string) (string, bool, bool) {
 	return "", false, false
 }
 
-// parseXPointerID matches the XPointer id() form id('X') or id("X") and returns
-// the quoted id. Anything else (a bare argument, a nested call, an unbalanced or
-// mismatched quote) is rejected so only the two SHOULD-support schemes resolve.
+// parseXPointerID matches the XPointer id() form id('X') or id("X"), allowing
+// XML S before the opening parenthesis, and returns the quoted id. Anything else
+// (a bare argument, a nested call, an unbalanced or mismatched quote) is rejected
+// so only the two SHOULD-support schemes resolve.
 func parseXPointerID(expr string) (string, bool) {
-	if !strings.HasPrefix(expr, "id(") || !strings.HasSuffix(expr, ")") {
+	if !strings.HasPrefix(expr, "id") {
+		return "", false
+	}
+	rest := strings.TrimLeft(expr[len("id"):], " \t\r\n")
+	if !strings.HasPrefix(rest, "(") || !strings.HasSuffix(rest, ")") {
 		return "", false
 	}
 	// XPath S contains only space, tab, carriage return, and line feed.
-	arg := strings.Trim(expr[len("id("):len(expr)-1], " \t\r\n")
+	arg := strings.Trim(rest[1:len(rest)-1], " \t\r\n")
 	if len(arg) < 2 {
 		return "", false
 	}

--- a/xmlenc1/reference_test.go
+++ b/xmlenc1/reference_test.go
@@ -296,6 +296,65 @@ func TestRetrievalMethod(t *testing.T) {
 		requireSecret(t, nodes)
 	})
 
+	for _, tc := range []struct {
+		name string
+		ws   string
+	}{
+		{name: "space", ws: " "},
+		{name: "tab", ws: "&#x9;"},
+		{name: "carriage return", ws: "&#xD;"},
+		{name: "line feed", ws: "&#xA;"},
+	} {
+		t.Run("XPath S accepts "+tc.name, func(t *testing.T) {
+			sessionKey, kek := newKeys(t)
+			uri := "#xpointer(" + tc.ws + "id(" + tc.ws + "'k'" + tc.ws + ")" + tc.ws + ")"
+			elem := retrievalDoc(t, sessionKey,
+				retrievalMethodXML(xmlenc1.TypeEncryptedKey, uri),
+				`<ds:KeyInfo>`+wrappedKeyXML(t, "k", kek, sessionKey, "")+`</ds:KeyInfo>`)
+			nodes, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), elem)
+			require.NoError(t, err)
+			requireSecret(t, nodes)
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		ws   string
+	}{
+		{name: "no-break space", ws: "\u00a0"},
+		{name: "next line", ws: "\u0085"},
+		{name: "line separator", ws: "\u2028"},
+		{name: "ideographic space", ws: "\u3000"},
+	} {
+		t.Run("rejects "+tc.name+" around the expression", func(t *testing.T) {
+			sessionKey, kek := newKeys(t)
+			uri := "#xpointer(" + tc.ws + "id('k')" + tc.ws + ")"
+			elem := retrievalDoc(t, sessionKey,
+				retrievalMethodXML(xmlenc1.TypeEncryptedKey, uri),
+				`<ds:KeyInfo>`+wrappedKeyXML(t, "k", kek, sessionKey, "")+`</ds:KeyInfo>`)
+			_, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), elem)
+			require.ErrorIs(t, err, xmlenc1.ErrReferenceNotFound)
+		})
+		t.Run("rejects "+tc.name+" around the id argument", func(t *testing.T) {
+			sessionKey, kek := newKeys(t)
+			uri := "#xpointer(id(" + tc.ws + "'k'" + tc.ws + "))"
+			elem := retrievalDoc(t, sessionKey,
+				retrievalMethodXML(xmlenc1.TypeEncryptedKey, uri),
+				`<ds:KeyInfo>`+wrappedKeyXML(t, "k", kek, sessionKey, "")+`</ds:KeyInfo>`)
+			_, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), elem)
+			require.ErrorIs(t, err, xmlenc1.ErrReferenceNotFound)
+		})
+	}
+
+	t.Run("quoted id whitespace is preserved", func(t *testing.T) {
+		sessionKey, kek := newKeys(t)
+		elem := retrievalDoc(t, sessionKey,
+			retrievalMethodXML(xmlenc1.TypeEncryptedKey, "#xpointer(id(' key '))"),
+			`<ds:KeyInfo>`+wrappedKeyXML(t, "key", kek, sessionKey, "")+`</ds:KeyInfo>`)
+		_, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), elem)
+		require.ErrorIs(t, err, xmlenc1.ErrReferenceNotFound)
+	})
+
 	// xmlenc-core1 §3.5.3 permits several RetrievalMethods, and two naming the
 	// same EncryptedKey describe one key: it must be trial-decrypted once and
 	// charged once, not once per reference.

--- a/xmlenc1/reference_test.go
+++ b/xmlenc1/reference_test.go
@@ -307,7 +307,7 @@ func TestRetrievalMethod(t *testing.T) {
 	} {
 		t.Run("XPath S accepts "+tc.name, func(t *testing.T) {
 			sessionKey, kek := newKeys(t)
-			uri := "#xpointer(" + tc.ws + "id(" + tc.ws + "'k'" + tc.ws + ")" + tc.ws + ")"
+			uri := "#xpointer(" + tc.ws + "id" + tc.ws + "(" + tc.ws + "'k'" + tc.ws + ")" + tc.ws + ")"
 			elem := retrievalDoc(t, sessionKey,
 				retrievalMethodXML(xmlenc1.TypeEncryptedKey, uri),
 				`<ds:KeyInfo>`+wrappedKeyXML(t, "k", kek, sessionKey, "")+`</ds:KeyInfo>`)


### PR DESCRIPTION
- Align same-document XPointer whitespace with XPath S in `xmlenc1` and `xmldsig1`.
- Preserve quoted IDs and reject wider Unicode whitespace at parser boundaries for follow-up `fu123`.
- Cover both packages with focused tests and `go test ./...`.
