### PR TITLE
preserve entity references in deep copies

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -27,9 +27,13 @@ stream         → internal/encoding, internal/xmlchar
 sax            → helium, enum
 helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack, internal/uripath, internal/iofs, internal/writerctl, internal/nodelink, internal/nslookup
                   (helium installs hooks in internal/writerctl in init so xpath3 fn:serialize can enable declaration-only encoding and xslt3 can omit document-child terminators without public methods; the writerctl package imports nothing, so the edge is one-way)
-                  (helium installs hooks in internal/nodelink in init so xslt3's strip-space copier can link a freshly built child without AddChild's preflight, and the xsd/xmldsig1 corrupt-tree cycle-guard tests can write a raw next-sibling pointer, all without public functions in helium; the nodelink package imports nothing, so the edge is one-way)
-                  (helium installs hooks in internal/nslookup in init so internal/domutil can search or read raw namespace declarations one at a time
-                  without cloning Element.Namespaces or exposing the mutable nsDefs slice; the nslookup package imports nothing, so the edge is one-way)
+                  (helium installs hooks in internal/nodelink in init so xslt3's strip-space copier can link a
+                  freshly built child without AddChild's preflight and bind an EntityRef to its copied declaration;
+                  the xsd/xmldsig1 corrupt-tree cycle-guard tests can write a raw next-sibling pointer; all hooks avoid
+                  public mutation functions in helium; the nodelink package imports nothing, so the edge is one-way)
+                  (helium installs hooks in internal/nslookup in init so internal/domutil can search or read raw
+                  namespace declarations one at a time without cloning Element.Namespaces or exposing the mutable
+                  nsDefs slice; the nslookup package imports nothing, so the edge is one-way)
 sink           → (none)
 enum           → (none)
 internal/lexicon → (none)

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -366,18 +366,20 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   as it is attached, so linking a deep chain one level at a time costs the sum of all subtree sizes. Skipping
   the preflight is sound here — never elsewhere — because every node `copyNode` returns is freshly allocated
   in `dc.dst` and has never been linked as an owned child. The `EntityRefNode` branch uses the active entity
-  correspondence when its declaration is part of the copy, then falls back to destination name lookup; a
-  declared reference carries the destination DTD's shared `Entity` child, and that declaration graph is disjoint
-  from the fresh document subtree and cannot reach the new parent. Within a DTD entity's parsed replacement
-  subtree, the same direct link is sound between fresh nodes. Each completed top-level replacement child is
-  attached to its destination `Entity` through the same direct linker only after `copyDTDReplacements`
-  validates the complete prospective declaration graph once with shared visit state. The shared state visits
-  each node once across chained declarations while retaining cycle rejection.
+  correspondence when its source reference is bound to a declaration included in the copy. With an active
+  correspondence, an unbound source reference stays bare even when the copied DTD has a declaration with the
+  same name; standalone `CopyNode` instead uses destination name lookup. Numeric character references always
+  stay bare. A declared reference carries the destination DTD's shared `Entity` child, and that declaration
+  graph is disjoint from the fresh document subtree and cannot reach the new parent. Within a DTD entity's
+  parsed replacement subtree, the same direct link is sound between fresh nodes. Each completed top-level
+  replacement child is attached to its destination `Entity` through the same direct linker only after
+  `copyDTDReplacements` validates the complete prospective declaration graph once with shared visit state.
+  The shared state visits each node once across chained declarations while retaining cycle rejection.
   `appendCopiedChild`
   is distinct from `appendFastChild` — it is not used outside the copier — because `appendFastChild` also
   backs `xslt3`'s strip-space copier, and widening its linking rule to add a merge check would change behavior
   for that unrelated caller too. `CopyDoc` builds both DTD subsets before the fresh document child list so
-  copied references bind to the copies of their actual source declarations, but records the external subset's
+  bound references bind to the copies of their actual source declarations, but records the external subset's
   off-chain claim only after the child list is complete. Each document-level append can therefore use the recorded
   owned tail instead of walking the growing child list.
 - `DeclareNamespace(prefix, uri)` / `AddNamespaceDecl(ns)` — do NOT themselves add a second declaration for a

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -200,8 +200,11 @@ elements corresponding exactly to the source's, and at O(1). Re-deriving them wo
 walk. The fallback walk consults ID-typed ATTLIST declarations by their raw qualified name (prefix+local), so
 it correctly resolves a prefixed element's qualified ATTLIST (`<!ATTLIST a:item eid ID>`) — but rebuilding
 from the source table is still preferred for identity and cost fidelity. `CopyDoc` also DEEP-COPIES the
-source's external subset (via `CopyExtSubset`), so the copy's fallback walk sees the same ID-typed ATTLIST
-decls as the source. `helium.CopyExtSubset(src, dst *Document)` DEEP-COPIES the source's external subset into
+source's external subset (via `CopyDTDSubsets`), so the copy's fallback walk sees the same ID-typed ATTLIST
+decls as the source. `helium.CopyDTDSubsets(src, dst *Document)` registers declarations from BOTH subsets
+before copying entity replacement trees, so a reference across the subset boundary resolves to the copy's
+destination-owned declaration. `helium.CopyExtSubset(src, dst *Document)` DEEP-COPIES the source's external
+subset into
 `dst` (independent `*DTD`; mutating one never affects the other); `CopyDTDInfo`, by contrast, copies only the
 internal subset and links it into the document tree (and returns an error when `dst` already has one).
 
@@ -288,11 +291,12 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   endpoint itself is a no-op before auto-unlink, so it also leaves both links unchanged. The guarded paths
   therefore detach no child from a chain it goes on claiming, and create no claim of their own. A `*Document`
   parent is NOT declined by type: a document's child list is an ordinary sibling chain that an append walks
-  exactly like any other. A document IS the one parent safe API hands such a claimant, through `CopyExtSubset`,
+  exactly like any other. A document IS the one parent safe API hands such a claimant, through the DTD-subset
+  copy paths,
   which gives the copied EXTERNAL subset the destination document as its parent and then leaves it reachable
   only through `ExtSubset`, never from the child list, so an append through that subset records a tail off the
   child list.
-  That is a CONDITION, not a type, and `Document.offChainChildClaim` (`document.go`, set by `CopyExtSubset`)
+  That is a CONDITION, not a type, and `Document.offChainChildClaim` (`document.go`, set by `copy_dtd.go`)
   records it on that document as the claimed PARENT, so it declines only for appends onto the document node
   itself and never for the elements that document owns. (`CreateInternalSubset` also gives a `DTD` the document
   as its parent, but it splices that `DTD` into the child list, so it creates no claim.) Every other parent
@@ -361,8 +365,10 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   the preflight is sound here — never elsewhere — because every node `copyNode` returns is freshly allocated
   in `dc.dst` and has never been linked as an owned child. The `EntityRefNode` branch uses `CreateReference`, so
   a declared reference carries the destination DTD's shared `Entity` child; that declaration graph is disjoint
-  from the fresh document subtree and cannot reach the new parent. Copying a DTD entity's parsed replacement
-  subtree uses ordinary `AddChild` instead, because its references can point within the declaration graph.
+  from the fresh document subtree and cannot reach the new parent. Within a DTD entity's parsed replacement
+  subtree, the same direct link is sound between fresh nodes. Each completed top-level replacement child is
+  attached to its destination `Entity` through ordinary `AddChild`, because its references can point within
+  the declaration graph and require one cycle preflight.
   `appendCopiedChild`
   is distinct from `appendFastChild` — it is not used outside the copier — because `appendFastChild` also
   backs `xslt3`'s strip-space copier, and widening its linking rule to add a merge check would change behavior
@@ -518,7 +524,8 @@ scan, never a raw `NextSibling()` walk, so a hang cannot precede the `Walk`-base
 with one exception: `addSibling`'s fallback walk (above) is a raw, unbounded `NextSibling()` walk, so calling
 `AddSibling` through a node whose sibling list is cyclic hangs forever. The document root-element scans
 (`Document.DocumentElement`/`SetDocumentElement`/`CreateInternalSubset`) and the deep-copy (`copyChildren`,
-`copyDTDChildren`) and serializer child descents iterate the SOURCE through `Children` (bounding a corrupt
+`copyDTDDeclarations`, `copyDTDReplacements`) and serializer child descents iterate the SOURCE through
+`Children` (bounding a corrupt
 source sibling list); `copyChildren` links each copied child into the destination via `appendCopiedChild`
 (above), not `Children`; `setListDoc` (the `SetTreeDoc` sibling walker) and the serializer's attribute-chain
 walk each carry a per-list seen guard (the latter also terminates a non-`*Attribute` successor that would

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -359,14 +359,17 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   depth: bottom-up child-linking through `AddChild` runs `childReaches` over each already-built child subtree
   as it is attached, so linking a deep chain one level at a time costs the sum of all subtree sizes. Skipping
   the preflight is sound here — never elsewhere — because every node `copyNode` returns is freshly allocated
-  in `dc.dst` and has never been linked anywhere: `CreateCharRef` (the `EntityRefNode` branch) creates a
-  childless `EntityRef` with no shared-Entity foreign link, unlike `CreateReference`, so a copied subtree can
-  never carry the one production foreign-link source `wouldCreateCycle` exists to catch. `appendCopiedChild`
+  in `dc.dst` and has never been linked as an owned child. The `EntityRefNode` branch uses `CreateReference`, so
+  a declared reference carries the destination DTD's shared `Entity` child; that declaration graph is disjoint
+  from the fresh document subtree and cannot reach the new parent. Copying a DTD entity's parsed replacement
+  subtree uses ordinary `AddChild` instead, because its references can point within the declaration graph.
+  `appendCopiedChild`
   is distinct from `appendFastChild` — it is not used outside the copier — because `appendFastChild` also
   backs `xslt3`'s strip-space copier, and widening its linking rule to add a merge check would change behavior
-  for that unrelated caller too. `CopyDoc` builds the fresh document child list before `CopyExtSubset` records
-  its off-chain claim on the destination document, so each document-level append can use the recorded owned
-  tail instead of walking the growing child list.
+  for that unrelated caller too. `CopyDoc` builds both DTD subsets before the fresh document child list so
+  copied references resolve against destination declarations, but records the external subset's off-chain claim
+  only after the child list is complete. Each document-level append can therefore use the recorded owned tail
+  instead of walking the growing child list.
 - `DeclareNamespace(prefix, uri)` / `AddNamespaceDecl(ns)` — do NOT themselves add a second declaration for a
   prefix in `nsDefs`, and NEVER touch the node's active namespace (`n.ns`) or expanded name.
   `DeclareNamespace` allocates a fresh `*Namespace`; `AddNamespaceDecl` attaches the caller's existing object

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -203,7 +203,12 @@ from the source table is still preferred for identity and cost fidelity. `CopyDo
 source's external subset (via `CopyDTDSubsets`), so the copy's fallback walk sees the same ID-typed ATTLIST
 decls as the source. `helium.CopyDTDSubsets(src, dst *Document)` returns the source-to-copy entity declaration
 correspondence and registers declarations from BOTH subsets before copying entity replacement trees, so each
-reference across the subset boundary binds to the copy of its actual source declaration.
+reference across the subset boundary binds to the copy of its actual source declaration. Copied replacement
+elements reproduce only their own namespace declarations; an active prefix cached by the parser stays name
+metadata without becoming a declaration, so C14N resolves it from each EntityRef site's namespace context.
+The xslt3 strip-space copy keeps the copied DTD declaration unchanged and binds each document reference to a
+private replacement view keyed by its containing element and inherited `xml:space` state. This
+lets top-level replacement whitespace follow each reference site's rules without changing another reference.
 `helium.CopyExtSubset(src, dst *Document)` DEEP-COPIES the source's external
 subset into
 `dst` (independent `*DTD`; mutating one never affects the other); `CopyDTDInfo`, by contrast, copies only the
@@ -356,8 +361,8 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   last child WITHOUT the cycle-guard / duplicate-attr checks. The caller guarantees an acyclic, dup-free child
   (deep copies, freshly-built trees). Ordinary code uses `AddChild`. It backs the parser's fast SAX path
   in-package; `xslt3`'s strip-space copier reaches it through the `internal/nodelink` hook `AppendFastChild`,
-  reaches `bindEntityReference` through `BindEntityReference`, and reaches the sealed-node-capable
-  `unlinkNode` through `Unlink`,
+  reaches `bindEntityReference` through `BindEntityReference`, and creates private context-specific entity
+  views through `CloneEntityReferenceBinding`,
   and the external `helium_test` package through `UnsafeAppendChildForTesting` in `export_test.go`.
 - `appendCopiedChild(parent, child)` (`copy_deep.go`) — the deep-copy core's own no-preflight link, used by
   `copyChildren` in place of `AddChild`. It mirrors `addChild`'s linking rules exactly, INCLUDING the

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -374,8 +374,10 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   in `dc.dst` and has never been linked as an owned child. The `EntityRefNode` branch uses the active entity
   correspondence when its source reference is bound to a declaration included in the copy. With an active
   correspondence, an unbound source reference stays bare even when the copied DTD has a declaration with the
-  same name; standalone `CopyNode` instead uses destination name lookup. Numeric character references always
-  stay bare. A declared reference carries the destination DTD's shared `Entity` child, and that declaration
+  same name; standalone `CopyNode` first resolves a bound reference in the corresponding destination subset,
+  preserving internal/external identity when both subsets declare the same name, then falls back to ordinary
+  destination name lookup. Numeric character references always stay bare. A declared reference carries the
+  destination DTD's shared `Entity` child, and that declaration
   graph is disjoint from the fresh document subtree and cannot reach the new parent. Within a DTD entity's
   parsed replacement subtree, the same direct link is sound between fresh nodes. Each completed top-level
   replacement child is attached to its destination `Entity` through the same direct linker only after

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -202,8 +202,8 @@ it correctly resolves a prefixed element's qualified ATTLIST (`<!ATTLIST a:item 
 from the source table is still preferred for identity and cost fidelity. `CopyDoc` also DEEP-COPIES the
 source's external subset (via `CopyDTDSubsets`), so the copy's fallback walk sees the same ID-typed ATTLIST
 decls as the source. `helium.CopyDTDSubsets(src, dst *Document)` registers declarations from BOTH subsets
-before copying entity replacement trees, so a reference across the subset boundary resolves to the copy's
-destination-owned declaration. `helium.CopyExtSubset(src, dst *Document)` DEEP-COPIES the source's external
+before copying entity replacement trees, so each reference across the subset boundary binds to the copy of
+its actual source declaration. `helium.CopyExtSubset(src, dst *Document)` DEEP-COPIES the source's external
 subset into
 `dst` (independent `*DTD`; mutating one never affects the other); `CopyDTDInfo`, by contrast, copies only the
 internal subset and links it into the document tree (and returns an error when `dst` already has one).
@@ -363,8 +363,9 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   depth: bottom-up child-linking through `AddChild` runs `childReaches` over each already-built child subtree
   as it is attached, so linking a deep chain one level at a time costs the sum of all subtree sizes. Skipping
   the preflight is sound here — never elsewhere — because every node `copyNode` returns is freshly allocated
-  in `dc.dst` and has never been linked as an owned child. The `EntityRefNode` branch uses `CreateReference`, so
-  a declared reference carries the destination DTD's shared `Entity` child; that declaration graph is disjoint
+  in `dc.dst` and has never been linked as an owned child. The `EntityRefNode` branch uses the active entity
+  correspondence when its declaration is part of the copy, then falls back to destination name lookup; a
+  declared reference carries the destination DTD's shared `Entity` child, and that declaration graph is disjoint
   from the fresh document subtree and cannot reach the new parent. Within a DTD entity's parsed replacement
   subtree, the same direct link is sound between fresh nodes. Each completed top-level replacement child is
   attached to its destination `Entity` through the same direct linker only after `copyDTDReplacements`
@@ -374,9 +375,9 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   is distinct from `appendFastChild` — it is not used outside the copier — because `appendFastChild` also
   backs `xslt3`'s strip-space copier, and widening its linking rule to add a merge check would change behavior
   for that unrelated caller too. `CopyDoc` builds both DTD subsets before the fresh document child list so
-  copied references resolve against destination declarations, but records the external subset's off-chain claim
-  only after the child list is complete. Each document-level append can therefore use the recorded owned tail
-  instead of walking the growing child list.
+  copied references bind to the copies of their actual source declarations, but records the external subset's
+  off-chain claim only after the child list is complete. Each document-level append can therefore use the recorded
+  owned tail instead of walking the growing child list.
 - `DeclareNamespace(prefix, uri)` / `AddNamespaceDecl(ns)` — do NOT themselves add a second declaration for a
   prefix in `nsDefs`, and NEVER touch the node's active namespace (`n.ns`) or expanded name.
   `DeclareNamespace` allocates a fresh `*Namespace`; `AddNamespaceDecl` attaches the caller's existing object

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -355,8 +355,9 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
 - `appendFastChild(parent, child)` (`tree_fastpath.go`) — package-private no-preflight append: links child as
   last child WITHOUT the cycle-guard / duplicate-attr checks. The caller guarantees an acyclic, dup-free child
   (deep copies, freshly-built trees). Ordinary code uses `AddChild`. It backs the parser's fast SAX path
-  in-package; `xslt3`'s strip-space copier reaches it through the `internal/nodelink` hook `AppendFastChild`
-  and reaches `bindEntityReference` through `BindEntityReference`,
+  in-package; `xslt3`'s strip-space copier reaches it through the `internal/nodelink` hook `AppendFastChild`,
+  reaches `bindEntityReference` through `BindEntityReference`, and reaches the sealed-node-capable
+  `unlinkNode` through `Unlink`,
   and the external `helium_test` package through `UnsafeAppendChildForTesting` in `export_test.go`.
 - `appendCopiedChild(parent, child)` (`copy_deep.go`) — the deep-copy core's own no-preflight link, used by
   `copyChildren` in place of `AddChild`. It mirrors `addChild`'s linking rules exactly, INCLUDING the

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -367,8 +367,9 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   a declared reference carries the destination DTD's shared `Entity` child; that declaration graph is disjoint
   from the fresh document subtree and cannot reach the new parent. Within a DTD entity's parsed replacement
   subtree, the same direct link is sound between fresh nodes. Each completed top-level replacement child is
-  attached to its destination `Entity` through ordinary `AddChild`, because its references can point within
-  the declaration graph and require one cycle preflight.
+  attached to its destination `Entity` through the same direct linker only after `copyDTDReplacements`
+  validates the complete prospective declaration graph once with shared visit state. The shared state visits
+  each node once across chained declarations while retaining cycle rejection.
   `appendCopiedChild`
   is distinct from `appendFastChild` — it is not used outside the copier — because `appendFastChild` also
   backs `xslt3`'s strip-space copier, and widening its linking rule to add a merge check would change behavior

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -201,9 +201,10 @@ walk. The fallback walk consults ID-typed ATTLIST declarations by their raw qual
 it correctly resolves a prefixed element's qualified ATTLIST (`<!ATTLIST a:item eid ID>`) — but rebuilding
 from the source table is still preferred for identity and cost fidelity. `CopyDoc` also DEEP-COPIES the
 source's external subset (via `CopyDTDSubsets`), so the copy's fallback walk sees the same ID-typed ATTLIST
-decls as the source. `helium.CopyDTDSubsets(src, dst *Document)` registers declarations from BOTH subsets
-before copying entity replacement trees, so each reference across the subset boundary binds to the copy of
-its actual source declaration. `helium.CopyExtSubset(src, dst *Document)` DEEP-COPIES the source's external
+decls as the source. `helium.CopyDTDSubsets(src, dst *Document)` returns the source-to-copy entity declaration
+correspondence and registers declarations from BOTH subsets before copying entity replacement trees, so each
+reference across the subset boundary binds to the copy of its actual source declaration.
+`helium.CopyExtSubset(src, dst *Document)` DEEP-COPIES the source's external
 subset into
 `dst` (independent `*DTD`; mutating one never affects the other); `CopyDTDInfo`, by contrast, copies only the
 internal subset and links it into the document tree (and returns an error when `dst` already has one).
@@ -354,7 +355,8 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
 - `appendFastChild(parent, child)` (`tree_fastpath.go`) — package-private no-preflight append: links child as
   last child WITHOUT the cycle-guard / duplicate-attr checks. The caller guarantees an acyclic, dup-free child
   (deep copies, freshly-built trees). Ordinary code uses `AddChild`. It backs the parser's fast SAX path
-  in-package; `xslt3`'s strip-space copier reaches it through the `internal/nodelink` hook `AppendFastChild`,
+  in-package; `xslt3`'s strip-space copier reaches it through the `internal/nodelink` hook `AppendFastChild`
+  and reaches `bindEntityReference` through `BindEntityReference`,
   and the external `helium_test` package through `UnsafeAppendChildForTesting` in `export_test.go`.
 - `appendCopiedChild(parent, child)` (`copy_deep.go`) — the deep-copy core's own no-preflight link, used by
   `copyChildren` in place of `AddChild`. It mirrors `addChild`'s linking rules exactly, INCLUDING the

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -323,8 +323,10 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   the document-level state a caller relies on (version/encoding/standalone, URL, property flags, SkipIDs, and
   the interned ID table rebuilt against the copy's own elements; no mutable map or DTD is aliased);
   DTD entity copies include their independent parsed replacement subtrees, so copied references retain the source's
-  string-value and canonical form without aliasing source nodes; `CopyDTDSubsets` registers BOTH subsets' declarations
-  before copying replacement trees, so references across the subset boundary resolve to destination-owned entities;
+  string-value and canonical form without aliasing source nodes; `CopyDoc` and `CopyDTDSubsets` carry each source
+  entity declaration's identity into its copy, so a copied reference binds to the copy of its actual declaration even
+  when the internal and external subsets contain the same name; `CopyDTDSubsets` registers BOTH subsets' declarations
+  before copying replacement trees, so references across the subset boundary bind to destination-owned entities;
   `CopyDTDInfo` copies the INTERNAL subset's metadata +
   entities/elements/attributes/notations into `dst` and
   RETURNS an error (notably when `dst` already has an internal subset); `CopyExtSubset` gives `dst` its own

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -314,12 +314,16 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
 - `Walk(doc, fn)`, `Children(node)`, `Descendants(node)` — tree traversal. All accept a typed-nil node (e.g.
   `Document.DocumentElement()` of a rootless doc) without panicking: the iterators
   (`Children`/`ChildElements`/`Descendants`) yield nothing; `Walk` returns `ErrNilNode`
-- `CopyNode(src, targetDoc)` — deep copy across documents; a nil or typed-nil `src` returns `ErrNilNode` instead of panicking
+- `CopyNode(src, targetDoc)` — deep copy across documents; a nil or typed-nil `src` returns `ErrNilNode` instead of
+  panicking. A copied `EntityRef` resolves only against `targetDoc`'s declarations: a matching declaration installs
+  the destination-owned shared `Entity` child, while an absent declaration leaves the reference childless
 - `CopyDoc(src) → (*Document, error)` / `CopyDTDInfo(src, dst) → error` / `CopyExtSubset(src, dst)` —
   document-level deep copy: `CopyDoc` is a COMPLETE independent copy — the whole tree, BOTH DTD subsets, and
   the document-level state a caller relies on (version/encoding/standalone, URL, property flags, SkipIDs, and
   the interned ID table rebuilt against the copy's own elements; no mutable map or DTD is aliased);
-  `CopyDTDInfo` copies the INTERNAL subset's metadata + entities/elements/attributes/notations into `dst` and
+  DTD entity copies include their independent parsed replacement subtrees, so copied references retain the source's
+  string-value and canonical form without aliasing source nodes; `CopyDTDInfo` copies the INTERNAL subset's metadata +
+  entities/elements/attributes/notations into `dst` and
   RETURNS an error (notably when `dst` already has an internal subset); `CopyExtSubset` gives `dst` its own
   independent deep copy of the source's EXTERNAL DTD subset (`copy.go` / `copy_dtd.go` / `dtd.go`)
 - No-preflight child linkage and raw single-pointer linkage are package-private: `appendFastChild(parent

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -317,12 +317,15 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
 - `CopyNode(src, targetDoc)` — deep copy across documents; a nil or typed-nil `src` returns `ErrNilNode` instead of
   panicking. A copied `EntityRef` resolves only against `targetDoc`'s declarations: a matching declaration installs
   the destination-owned shared `Entity` child, while an absent declaration leaves the reference childless
-- `CopyDoc(src) → (*Document, error)` / `CopyDTDInfo(src, dst) → error` / `CopyExtSubset(src, dst)` —
+- `CopyDoc(src) → (*Document, error)` / `CopyDTDSubsets(src, dst) → error` /
+  `CopyDTDInfo(src, dst) → error` / `CopyExtSubset(src, dst)` —
   document-level deep copy: `CopyDoc` is a COMPLETE independent copy — the whole tree, BOTH DTD subsets, and
   the document-level state a caller relies on (version/encoding/standalone, URL, property flags, SkipIDs, and
   the interned ID table rebuilt against the copy's own elements; no mutable map or DTD is aliased);
   DTD entity copies include their independent parsed replacement subtrees, so copied references retain the source's
-  string-value and canonical form without aliasing source nodes; `CopyDTDInfo` copies the INTERNAL subset's metadata +
+  string-value and canonical form without aliasing source nodes; `CopyDTDSubsets` registers BOTH subsets' declarations
+  before copying replacement trees, so references across the subset boundary resolve to destination-owned entities;
+  `CopyDTDInfo` copies the INTERNAL subset's metadata +
   entities/elements/attributes/notations into `dst` and
   RETURNS an error (notably when `dst` already has an internal subset); `CopyExtSubset` gives `dst` its own
   independent deep copy of the source's EXTERNAL DTD subset (`copy.go` / `copy_dtd.go` / `dtd.go`)

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -316,7 +316,9 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   (`Children`/`ChildElements`/`Descendants`) yield nothing; `Walk` returns `ErrNilNode`
 - `CopyNode(src, targetDoc)` — deep copy across documents; a nil or typed-nil `src` returns `ErrNilNode` instead of
   panicking. A nil `targetDoc` creates a standalone copy. A copied named `EntityRef` resolves only against a
-  non-nil `targetDoc`'s declarations: a matching declaration installs the destination-owned shared `Entity` child,
+  non-nil `targetDoc`'s declarations: a bound source reference first resolves in the corresponding destination
+  internal or external subset, preserving subset identity when both declare the same name, then falls back to
+  ordinary destination name lookup. A matching declaration installs the destination-owned shared `Entity` child,
   while an absent declaration or nil target leaves the reference childless. A numeric character reference always
   remains bare
 - `CopyDoc(src) → (*Document, error)` /

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -346,7 +346,7 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   `AddChild`/`AddSibling`/`Replace`/`AppendText`/`SetLine`/`SetOwnerDocument`/`SetTreeDoc`), so ordinary tree
   mutation cannot reach them by accident, and there is no public entry point to any of them. Sibling packages
   in this module reach them through the `internal/nodelink` hooks (`AppendFastChild`, `BindEntityReference`, and
-  `Unlink` for `xslt3`'s strip-space copier; `CorruptSelfNextSibling` and
+  `CloneEntityReferenceBinding` for `xslt3`'s strip-space copier; `CorruptSelfNextSibling` and
   `CorruptTypedNilNextSibling` for the `xsd`/`xmldsig1` corrupt-tree cycle-guard fixtures only); the external
   `helium_test` package reaches them through the `*ForTesting`
   wrappers in `export_test.go`. There is no `prev`-pointer setter

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -315,8 +315,9 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   `Document.DocumentElement()` of a rootless doc) without panicking: the iterators
   (`Children`/`ChildElements`/`Descendants`) yield nothing; `Walk` returns `ErrNilNode`
 - `CopyNode(src, targetDoc)` — deep copy across documents; a nil or typed-nil `src` returns `ErrNilNode` instead of
-  panicking. A copied `EntityRef` resolves only against `targetDoc`'s declarations: a matching declaration installs
-  the destination-owned shared `Entity` child, while an absent declaration leaves the reference childless
+  panicking. A copied named `EntityRef` resolves only against `targetDoc`'s declarations: a matching declaration
+  installs the destination-owned shared `Entity` child, while an absent declaration leaves the reference childless.
+  A numeric character reference always remains bare
 - `CopyDoc(src) → (*Document, error)` /
   `CopyDTDSubsets(src, dst) → (map[*Entity]*Entity, error)` /
   `CopyDTDInfo(src, dst) → error` / `CopyExtSubset(src, dst)` —
@@ -325,10 +326,12 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   the interned ID table rebuilt against the copy's own elements; no mutable map or DTD is aliased);
   DTD entity copies include their independent parsed replacement subtrees, so copied references retain the source's
   string-value and canonical form without aliasing source nodes; `CopyDoc` and `CopyDTDSubsets` carry each source
-  entity declaration's identity into its copy, so a copied reference binds to the copy of its actual declaration even
-  when the internal and external subsets contain the same name; `CopyDTDSubsets` returns that source-to-copy entity
-  correspondence for callers that copy document content separately, and registers BOTH subsets' declarations before
-  copying replacement trees, so references across the subset boundary bind to destination-owned entities;
+  entity declaration's identity into its copy, so a bound copied reference binds to the copy of its actual declaration
+  even when the internal and external subsets contain the same name. `CopyDoc` keeps a childless source reference
+  childless even when its copied DTD contains a declaration with the same name. `CopyDTDSubsets` returns that
+  source-to-copy entity correspondence for callers that copy document content separately, and registers BOTH
+  subsets' declarations before copying replacement trees, so references across the subset boundary bind to
+  destination-owned entities;
   `CopyDTDInfo` copies the INTERNAL subset's metadata +
   entities/elements/attributes/notations into `dst` and
   RETURNS an error (notably when `dst` already has an internal subset); `CopyExtSubset` gives `dst` its own

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -315,9 +315,10 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   `Document.DocumentElement()` of a rootless doc) without panicking: the iterators
   (`Children`/`ChildElements`/`Descendants`) yield nothing; `Walk` returns `ErrNilNode`
 - `CopyNode(src, targetDoc)` — deep copy across documents; a nil or typed-nil `src` returns `ErrNilNode` instead of
-  panicking. A copied named `EntityRef` resolves only against `targetDoc`'s declarations: a matching declaration
-  installs the destination-owned shared `Entity` child, while an absent declaration leaves the reference childless.
-  A numeric character reference always remains bare
+  panicking. A nil `targetDoc` creates a standalone copy. A copied named `EntityRef` resolves only against a
+  non-nil `targetDoc`'s declarations: a matching declaration installs the destination-owned shared `Entity` child,
+  while an absent declaration or nil target leaves the reference childless. A numeric character reference always
+  remains bare
 - `CopyDoc(src) → (*Document, error)` /
   `CopyDTDSubsets(src, dst) → (map[*Entity]*Entity, error)` /
   `CopyDTDInfo(src, dst) → error` / `CopyExtSubset(src, dst)` —
@@ -344,8 +345,8 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   interface (which exposes only guarded mutation:
   `AddChild`/`AddSibling`/`Replace`/`AppendText`/`SetLine`/`SetOwnerDocument`/`SetTreeDoc`), so ordinary tree
   mutation cannot reach them by accident, and there is no public entry point to any of them. Sibling packages
-  in this module reach them through the `internal/nodelink` hooks (`AppendFastChild` and
-  `BindEntityReference` for `xslt3`'s strip-space copier; `CorruptSelfNextSibling` and
+  in this module reach them through the `internal/nodelink` hooks (`AppendFastChild`, `BindEntityReference`, and
+  `Unlink` for `xslt3`'s strip-space copier; `CorruptSelfNextSibling` and
   `CorruptTypedNilNextSibling` for the `xsd`/`xmldsig1` corrupt-tree cycle-guard fixtures only); the external
   `helium_test` package reaches them through the `*ForTesting`
   wrappers in `export_test.go`. There is no `prev`-pointer setter

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -317,7 +317,8 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
 - `CopyNode(src, targetDoc)` — deep copy across documents; a nil or typed-nil `src` returns `ErrNilNode` instead of
   panicking. A copied `EntityRef` resolves only against `targetDoc`'s declarations: a matching declaration installs
   the destination-owned shared `Entity` child, while an absent declaration leaves the reference childless
-- `CopyDoc(src) → (*Document, error)` / `CopyDTDSubsets(src, dst) → error` /
+- `CopyDoc(src) → (*Document, error)` /
+  `CopyDTDSubsets(src, dst) → (map[*Entity]*Entity, error)` /
   `CopyDTDInfo(src, dst) → error` / `CopyExtSubset(src, dst)` —
   document-level deep copy: `CopyDoc` is a COMPLETE independent copy — the whole tree, BOTH DTD subsets, and
   the document-level state a caller relies on (version/encoding/standalone, URL, property flags, SkipIDs, and
@@ -325,8 +326,9 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   DTD entity copies include their independent parsed replacement subtrees, so copied references retain the source's
   string-value and canonical form without aliasing source nodes; `CopyDoc` and `CopyDTDSubsets` carry each source
   entity declaration's identity into its copy, so a copied reference binds to the copy of its actual declaration even
-  when the internal and external subsets contain the same name; `CopyDTDSubsets` registers BOTH subsets' declarations
-  before copying replacement trees, so references across the subset boundary bind to destination-owned entities;
+  when the internal and external subsets contain the same name; `CopyDTDSubsets` returns that source-to-copy entity
+  correspondence for callers that copy document content separately, and registers BOTH subsets' declarations before
+  copying replacement trees, so references across the subset boundary bind to destination-owned entities;
   `CopyDTDInfo` copies the INTERNAL subset's metadata +
   entities/elements/attributes/notations into `dst` and
   RETURNS an error (notably when `dst` already has an internal subset); `CopyExtSubset` gives `dst` its own
@@ -339,9 +341,10 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   interface (which exposes only guarded mutation:
   `AddChild`/`AddSibling`/`Replace`/`AppendText`/`SetLine`/`SetOwnerDocument`/`SetTreeDoc`), so ordinary tree
   mutation cannot reach them by accident, and there is no public entry point to any of them. Sibling packages
-  in this module reach them through the `internal/nodelink` hooks (`AppendFastChild` for `xslt3`'s strip-space
-  copier; `CorruptSelfNextSibling` and `CorruptTypedNilNextSibling` for the `xsd`/`xmldsig1` corrupt-tree
-  cycle-guard fixtures only); the external `helium_test` package reaches them through the `*ForTesting`
+  in this module reach them through the `internal/nodelink` hooks (`AppendFastChild` and
+  `BindEntityReference` for `xslt3`'s strip-space copier; `CorruptSelfNextSibling` and
+  `CorruptTypedNilNextSibling` for the `xsd`/`xmldsig1` corrupt-tree cycle-guard fixtures only); the external
+  `helium_test` package reaches them through the `*ForTesting`
   wrappers in `export_test.go`. There is no `prev`-pointer setter
 - `Document.SetDocumentElement(root MutableNode) → error` — sets/replaces the document element; `root` must be
   an element (non-element kind → `ErrInvalidOperation`, nil/typed-nil root or nil receiver → `ErrNilNode`),

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -99,7 +99,7 @@ bug that prompted it.
 | `node_leaf_test.go` | root | Text/Comment/CDATA/PI/Entity/Notation node methods and guards |
 | `node_namespace_test.go` | root | `DeclareNamespace` collapse and namespace lookup |
 | `tree_test.go` | root | Base URIs, tree mutation, `Walk`, node accessors |
-| `copy_test.go` | root | `CopyNode`/`CopyDoc`/`CopyDTDInfo`/`CopyExtSubset` deep-copy coverage; DTD attribute-declaration order fidelity |
+| `copy_test.go` | root | `CopyNode`/`CopyDoc`/`CopyDTDSubsets`/`CopyDTDInfo`/`CopyExtSubset` deep-copy coverage; DTD attribute-declaration order fidelity |
 | `dtd_test.go` | root | DTD data-model: internal-subset accessors, element/attr/notation decls, node wrappers |
 | `valid_test.go` | root | Document-level DTD validation and external-subset lookup |
 | `valid_dtd_decl_test.go` | root | DTD declaration-consistency VCs and declaration-order stability of their diagnostics |

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -34,6 +34,28 @@ func readExpected(t *testing.T, path string) []byte {
 	return data
 }
 
+func TestCanonicalizeCopiedEntityReferences(t *testing.T) {
+	t.Parallel()
+
+	const srcXML = `<!DOCTYPE root [<!ENTITY item "<p:item xmlns:p='urn:item'>A&amp;B</p:item>">]>` +
+		`<root xmlns:p="urn:item">&item;&item;</root>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(srcXML))
+	require.NoError(t, err)
+	copied, err := helium.CopyDoc(doc)
+	require.NoError(t, err)
+
+	canonicalizer := c14n.NewCanonicalizer(c14n.C14N10)
+	want, err := canonicalizer.CanonicalizeTo(doc)
+	require.NoError(t, err)
+	got, err := canonicalizer.CanonicalizeTo(copied)
+	require.NoError(t, err)
+	require.Equal(t, string(want), string(got))
+	require.Equal(t,
+		`<root xmlns:p="urn:item"><p:item>A&amp;B</p:item><p:item>A&amp;B</p:item></root>`,
+		string(got),
+	)
+}
+
 // parseXPathFile parses a .xpath file and returns the XPath expression
 // string and namespace bindings.
 func parseXPathFile(t *testing.T, path string) (string, map[string]string) {

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -56,6 +56,34 @@ func TestCanonicalizeCopiedEntityReferences(t *testing.T) {
 	)
 }
 
+func TestCanonicalizeCopiedEntityReferencesUsesEachReferenceSite(t *testing.T) {
+	t.Parallel()
+
+	const srcXML = `<!DOCTYPE r [<!ENTITY x "<p:x/>">]>` +
+		`<r><a xmlns:p="urn:one">&x;</a><b xmlns:p="urn:two">&x;</b></r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(srcXML))
+	require.NoError(t, err)
+	copied, err := helium.CopyDoc(doc)
+	require.NoError(t, err)
+	copiedEntity, found := copied.IntSubset().LookupEntity("x")
+	require.True(t, found)
+	replacement, ok := helium.AsNode[*helium.Element](copiedEntity.FirstChild())
+	require.True(t, ok)
+	require.Empty(t, replacement.Namespaces())
+	require.Equal(t, "p", replacement.Prefix())
+
+	canonicalizer := c14n.NewCanonicalizer(c14n.C14N10)
+	want, err := canonicalizer.CanonicalizeTo(doc)
+	require.NoError(t, err)
+	got, err := canonicalizer.CanonicalizeTo(copied)
+	require.NoError(t, err)
+	require.Equal(t, string(want), string(got))
+	require.Equal(t,
+		`<r><a xmlns:p="urn:one"><p:x></p:x></a><b xmlns:p="urn:two"><p:x></p:x></b></r>`,
+		string(got),
+	)
+}
+
 // parseXPathFile parses a .xpath file and returns the XPath expression
 // string and namespace bindings.
 func parseXPathFile(t *testing.T, path string) (string, map[string]string) {

--- a/copy.go
+++ b/copy.go
@@ -26,8 +26,8 @@ func CopyNode(src Node, targetDoc *Document) (Node, error) {
 			return nil, fmt.Errorf("helium: unexpected ElementNode type %T", src)
 		}
 		// The general copy path over-declares namespaces (load-bearing for
-		// streaming's fixNamespacesAfterCopy) and links with the preflighted
-		// AddChild, copying every node. See deepCopyOptions for the knobs.
+		// streaming's fixNamespacesAfterCopy) and uses the copier-only direct
+		// linker. See deepCopyOptions for the knobs.
 		dc := &deepCopier{dst: targetDoc, opts: deepCopyOptions{overDeclareNS: true}}
 		return dc.copyElement(elem, nil, nil)
 	case TextNode:

--- a/copy.go
+++ b/copy.go
@@ -86,19 +86,17 @@ func CopyDoc(src *Document) (*Document, error) {
 	// resolve to destination-owned declarations. The external subset's off-chain
 	// parent claim is recorded after the child list is built to retain O(1)
 	// document appends.
-	if dtd := src.intSubset; dtd != nil {
-		if err := copyDTD(dtd, dst); err != nil {
-			return nil, err
-		}
+	if err := copyDTDSubsets(src, dst, false); err != nil {
+		return nil, err
 	}
-	copyExtSubset(src, dst, false)
 
 	// Copy all document children (the DTD was already handled) through the shared
-	// core in over-declare / AddChild mode, reproducing the historical behavior.
+	// core in over-declare mode, reproducing the historical behavior.
 	// onCopy records the source->copy element correspondence so the ID table can be
 	// rebuilt against the copy's own elements, aliasing nothing in the source map.
-	// Build this fresh child list before CopyExtSubset records its off-chain claim
-	// on dst; otherwise every append must walk the growing list to recover its tail.
+	// Build this fresh child list before the DTD-subset copy records its off-chain
+	// claim on dst; otherwise every append must walk the growing list to recover
+	// its tail.
 	var onCopy func(src, cp Node)
 	var corr elemCorrespondence
 	if len(src.ids) > 0 {

--- a/copy.go
+++ b/copy.go
@@ -3,6 +3,7 @@ package helium
 import (
 	"fmt"
 	"slices"
+	"strings"
 )
 
 // CopyNode creates a deep copy of src, owned by targetDoc.
@@ -51,20 +52,23 @@ func CopyNode(src Node, targetDoc *Document) (Node, error) {
 
 // copyEntityReference creates a fresh reference owned by targetDoc. When the
 // enclosing copy includes the source reference's actual declaration,
-// entityCopies binds the reference to that declaration's copy. Other callers
-// retain the name-based targetDoc lookup used by CopyNode. No path aliases the
-// source DTD or invents a destination declaration.
+// entityCopies binds the reference to that declaration's copy. A document copy
+// keeps an unbound source reference unbound even when the copied DTD has a
+// declaration with the same name. Other callers retain the name-based targetDoc
+// lookup used by CopyNode. Numeric character references always remain bare. No
+// path aliases the source DTD or invents a destination declaration.
 func copyEntityReference(
 	src Node,
 	targetDoc *Document,
 	entityCopies map[*Entity]*Entity,
 ) (*EntityRef, error) {
-	if targetDoc == nil {
-		return targetDoc.CreateCharRef(src.Name())
+	name := src.Name()
+	if strings.HasPrefix(name, "#") {
+		return targetDoc.CreateCharRef(name)
 	}
 	if srcEntity, ok := AsNode[*Entity](src.FirstChild()); ok {
 		if dstEntity := entityCopies[srcEntity]; dstEntity != nil {
-			ref, err := targetDoc.CreateCharRef(src.Name())
+			ref, err := targetDoc.CreateCharRef(name)
 			if err != nil {
 				return nil, err
 			}
@@ -72,17 +76,20 @@ func copyEntityReference(
 			return ref, nil
 		}
 	}
-	return targetDoc.CreateReference(src.Name())
+	if entityCopies != nil {
+		return targetDoc.CreateCharRef(name)
+	}
+	return targetDoc.CreateReference(name)
 }
 
 // CopyDoc creates a complete deep copy of a document: its children, its internal
 // AND external DTD subsets, and the document-level state a caller reasonably
 // relies on (the XML-declaration version/encoding/standalone, the base URI, the
 // property flags, the ID-skip state, and the interned ID table). The copy is
-// fully independent — the external subset is deep-copied, each entity reference
-// binds to the copy of its actual source declaration, and the ID table is rebuilt
-// against the copy's own elements. No mutable map or DTD is aliased between src
-// and the result. Mutating one document never affects the other.
+// fully independent — the external subset is deep-copied, each bound entity
+// reference binds to the copy of its actual source declaration, and the ID table
+// is rebuilt against the copy's own elements. No mutable map or DTD is aliased
+// between src and the result. Mutating one document never affects the other.
 func CopyDoc(src *Document) (*Document, error) {
 	if src == nil {
 		return nil, fmt.Errorf("helium: cannot copy nil document")

--- a/copy.go
+++ b/copy.go
@@ -39,7 +39,7 @@ func CopyNode(src Node, targetDoc *Document) (Node, error) {
 	case ProcessingInstructionNode:
 		return targetDoc.CreatePI(src.Name(), string(src.Content())), nil
 	case EntityRefNode:
-		return targetDoc.CreateCharRef(src.Name())
+		return copyEntityReference(src, targetDoc)
 	case NamespaceNode:
 		// Namespace nodes are virtual; return a new wrapper with the same data.
 		ns := NewNamespace(src.Name(), string(src.Content()))
@@ -47,6 +47,17 @@ func CopyNode(src Node, targetDoc *Document) (Node, error) {
 	default:
 		return nil, fmt.Errorf("helium: cannot copy node of type %s", src.Type())
 	}
+}
+
+// copyEntityReference creates a fresh reference and resolves it only against
+// declarations owned by targetDoc. It therefore preserves declared replacement
+// semantics without aliasing the source DTD or inventing a destination
+// declaration. The nil receiver behavior matches the other leaf constructors.
+func copyEntityReference(src Node, targetDoc *Document) (*EntityRef, error) {
+	if targetDoc == nil {
+		return targetDoc.CreateCharRef(src.Name())
+	}
+	return targetDoc.CreateReference(src.Name())
 }
 
 // CopyDoc creates a complete deep copy of a document: its children, its internal
@@ -71,12 +82,16 @@ func CopyDoc(src *Document) (*Document, error) {
 	dst.properties = src.properties
 	dst.idsSkip = src.idsSkip
 
-	// Deep-copy DTD (metadata + entities, elements, attributes, notations).
+	// Deep-copy both DTD subsets before document content so EntityRef copies can
+	// resolve to destination-owned declarations. The external subset's off-chain
+	// parent claim is recorded after the child list is built to retain O(1)
+	// document appends.
 	if dtd := src.intSubset; dtd != nil {
 		if err := copyDTD(dtd, dst); err != nil {
 			return nil, err
 		}
 	}
+	copyExtSubset(src, dst, false)
 
 	// Copy all document children (the DTD was already handled) through the shared
 	// core in over-declare / AddChild mode, reproducing the historical behavior.
@@ -95,10 +110,9 @@ func CopyDoc(src *Document) (*Document, error) {
 		return nil, err
 	}
 
-	// Deep-copy the external subset too (independent *DTD, not aliased). The lazy
-	// GetElementByID fallback consults it for ID-typed ATTLIST declarations, so a
-	// copy that dropped it would resolve fewer ids than the source.
-	CopyExtSubset(src, dst)
+	if dst.extSubset != nil {
+		dst.offChainChildClaim = true
+	}
 
 	// Rebuild the interned ID table by translating each source entry's element
 	// through the source->copy correspondence, so id()/GetElementByID on the copy

--- a/copy.go
+++ b/copy.go
@@ -55,9 +55,11 @@ func CopyNode(src Node, targetDoc *Document) (Node, error) {
 // enclosing copy includes the source reference's actual declaration,
 // entityCopies binds the reference to that declaration's copy. A document copy
 // keeps an unbound source reference unbound even when the copied DTD has a
-// declaration with the same name. Other callers retain the name-based targetDoc
-// lookup used by CopyNode. Numeric character references always remain bare. No
-// path aliases the source DTD or invents a destination declaration.
+// declaration with the same name. CopyNode first looks in the corresponding
+// destination subset for a bound source reference, then falls back to the
+// destination's ordinary name lookup. Numeric character references always
+// remain bare. No path aliases the source DTD or invents a destination
+// declaration.
 func copyEntityReference(
 	src Node,
 	targetDoc *Document,
@@ -71,7 +73,11 @@ func copyEntityReference(
 		return targetDoc.CreateCharRef(name)
 	}
 	if srcEntity, ok := AsNode[*Entity](src.FirstChild()); ok {
-		if dstEntity := entityCopies[srcEntity]; dstEntity != nil {
+		dstEntity := entityCopies[srcEntity]
+		if entityCopies == nil {
+			dstEntity = correspondingSubsetEntity(src, srcEntity, targetDoc)
+		}
+		if dstEntity != nil {
 			ref, err := targetDoc.CreateCharRef(name)
 			if err != nil {
 				return nil, err
@@ -84,6 +90,32 @@ func copyEntityReference(
 		return targetDoc.CreateCharRef(name)
 	}
 	return targetDoc.CreateReference(name)
+}
+
+// correspondingSubsetEntity finds the same-name destination declaration in
+// the subset that owns srcEntity. It preserves a bound reference's subset
+// identity when both destination subsets declare the same name.
+func correspondingSubsetEntity(src Node, srcEntity *Entity, targetDoc *Document) *Entity {
+	sourceDoc := src.OwnerDocument()
+	if sourceDoc == nil {
+		return nil
+	}
+
+	var targetSubset *DTD
+	switch srcEntity.Parent() {
+	case sourceDoc.intSubset:
+		targetSubset = targetDoc.intSubset
+	case sourceDoc.extSubset:
+		targetSubset = targetDoc.extSubset
+	default:
+		return nil
+	}
+	if targetSubset == nil {
+		return nil
+	}
+
+	dstEntity, _ := targetSubset.LookupEntity(src.Name())
+	return dstEntity
 }
 
 // CopyDoc creates a complete deep copy of a document: its children, its internal

--- a/copy.go
+++ b/copy.go
@@ -39,7 +39,7 @@ func CopyNode(src Node, targetDoc *Document) (Node, error) {
 	case ProcessingInstructionNode:
 		return targetDoc.CreatePI(src.Name(), string(src.Content())), nil
 	case EntityRefNode:
-		return copyEntityReference(src, targetDoc)
+		return copyEntityReference(src, targetDoc, nil)
 	case NamespaceNode:
 		// Namespace nodes are virtual; return a new wrapper with the same data.
 		ns := NewNamespace(src.Name(), string(src.Content()))
@@ -49,13 +49,28 @@ func CopyNode(src Node, targetDoc *Document) (Node, error) {
 	}
 }
 
-// copyEntityReference creates a fresh reference and resolves it only against
-// declarations owned by targetDoc. It therefore preserves declared replacement
-// semantics without aliasing the source DTD or inventing a destination
-// declaration. The nil receiver behavior matches the other leaf constructors.
-func copyEntityReference(src Node, targetDoc *Document) (*EntityRef, error) {
+// copyEntityReference creates a fresh reference owned by targetDoc. When the
+// enclosing copy includes the source reference's actual declaration,
+// entityCopies binds the reference to that declaration's copy. Other callers
+// retain the name-based targetDoc lookup used by CopyNode. No path aliases the
+// source DTD or invents a destination declaration.
+func copyEntityReference(
+	src Node,
+	targetDoc *Document,
+	entityCopies map[*Entity]*Entity,
+) (*EntityRef, error) {
 	if targetDoc == nil {
 		return targetDoc.CreateCharRef(src.Name())
+	}
+	if srcEntity, ok := AsNode[*Entity](src.FirstChild()); ok {
+		if dstEntity := entityCopies[srcEntity]; dstEntity != nil {
+			ref, err := targetDoc.CreateCharRef(src.Name())
+			if err != nil {
+				return nil, err
+			}
+			bindEntityReference(ref, dstEntity)
+			return ref, nil
+		}
 	}
 	return targetDoc.CreateReference(src.Name())
 }
@@ -64,9 +79,10 @@ func copyEntityReference(src Node, targetDoc *Document) (*EntityRef, error) {
 // AND external DTD subsets, and the document-level state a caller reasonably
 // relies on (the XML-declaration version/encoding/standalone, the base URI, the
 // property flags, the ID-skip state, and the interned ID table). The copy is
-// fully independent — the external subset is deep-copied and the ID table is
-// rebuilt against the copy's own elements, so no mutable map or DTD is aliased
-// between src and the result. Mutating one document never affects the other.
+// fully independent — the external subset is deep-copied, each entity reference
+// binds to the copy of its actual source declaration, and the ID table is rebuilt
+// against the copy's own elements. No mutable map or DTD is aliased between src
+// and the result. Mutating one document never affects the other.
 func CopyDoc(src *Document) (*Document, error) {
 	if src == nil {
 		return nil, fmt.Errorf("helium: cannot copy nil document")
@@ -83,10 +99,11 @@ func CopyDoc(src *Document) (*Document, error) {
 	dst.idsSkip = src.idsSkip
 
 	// Deep-copy both DTD subsets before document content so EntityRef copies can
-	// resolve to destination-owned declarations. The external subset's off-chain
-	// parent claim is recorded after the child list is built to retain O(1)
-	// document appends.
-	if err := copyDTDSubsets(src, dst, false); err != nil {
+	// bind to the copy of their actual source declaration. The external subset's
+	// off-chain parent claim is recorded after the child list is built to retain
+	// O(1) document appends.
+	entityCopies, err := copyDTDSubsets(src, dst, false)
+	if err != nil {
 		return nil, err
 	}
 
@@ -103,7 +120,14 @@ func CopyDoc(src *Document) (*Document, error) {
 		corr.m = make(map[*Element]*Element, len(src.ids))
 		onCopy = corr.record
 	}
-	dc := &deepCopier{dst: dst, opts: deepCopyOptions{overDeclareNS: true, onCopy: onCopy}}
+	dc := &deepCopier{
+		dst: dst,
+		opts: deepCopyOptions{
+			overDeclareNS: true,
+			onCopy:        onCopy,
+			entityCopies:  entityCopies,
+		},
+	}
 	if err := dc.copyChildren(src, dst, nil, nil); err != nil {
 		return nil, err
 	}

--- a/copy.go
+++ b/copy.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 )
 
-// CopyNode creates a deep copy of src, owned by targetDoc.
+// CopyNode creates a deep copy of src, owned by targetDoc. A nil targetDoc
+// creates a standalone copy.
 // Supports Element, Text, Comment, CDATASection, PI, and EntityRef nodes.
 //
 // A nil or typed-nil src (e.g. the *Element that Document.DocumentElement
@@ -64,6 +65,9 @@ func copyEntityReference(
 ) (*EntityRef, error) {
 	name := src.Name()
 	if strings.HasPrefix(name, "#") {
+		return targetDoc.CreateCharRef(name)
+	}
+	if targetDoc == nil {
 		return targetDoc.CreateCharRef(name)
 	}
 	if srcEntity, ok := AsNode[*Entity](src.FirstChild()); ok {

--- a/copy_deep.go
+++ b/copy_deep.go
@@ -9,21 +9,12 @@ import (
 // single set of "speed/shape primitives" that every deep-copy site in the tree
 // layer is expressed through: the leaf-node copy switch, the attribute copy
 // loop, and the namespace binding all live in one place and are selected by
-// these knobs. Child-linking normally uses appendCopiedChild (see its doc
-// comment). DTD entity replacement trees opt into AddChild's cycle preflight
-// because their copied EntityRef nodes can point into the copied declaration
-// graph.
+// these knobs. Child-linking uses appendCopiedChild (see its doc comment).
 //
 // The defaults (the zero value) select the general helium.CopyDoc/CopyNode
 // shape: over-declared namespaces, no filtering, no mapping. Callers that want
 // the faster shape opt in.
 type deepCopyOptions struct {
-	// preflightLinks selects MutableNode.AddChild instead of the direct copy-only
-	// linker. DTD entity replacement trees use it because their EntityRef nodes
-	// share destination declaration children and can therefore form graph edges
-	// outside the freshly allocated replacement subtree.
-	preflightLinks bool
-
 	// overDeclareNS selects the namespace-declaration strategy for elements.
 	//
 	// When true (the historical helium.CopyDoc behavior), every element
@@ -91,12 +82,6 @@ func (dc *deepCopier) copyChildren(src Node, parent MutableNode, inScope map[str
 		if child == nil {
 			continue
 		}
-		if dc.opts.preflightLinks {
-			if err := parent.AddChild(child); err != nil {
-				return err
-			}
-			continue
-		}
 		if err := appendCopiedChild(parent, child); err != nil {
 			return err
 		}
@@ -118,8 +103,9 @@ func (dc *deepCopier) copyChildren(src Node, parent MutableNode, inScope map[str
 // owned by dc.dst that has never been linked as an owned child. EntityRefNode
 // may carry the destination DTD's shared Entity declaration child, but that
 // declaration graph is disjoint from the fresh document subtree and therefore
-// cannot reach its new parent. DTD entity replacement trees use preflightLinks
-// instead because references there can point within the declaration graph.
+// cannot reach its new parent. DTD entity replacement trees use this linker
+// only between fresh nodes; their completed top-level children are attached to
+// the destination Entity through AddChild's cycle preflight.
 // Do NOT call this on a node from outside the copier: an arbitrary
 // caller-supplied child has no such guarantee.
 func appendCopiedChild(parent MutableNode, child Node) error {

--- a/copy_deep.go
+++ b/copy_deep.go
@@ -104,8 +104,8 @@ func (dc *deepCopier) copyChildren(src Node, parent MutableNode, inScope map[str
 // may carry the destination DTD's shared Entity declaration child, but that
 // declaration graph is disjoint from the fresh document subtree and therefore
 // cannot reach its new parent. DTD entity replacement trees use this linker
-// only between fresh nodes; their completed top-level children are attached to
-// the destination Entity through AddChild's cycle preflight.
+// between fresh nodes and for their completed top-level children only after one
+// shared-state validation has proved the prospective declaration graph acyclic.
 // Do NOT call this on a node from outside the copier: an arbitrary
 // caller-supplied child has no such guarantee.
 func appendCopiedChild(parent MutableNode, child Node) error {

--- a/copy_deep.go
+++ b/copy_deep.go
@@ -48,6 +48,10 @@ type deepCopyOptions struct {
 	// bookkeeping such as the strip-space node map and ID-table rebuild.
 	onCopy func(src, cp Node)
 
+	// entityCopies binds a copied EntityRef to the copy of its actual source
+	// declaration when a document or DTD copy includes that declaration.
+	entityCopies map[*Entity]*Entity
+
 	// afterElementAttrs, when non-nil, is invoked for each copied element AFTER
 	// its attributes have been copied (but before its children), with the source
 	// and copy elements. strip-space uses it to map attribute correspondence,
@@ -101,11 +105,12 @@ func (dc *deepCopier) copyChildren(src Node, parent MutableNode, inScope map[str
 // This is safe ONLY for a child that copyNode just returned while copying a
 // normal document or element tree. Every branch allocates a brand-new node
 // owned by dc.dst that has never been linked as an owned child. EntityRefNode
-// may carry the destination DTD's shared Entity declaration child, but that
-// declaration graph is disjoint from the fresh document subtree and therefore
-// cannot reach its new parent. DTD entity replacement trees use this linker
-// between fresh nodes and for their completed top-level children only after one
-// shared-state validation has proved the prospective declaration graph acyclic.
+// may carry a copied or name-resolved destination DTD declaration child, but
+// that declaration graph is disjoint from the fresh document subtree and
+// therefore cannot reach its new parent. DTD entity replacement trees use this
+// linker between fresh nodes and for their completed top-level children only
+// after one shared-state validation has proved the prospective declaration graph
+// acyclic.
 // Do NOT call this on a node from outside the copier: an arbitrary
 // caller-supplied child has no such guarantee.
 func appendCopiedChild(parent MutableNode, child Node) error {
@@ -188,7 +193,7 @@ func (dc *deepCopier) copyNode(src Node, parent *Element, inScope map[string]*Na
 		if dc.filtered(src, parent, parentState) {
 			return nil, nil //nolint:nilnil // omitted by filter
 		}
-		cp, err := copyEntityReference(src, dc.dst)
+		cp, err := copyEntityReference(src, dc.dst, dc.opts.entityCopies)
 		if err != nil {
 			return nil, err
 		}

--- a/copy_deep.go
+++ b/copy_deep.go
@@ -31,6 +31,13 @@ type deepCopyOptions struct {
 	// degenerate source whose active namespace is not in scope anywhere.
 	overDeclareNS bool
 
+	// entityReplacementNS preserves an entity replacement element's own nsDefs
+	// and active prefix metadata without declaring the parser-cached active
+	// namespace. Canonicalization resolves that prefix at each EntityRef site;
+	// declaring the cached URI here would freeze the first site's binding into
+	// every copied reference.
+	entityReplacementNS bool
+
 	// omit, when non-nil, decides whether a node is dropped from the copy. It is
 	// the generalized node-filter predicate: strip-space passes a
 	// whitespace-omit filter; the general copy passes nil (copy everything). It
@@ -289,10 +296,29 @@ func (dc *deepCopier) copyElement(src *Element, inScope map[string]*Namespace, p
 // child namespace scope (only meaningful in exact mode; nil in over-declare
 // mode, which does not track scope).
 func (dc *deepCopier) bindNamespaces(src, elem *Element, inScope map[string]*Namespace) (map[string]*Namespace, error) {
+	if dc.opts.entityReplacementNS {
+		return nil, dc.bindNamespacesEntityReplacement(src, elem)
+	}
 	if dc.opts.overDeclareNS {
 		return nil, dc.bindNamespacesOverDeclare(src, elem)
 	}
 	return dc.bindNamespacesExact(src, elem, inScope)
+}
+
+// bindNamespacesEntityReplacement preserves declarations physically present in
+// replacement text and keeps the active prefix/URI only as name metadata. The
+// active binding remains undeclared so consumers can resolve it from each
+// EntityRef site's namespace context.
+func (dc *deepCopier) bindNamespacesEntityReplacement(src, elem *Element) error {
+	for _, ns := range src.Namespaces() {
+		if err := elem.DeclareNamespace(ns.Prefix(), ns.URI()); err != nil {
+			return err
+		}
+	}
+	if ns := src.Namespace(); ns != nil {
+		return elem.SetActiveNamespace(ns.Prefix(), ns.URI())
+	}
+	return nil
 }
 
 // bindNamespacesOverDeclare reproduces the historical helium.copyElement

--- a/copy_deep.go
+++ b/copy_deep.go
@@ -9,15 +9,21 @@ import (
 // single set of "speed/shape primitives" that every deep-copy site in the tree
 // layer is expressed through: the leaf-node copy switch, the attribute copy
 // loop, and the namespace binding all live in one place and are selected by
-// these knobs. Child-linking is NOT one of these knobs: copyChildren always
-// links through appendCopiedChild (see its doc comment), which every
-// deep-copy site can share safely because copyNode never returns a node that
-// is already linked or that carries a foreign child link.
+// these knobs. Child-linking normally uses appendCopiedChild (see its doc
+// comment). DTD entity replacement trees opt into AddChild's cycle preflight
+// because their copied EntityRef nodes can point into the copied declaration
+// graph.
 //
-// The defaults (the zero value) reproduce the historical helium.CopyDoc/CopyNode
-// behavior EXACTLY: over-declared namespaces, no filtering, no mapping.
-// Callers that want the faster shape opt in.
+// The defaults (the zero value) select the general helium.CopyDoc/CopyNode
+// shape: over-declared namespaces, no filtering, no mapping. Callers that want
+// the faster shape opt in.
 type deepCopyOptions struct {
+	// preflightLinks selects MutableNode.AddChild instead of the direct copy-only
+	// linker. DTD entity replacement trees use it because their EntityRef nodes
+	// share destination declaration children and can therefore form graph edges
+	// outside the freshly allocated replacement subtree.
+	preflightLinks bool
+
 	// overDeclareNS selects the namespace-declaration strategy for elements.
 	//
 	// When true (the historical helium.CopyDoc behavior), every element
@@ -85,6 +91,12 @@ func (dc *deepCopier) copyChildren(src Node, parent MutableNode, inScope map[str
 		if child == nil {
 			continue
 		}
+		if dc.opts.preflightLinks {
+			if err := parent.AddChild(child); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := appendCopiedChild(parent, child); err != nil {
 			return err
 		}
@@ -101,20 +113,15 @@ func (dc *deepCopier) copyChildren(src Node, parent MutableNode, inScope map[str
 // children, so linking a deep tree bottom-up through AddChild re-walks a
 // growing subtree at every level.
 //
-// This is safe ONLY for a child that copyNode just returned. Every copyNode
-// branch allocates a brand-new node owned by dc.dst that has never been
-// linked anywhere: TextNode/CDATASectionNode/CommentNode/
-// ProcessingInstructionNode create fresh leaf nodes; EntityRefNode calls
-// dc.dst.CreateCharRef, which creates a childless EntityRef with no shared
-// Entity child (unlike CreateReference, whose EntityRef DOES carry a foreign
-// child link — CreateCharRef never installs one); ElementNode recurses through
-// copyElement, itself built only from fresh nodes; and the default branch
-// delegates to CopyNode, which for every node type it supports likewise
-// returns a freshly allocated, unlinked node. None of these can already be
-// linked into a tree or carry a foreign child link, so wouldCreateCycle could
-// never have found anything for such a child — the preflight is pure
-// overhead here. Do NOT call this on a node from outside the copier: an
-// arbitrary caller-supplied child has no such guarantee.
+// This is safe ONLY for a child that copyNode just returned while copying a
+// normal document or element tree. Every branch allocates a brand-new node
+// owned by dc.dst that has never been linked as an owned child. EntityRefNode
+// may carry the destination DTD's shared Entity declaration child, but that
+// declaration graph is disjoint from the fresh document subtree and therefore
+// cannot reach its new parent. DTD entity replacement trees use preflightLinks
+// instead because references there can point within the declaration graph.
+// Do NOT call this on a node from outside the copier: an arbitrary
+// caller-supplied child has no such guarantee.
 func appendCopiedChild(parent MutableNode, child Node) error {
 	pdn := parent.baseDocNode()
 	cdn := child.baseDocNode()
@@ -195,7 +202,7 @@ func (dc *deepCopier) copyNode(src Node, parent *Element, inScope map[string]*Na
 		if dc.filtered(src, parent, parentState) {
 			return nil, nil //nolint:nilnil // omitted by filter
 		}
-		cp, err := dc.dst.CreateCharRef(src.Name())
+		cp, err := copyEntityReference(src, dc.dst)
 		if err != nil {
 			return nil, err
 		}

--- a/copy_dtd.go
+++ b/copy_dtd.go
@@ -33,7 +33,62 @@ func copyDTD(src *DTD, dst *Document) error {
 	if err != nil {
 		return err
 	}
-	return copyDTDChildren(src, dstDTD, dst)
+	state, err := copyDTDDeclarations(src, dstDTD, dst)
+	if err != nil {
+		return err
+	}
+	return copyDTDReplacements(state, dst)
+}
+
+// CopyDTDSubsets deep-copies both DTD subsets from src into dst. It registers
+// every declaration before copying entity replacement trees, so references can
+// resolve across the internal/external subset boundary. A nil src or dst is a
+// no-op. It returns an error when the internal subset cannot be installed or a
+// replacement tree cannot be linked safely.
+func CopyDTDSubsets(src, dst *Document) error {
+	return copyDTDSubsets(src, dst, true)
+}
+
+func copyDTDSubsets(src, dst *Document, recordOffChainClaim bool) error {
+	if src == nil || dst == nil {
+		return nil
+	}
+
+	var states []dtdCopyState
+	if src.intSubset != nil {
+		dstDTD, err := dst.CreateInternalSubset(
+			src.intSubset.name, src.intSubset.externalID, src.intSubset.systemID,
+		)
+		if err != nil {
+			return err
+		}
+		state, err := copyDTDDeclarations(src.intSubset, dstDTD, dst)
+		if err != nil {
+			return err
+		}
+		states = append(states, state)
+	}
+
+	if src.extSubset != nil {
+		dstDTD := newExternalSubsetCopy(src.extSubset, dst)
+		state, err := copyDTDDeclarations(src.extSubset, dstDTD, dst)
+		if err != nil {
+			return err
+		}
+		dst.extSubset = dstDTD
+		if recordOffChainClaim {
+			dst.offChainChildClaim = true
+		}
+		states = append(states, state)
+	}
+
+	for _, state := range states {
+		if err := copyDTDReplacements(state, dst); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // CopyExtSubset deep-copies src's external DTD subset into dst, installing it as
@@ -59,34 +114,50 @@ func copyExtSubset(src, dst *Document, recordOffChainClaim bool) {
 		return
 	}
 
-	dstDTD := newDTD()
-	dstDTD.name = srcDTD.name
-	dstDTD.externalID = srcDTD.externalID
-	dstDTD.systemID = srcDTD.systemID
-	dstDTD.doc = dst
-	dstDTD.parent = dst
-
-	_ = copyDTDChildren(srcDTD, dstDTD, dst)
+	dstDTD := newExternalSubsetCopy(srcDTD, dst)
+	state, err := copyDTDDeclarations(srcDTD, dstDTD, dst)
+	if err != nil {
+		return
+	}
 
 	dst.extSubset = dstDTD
+	if recordOffChainClaim {
+		dst.offChainChildClaim = true
+	}
+	if err := copyDTDReplacements(state, dst); err != nil {
+		return
+	}
 	// dstDTD claims dst as its parent but is deliberately NOT in dst's child
 	// list, so dst now holds a node that can move its recorded lastChild off that
 	// list. Record it on dst, the parent that was handed the claimant: appends
 	// onto dst itself stop resolving their point from dst.lastChild
 	// (tailJumpTarget, resolveOwnedTail) and walk instead, while every element
 	// dst owns keeps its own O(1) resolution.
-	if recordOffChainClaim {
-		dst.offChainChildClaim = true
-	}
 }
 
-// copyDTDChildren walks src's children in document order, copying each
+func newExternalSubsetCopy(srcDTD *DTD, dst *Document) *DTD {
+	dstDTD := newDTD()
+	dstDTD.name = srcDTD.name
+	dstDTD.externalID = srcDTD.externalID
+	dstDTD.systemID = srcDTD.systemID
+	dstDTD.doc = dst
+	dstDTD.parent = dst
+	return dstDTD
+}
+
+// dtdCopyState keeps the source-to-copy entity correspondence between the
+// declaration and replacement-tree phases.
+type dtdCopyState struct {
+	src          *DTD
+	entityCopies map[*Entity]*Entity
+}
+
+// copyDTDDeclarations walks src's children in document order, copying each
 // declaration as an independent node owned by dst and registering it both in
 // dstDTD's lookup maps and as a child (so serialization round-trips
-// identically). Shared by copyDTD (internal subset) and CopyExtSubset
-// (external subset), which differ only in how dstDTD is allocated and where it
-// is attached.
-func copyDTDChildren(src, dstDTD *DTD, dst *Document) error {
+// identically). Replacement trees are copied separately after all applicable
+// subsets have completed this phase.
+func copyDTDDeclarations(src, dstDTD *DTD, dst *Document) (dtdCopyState, error) {
 	// Correspondence from each source attribute declaration to its copy, so the
 	// copy's registration-order sequences can be rebuilt from the source's.
 	attrCopies := make(map[*AttributeDecl]*AttributeDecl)
@@ -107,13 +178,17 @@ func copyDTDChildren(src, dstDTD *DTD, dst *Document) error {
 					dstDTD.entities[ent.name] = cp
 				}
 				entityCopies[ent] = cp
-				_ = dstDTD.AddChild(cp)
+				if err := dstDTD.AddChild(cp); err != nil {
+					return dtdCopyState{}, err
+				}
 			}
 		case ElementDeclNode:
 			if edecl, ok := AsNode[*ElementDecl](c); ok {
 				cp := copyElementDecl(edecl, dst)
 				dstDTD.elements[edecl.name+":"+edecl.prefix] = cp
-				_ = dstDTD.AddChild(cp)
+				if err := dstDTD.AddChild(cp); err != nil {
+					return dtdCopyState{}, err
+				}
 			}
 		case AttributeDeclNode:
 			if adecl, ok := AsNode[*AttributeDecl](c); ok {
@@ -128,34 +203,59 @@ func copyDTDChildren(src, dstDTD *DTD, dst *Document) error {
 				// sequence once every copy exists (copyAttrDeclOrder below).
 				dstDTD.attributes[attrDeclKey{local: adecl.name, prefix: adecl.prefix, elem: adecl.elem}] = cp
 				attrCopies[adecl] = cp
-				_ = dstDTD.AddChild(cp)
+				if err := dstDTD.AddChild(cp); err != nil {
+					return dtdCopyState{}, err
+				}
 			}
 		case NotationNode:
 			if nota, ok := AsNode[*Notation](c); ok {
 				cp := copyNotation(nota, dst)
 				dstDTD.notations[nota.name] = cp
-				_ = dstDTD.AddChild(cp)
+				if err := dstDTD.AddChild(cp); err != nil {
+					return dtdCopyState{}, err
+				}
 			}
 		case CommentNode:
-			_ = dstDTD.AddChild(dst.CreateComment(slices.Clone(c.Content())))
+			if err := dstDTD.AddChild(dst.CreateComment(slices.Clone(c.Content()))); err != nil {
+				return dtdCopyState{}, err
+			}
 		case ProcessingInstructionNode:
-			_ = dstDTD.AddChild(dst.CreatePI(c.Name(), string(c.Content())))
+			if err := dstDTD.AddChild(dst.CreatePI(c.Name(), string(c.Content()))); err != nil {
+				return dtdCopyState{}, err
+			}
 		}
 	}
 
 	copyAttrDeclOrder(src, dstDTD, attrCopies)
+	return dtdCopyState{src: src, entityCopies: entityCopies}, nil
+}
 
+// copyDTDReplacements copies each entity's parsed replacement tree after every
+// declaration needed by the operation has been registered. Links within each
+// fresh replacement child bypass the cycle scan; attaching that completed child
+// to its destination declaration retains the full AddChild preflight.
+func copyDTDReplacements(state dtdCopyState, dst *Document) error {
 	// EntityRef nodes share their declaration's parsed replacement subtree.
 	// Copy it only after every declaration has been registered, so nested and
 	// forward references resolve to destination-owned Entity nodes.
-	dc := &deepCopier{dst: dst, opts: deepCopyOptions{overDeclareNS: true, preflightLinks: true}}
-	for c := range Children(src) {
+	dc := &deepCopier{dst: dst, opts: deepCopyOptions{overDeclareNS: true}}
+	for c := range Children(state.src) {
 		ent, ok := AsNode[*Entity](c)
 		if !ok {
 			continue
 		}
-		if err := dc.copyChildren(ent, entityCopies[ent], nil, nil); err != nil {
-			return err
+		dstEnt := state.entityCopies[ent]
+		for replacement := range Children(ent) {
+			child, err := dc.copyNode(replacement, nil, nil, nil)
+			if err != nil {
+				return err
+			}
+			if child == nil {
+				continue
+			}
+			if err := dstEnt.AddChild(child); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/copy_dtd.go
+++ b/copy_dtd.go
@@ -34,25 +34,32 @@ func copyDTD(src *DTD, dst *Document) error {
 	if err != nil {
 		return err
 	}
-	state, err := copyDTDDeclarations(src, dstDTD, dst)
+	entityCopies := make(map[*Entity]*Entity)
+	state, err := copyDTDDeclarations(src, dstDTD, dst, entityCopies)
 	if err != nil {
 		return err
 	}
-	return copyDTDReplacements(state, dst)
+	return copyDTDReplacements(state, dst, entityCopies)
 }
 
 // CopyDTDSubsets deep-copies both DTD subsets from src into dst. It registers
-// every declaration before copying entity replacement trees, so references can
-// resolve across the internal/external subset boundary. A nil src or dst is a
-// no-op. It returns an error when the internal subset cannot be installed or a
-// replacement tree cannot be linked safely.
+// every declaration before copying entity replacement trees, then binds each
+// copied reference to the copy of its actual source declaration across the
+// internal/external subset boundary. A nil src or dst is a no-op. It returns an
+// error when the internal subset cannot be installed or a replacement tree
+// cannot be linked safely.
 func CopyDTDSubsets(src, dst *Document) error {
-	return copyDTDSubsets(src, dst, true)
+	_, err := copyDTDSubsets(src, dst, true)
+	return err
 }
 
-func copyDTDSubsets(src, dst *Document, recordOffChainClaim bool) error {
+func copyDTDSubsets(
+	src, dst *Document,
+	recordOffChainClaim bool,
+) (map[*Entity]*Entity, error) {
+	entityCopies := make(map[*Entity]*Entity)
 	if src == nil || dst == nil {
-		return nil
+		return entityCopies, nil
 	}
 
 	var states []dtdCopyState
@@ -61,20 +68,20 @@ func copyDTDSubsets(src, dst *Document, recordOffChainClaim bool) error {
 			src.intSubset.name, src.intSubset.externalID, src.intSubset.systemID,
 		)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		state, err := copyDTDDeclarations(src.intSubset, dstDTD, dst)
+		state, err := copyDTDDeclarations(src.intSubset, dstDTD, dst, entityCopies)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		states = append(states, state)
 	}
 
 	if src.extSubset != nil {
 		dstDTD := newExternalSubsetCopy(src.extSubset, dst)
-		state, err := copyDTDDeclarations(src.extSubset, dstDTD, dst)
+		state, err := copyDTDDeclarations(src.extSubset, dstDTD, dst, entityCopies)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		dst.extSubset = dstDTD
 		if recordOffChainClaim {
@@ -84,12 +91,12 @@ func copyDTDSubsets(src, dst *Document, recordOffChainClaim bool) error {
 	}
 
 	for _, state := range states {
-		if err := copyDTDReplacements(state, dst); err != nil {
-			return err
+		if err := copyDTDReplacements(state, dst, entityCopies); err != nil {
+			return nil, err
 		}
 	}
 
-	return nil
+	return entityCopies, nil
 }
 
 // CopyExtSubset deep-copies src's external DTD subset into dst, installing it as
@@ -116,7 +123,8 @@ func copyExtSubset(src, dst *Document, recordOffChainClaim bool) {
 	}
 
 	dstDTD := newExternalSubsetCopy(srcDTD, dst)
-	state, err := copyDTDDeclarations(srcDTD, dstDTD, dst)
+	entityCopies := make(map[*Entity]*Entity)
+	state, err := copyDTDDeclarations(srcDTD, dstDTD, dst, entityCopies)
 	if err != nil {
 		return
 	}
@@ -125,7 +133,7 @@ func copyExtSubset(src, dst *Document, recordOffChainClaim bool) {
 	if recordOffChainClaim {
 		dst.offChainChildClaim = true
 	}
-	if err := copyDTDReplacements(state, dst); err != nil {
+	if err := copyDTDReplacements(state, dst, entityCopies); err != nil {
 		return
 	}
 	// dstDTD claims dst as its parent but is deliberately NOT in dst's child
@@ -146,11 +154,9 @@ func newExternalSubsetCopy(srcDTD *DTD, dst *Document) *DTD {
 	return dstDTD
 }
 
-// dtdCopyState keeps the source-to-copy entity correspondence between the
-// declaration and replacement-tree phases.
+// dtdCopyState keeps the source subset needed by the replacement-tree phase.
 type dtdCopyState struct {
-	src          *DTD
-	entityCopies map[*Entity]*Entity
+	src *DTD
 }
 
 // copyDTDDeclarations walks src's children in document order, copying each
@@ -158,12 +164,14 @@ type dtdCopyState struct {
 // dstDTD's lookup maps and as a child (so serialization round-trips
 // identically). Replacement trees are copied separately after all applicable
 // subsets have completed this phase.
-func copyDTDDeclarations(src, dstDTD *DTD, dst *Document) (dtdCopyState, error) {
+func copyDTDDeclarations(
+	src, dstDTD *DTD,
+	dst *Document,
+	entityCopies map[*Entity]*Entity,
+) (dtdCopyState, error) {
 	// Correspondence from each source attribute declaration to its copy, so the
 	// copy's registration-order sequences can be rebuilt from the source's.
 	attrCopies := make(map[*AttributeDecl]*AttributeDecl)
-	entityCopies := make(map[*Entity]*Entity)
-
 	// The DTD owns its declaration children, so Children's owned-boundary advance
 	// equals a raw NextSibling walk here while adding a per-list seen guard, so a
 	// corrupt (cyclic) declaration list terminates instead of spinning.
@@ -228,25 +236,35 @@ func copyDTDDeclarations(src, dstDTD *DTD, dst *Document) (dtdCopyState, error) 
 	}
 
 	copyAttrDeclOrder(src, dstDTD, attrCopies)
-	return dtdCopyState{src: src, entityCopies: entityCopies}, nil
+	return dtdCopyState{src: src}, nil
 }
 
 // copyDTDReplacements copies each entity's parsed replacement tree after every
 // declaration needed by the operation has been registered. It validates the
 // completed declaration graph with shared visit state before linking any fresh
 // replacement roots, so both validation and linking are linear in graph size.
-func copyDTDReplacements(state dtdCopyState, dst *Document) error {
+func copyDTDReplacements(
+	state dtdCopyState,
+	dst *Document,
+	entityCopies map[*Entity]*Entity,
+) error {
 	// EntityRef nodes share their declaration's parsed replacement subtree.
 	// Copy it only after every declaration has been registered, so nested and
-	// forward references resolve to destination-owned Entity nodes.
-	dc := &deepCopier{dst: dst, opts: deepCopyOptions{overDeclareNS: true}}
+	// forward references bind to the destination copy of that same declaration.
+	dc := &deepCopier{
+		dst: dst,
+		opts: deepCopyOptions{
+			overDeclareNS: true,
+			entityCopies:  entityCopies,
+		},
+	}
 	var replacements []dtdReplacementCopy
 	for c := range Children(state.src) {
 		ent, ok := AsNode[*Entity](c)
 		if !ok {
 			continue
 		}
-		dstEnt := state.entityCopies[ent]
+		dstEnt := entityCopies[ent]
 		replacementCopy := dtdReplacementCopy{entity: dstEnt}
 		for replacement := range Children(ent) {
 			child, err := dc.copyNode(replacement, nil, nil, nil)

--- a/copy_dtd.go
+++ b/copy_dtd.go
@@ -1,6 +1,7 @@
 package helium
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/lestrrat-go/helium/enum"
@@ -231,20 +232,22 @@ func copyDTDDeclarations(src, dstDTD *DTD, dst *Document) (dtdCopyState, error) 
 }
 
 // copyDTDReplacements copies each entity's parsed replacement tree after every
-// declaration needed by the operation has been registered. Links within each
-// fresh replacement child bypass the cycle scan; attaching that completed child
-// to its destination declaration retains the full AddChild preflight.
+// declaration needed by the operation has been registered. It validates the
+// completed declaration graph with shared visit state before linking any fresh
+// replacement roots, so both validation and linking are linear in graph size.
 func copyDTDReplacements(state dtdCopyState, dst *Document) error {
 	// EntityRef nodes share their declaration's parsed replacement subtree.
 	// Copy it only after every declaration has been registered, so nested and
 	// forward references resolve to destination-owned Entity nodes.
 	dc := &deepCopier{dst: dst, opts: deepCopyOptions{overDeclareNS: true}}
+	var replacements []dtdReplacementCopy
 	for c := range Children(state.src) {
 		ent, ok := AsNode[*Entity](c)
 		if !ok {
 			continue
 		}
 		dstEnt := state.entityCopies[ent]
+		replacementCopy := dtdReplacementCopy{entity: dstEnt}
 		for replacement := range Children(ent) {
 			child, err := dc.copyNode(replacement, nil, nil, nil)
 			if err != nil {
@@ -253,13 +256,149 @@ func copyDTDReplacements(state dtdCopyState, dst *Document) error {
 			if child == nil {
 				continue
 			}
-			if err := dstEnt.AddChild(child); err != nil {
+			replacementCopy.children = append(replacementCopy.children, child)
+		}
+		replacements = append(replacements, replacementCopy)
+	}
+
+	validator := newDTDReplacementGraphValidator(replacements)
+	if validator.hasCycle() {
+		return fmt.Errorf("%w: cannot copy a cyclic DTD entity replacement graph", ErrCyclicNode)
+	}
+
+	for _, replacement := range replacements {
+		for _, child := range replacement.children {
+			if err := appendCopiedChild(replacement.entity, child); err != nil {
 				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+type dtdReplacementCopy struct {
+	entity   *Entity
+	children []Node
+}
+
+const (
+	dtdReplacementVisitActive uint8 = iota + 1
+	dtdReplacementVisitDone
+)
+
+// dtdReplacementGraphValidator checks the prospective declaration graph before
+// its detached replacement roots are linked. states is shared across every
+// declaration root, so a chain reached from many entities is visited once.
+type dtdReplacementGraphValidator struct {
+	roots        []*Entity
+	replacements map[*docnode][]Node
+	states       map[*docnode]uint8
+	visits       int
+}
+
+func newDTDReplacementGraphValidator(replacements []dtdReplacementCopy) *dtdReplacementGraphValidator {
+	v := &dtdReplacementGraphValidator{
+		roots:        make([]*Entity, 0, len(replacements)),
+		replacements: make(map[*docnode][]Node, len(replacements)),
+		states:       make(map[*docnode]uint8),
+	}
+	for _, replacement := range replacements {
+		v.roots = append(v.roots, replacement.entity)
+		v.replacements[replacement.entity.baseDocNode()] = replacement.children
+	}
+	return v
+}
+
+type dtdReplacementGraphFrame struct {
+	node           Node
+	entered        bool
+	hasReplacement bool
+	replacements   []Node
+	replacementPos int
+	nextChild      Node
+	siblingGuard   siblingCycleGuard
+}
+
+// hasCycle reports whether any replacement child can reach an entity that is
+// already active on the same child-pointer path. The explicit stack keeps deep
+// declaration chains safe, while the shared done state bounds work to one visit
+// per node across all entity roots.
+func (v *dtdReplacementGraphValidator) hasCycle() bool {
+	for _, entity := range v.roots {
+		if v.states[entity.baseDocNode()] == dtdReplacementVisitDone {
+			continue
+		}
+		if v.hasCycleFrom(entity) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *dtdReplacementGraphValidator) hasCycleFrom(root Node) bool {
+	stack := []dtdReplacementGraphFrame{{node: root}}
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		dn := top.node.baseDocNode()
+		if !top.entered {
+			if v.states[dn] == dtdReplacementVisitActive {
+				return true
+			}
+			if v.states[dn] == dtdReplacementVisitDone {
+				stack = stack[:len(stack)-1]
+				continue
+			}
+			v.states[dn] = dtdReplacementVisitActive
+			v.visits++
+			top.entered = true
+			top.replacements, top.hasReplacement = v.replacements[dn]
+			if !top.hasReplacement {
+				top.nextChild = dn.firstChild
+			}
+		}
+
+		child, cycle := top.takeChild(dn)
+		if cycle {
+			return true
+		}
+		if child == nil {
+			v.states[dn] = dtdReplacementVisitDone
+			stack = stack[:len(stack)-1]
+			continue
+		}
+		cdn := child.baseDocNode()
+		if v.states[cdn] == dtdReplacementVisitActive {
+			return true
+		}
+		if v.states[cdn] == dtdReplacementVisitDone {
+			continue
+		}
+		stack = append(stack, dtdReplacementGraphFrame{node: child})
+	}
+	return false
+}
+
+func (f *dtdReplacementGraphFrame) takeChild(owner *docnode) (Node, bool) {
+	if f.hasReplacement {
+		if f.replacementPos >= len(f.replacements) {
+			return nil, false
+		}
+		child := f.replacements[f.replacementPos]
+		f.replacementPos++
+		return child, false
+	}
+
+	child := f.nextChild
+	if child == nil {
+		return nil, false
+	}
+	cdn := child.baseDocNode()
+	if f.siblingGuard.step(cdn) {
+		return nil, true
+	}
+	f.nextChild = nextOwnedSibling(owner, cdn)
+	return child, false
 }
 
 // copyAttrDeclOrder fills dstDTD's registration-order sequences (attrDecls and

--- a/copy_dtd.go
+++ b/copy_dtd.go
@@ -45,12 +45,13 @@ func copyDTD(src *DTD, dst *Document) error {
 // CopyDTDSubsets deep-copies both DTD subsets from src into dst. It registers
 // every declaration before copying entity replacement trees, then binds each
 // copied reference to the copy of its actual source declaration across the
-// internal/external subset boundary. A nil src or dst is a no-op. It returns an
-// error when the internal subset cannot be installed or a replacement tree
-// cannot be linked safely.
-func CopyDTDSubsets(src, dst *Document) error {
-	_, err := copyDTDSubsets(src, dst, true)
-	return err
+// internal/external subset boundary. The returned map carries the same
+// source-declaration-to-copy correspondence for callers that copy document
+// content separately. A nil src or dst is a no-op and returns an empty map. It
+// returns an error when the internal subset cannot be installed or a replacement
+// tree cannot be linked safely.
+func CopyDTDSubsets(src, dst *Document) (map[*Entity]*Entity, error) {
+	return copyDTDSubsets(src, dst, true)
 }
 
 func copyDTDSubsets(

--- a/copy_dtd.go
+++ b/copy_dtd.go
@@ -255,8 +255,8 @@ func copyDTDReplacements(
 	dc := &deepCopier{
 		dst: dst,
 		opts: deepCopyOptions{
-			overDeclareNS: true,
-			entityCopies:  entityCopies,
+			entityReplacementNS: true,
+			entityCopies:        entityCopies,
 		},
 	}
 	var replacements []dtdReplacementCopy

--- a/copy_dtd.go
+++ b/copy_dtd.go
@@ -47,6 +47,10 @@ func copyDTD(src *DTD, dst *Document) error {
 // the document — it is referenced only via ExtSubset — so the copy is not added
 // to dst's child list. If src has no external subset this is a no-op.
 func CopyExtSubset(src, dst *Document) {
+	copyExtSubset(src, dst, true)
+}
+
+func copyExtSubset(src, dst *Document, recordOffChainClaim bool) {
 	if src == nil || dst == nil {
 		return
 	}
@@ -71,7 +75,9 @@ func CopyExtSubset(src, dst *Document) {
 	// onto dst itself stop resolving their point from dst.lastChild
 	// (tailJumpTarget, resolveOwnedTail) and walk instead, while every element
 	// dst owns keeps its own O(1) resolution.
-	dst.offChainChildClaim = true
+	if recordOffChainClaim {
+		dst.offChainChildClaim = true
+	}
 }
 
 // copyDTDChildren walks src's children in document order, copying each
@@ -84,6 +90,7 @@ func copyDTDChildren(src, dstDTD *DTD, dst *Document) error {
 	// Correspondence from each source attribute declaration to its copy, so the
 	// copy's registration-order sequences can be rebuilt from the source's.
 	attrCopies := make(map[*AttributeDecl]*AttributeDecl)
+	entityCopies := make(map[*Entity]*Entity)
 
 	// The DTD owns its declaration children, so Children's owned-boundary advance
 	// equals a raw NextSibling walk here while adding a per-list seen guard, so a
@@ -99,6 +106,7 @@ func copyDTDChildren(src, dstDTD *DTD, dst *Document) error {
 				default:
 					dstDTD.entities[ent.name] = cp
 				}
+				entityCopies[ent] = cp
 				_ = dstDTD.AddChild(cp)
 			}
 		case ElementDeclNode:
@@ -136,6 +144,20 @@ func copyDTDChildren(src, dstDTD *DTD, dst *Document) error {
 	}
 
 	copyAttrDeclOrder(src, dstDTD, attrCopies)
+
+	// EntityRef nodes share their declaration's parsed replacement subtree.
+	// Copy it only after every declaration has been registered, so nested and
+	// forward references resolve to destination-owned Entity nodes.
+	dc := &deepCopier{dst: dst, opts: deepCopyOptions{overDeclareNS: true, preflightLinks: true}}
+	for c := range Children(src) {
+		ent, ok := AsNode[*Entity](c)
+		if !ok {
+			continue
+		}
+		if err := dc.copyChildren(ent, entityCopies[ent], nil, nil); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/copy_dtd_internal_test.go
+++ b/copy_dtd_internal_test.go
@@ -1,0 +1,49 @@
+package helium
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lestrrat-go/helium/enum"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDTDReplacementGraphValidationVisitsAChainOnce guards the shared session
+// state used across declaration roots. Each entity after the first refers to
+// its predecessor, so restarting the traversal for every root would visit a
+// triangular number of nodes. Shared done state visits each declaration and
+// each replacement root exactly once.
+func TestDTDReplacementGraphValidationVisitsAChainOnce(t *testing.T) {
+	const entityCount = 512
+
+	doc := NewDefaultDocument()
+	dtd, err := doc.CreateInternalSubset("root", "", "")
+	require.NoError(t, err)
+
+	entities := make([]*Entity, 0, entityCount)
+	for i := range entityCount {
+		entity, addErr := dtd.AddEntity(
+			fmt.Sprintf("e%d", i), enum.InternalGeneralEntity, "", "", "",
+		)
+		require.NoError(t, addErr)
+		entities = append(entities, entity)
+	}
+
+	replacements := make([]dtdReplacementCopy, 0, entityCount)
+	for i, entity := range entities {
+		var child Node = doc.CreateText([]byte("base"))
+		if i > 0 {
+			child, err = doc.CreateReference(entities[i-1].Name())
+			require.NoError(t, err)
+		}
+		replacements = append(replacements, dtdReplacementCopy{
+			entity:   entity,
+			children: []Node{child},
+		})
+	}
+
+	validator := newDTDReplacementGraphValidator(replacements)
+	require.False(t, validator.hasCycle())
+	require.Equal(t, entityCount*2, validator.visits,
+		"each entity and replacement root must be visited once across the full chain")
+}

--- a/copy_test.go
+++ b/copy_test.go
@@ -318,7 +318,12 @@ func TestCopyNode(t *testing.T) {
 func TestCopyEntityReference(t *testing.T) {
 	t.Parallel()
 
-	const srcXML = `<!DOCTYPE root [<!ENTITY payload "QUJD">]><root>&payload;&payload;</root>`
+	const (
+		srcXML            = `<!DOCTYPE root [<!ENTITY payload "QUJD">]><root>&payload;&payload;</root>`
+		entitiesDTDPath   = "entities.dtd"
+		externalDoctype   = `<!DOCTYPE root SYSTEM "` + entitiesDTDPath + `">`
+		externalIntSubset = `<!DOCTYPE root SYSTEM "` + entitiesDTDPath + `" [<!ENTITY internal "&external;">]>`
+	)
 	src, err := helium.NewParser().Parse(t.Context(), []byte(srcXML))
 	require.NoError(t, err)
 
@@ -432,12 +437,12 @@ func TestCopyEntityReference(t *testing.T) {
 	})
 
 	t.Run("document copy resolves an external declaration", func(t *testing.T) {
-		fsys := fstest.MapFS{"entities.dtd": {Data: []byte(`<!ENTITY payload "QUJD">`)}}
+		fsys := fstest.MapFS{entitiesDTDPath: {Data: []byte(`<!ENTITY payload "QUJD">`)}}
 		external, parseErr := helium.NewParser().
 			BlockXXE(false).
 			LoadExternalDTD(true).
 			FS(fsys).
-			Parse(t.Context(), []byte(`<!DOCTYPE root SYSTEM "entities.dtd"><root>&payload;</root>`))
+			Parse(t.Context(), []byte(externalDoctype+`<root>&payload;</root>`))
 		require.NoError(t, parseErr)
 
 		copied, copyErr := helium.CopyDoc(external)
@@ -450,12 +455,12 @@ func TestCopyEntityReference(t *testing.T) {
 	})
 
 	t.Run("document copy preserves declaration identity", func(t *testing.T) {
-		fsys := fstest.MapFS{"entities.dtd": {Data: []byte(`<!ENTITY payload "EXTERNAL">`)}}
+		fsys := fstest.MapFS{entitiesDTDPath: {Data: []byte(`<!ENTITY payload "EXTERNAL">`)}}
 		source, parseErr := helium.NewParser().
 			BlockXXE(false).
 			LoadExternalDTD(true).
 			FS(fsys).
-			Parse(t.Context(), []byte(`<!DOCTYPE root SYSTEM "entities.dtd"><root/>`))
+			Parse(t.Context(), []byte(externalDoctype+`<root/>`))
 		require.NoError(t, parseErr)
 
 		sourceExternal, found := source.ExtSubset().LookupEntity("payload")
@@ -481,12 +486,12 @@ func TestCopyEntityReference(t *testing.T) {
 	})
 
 	t.Run("element copy preserves declaration subset identity", func(t *testing.T) {
-		fsys := fstest.MapFS{"entities.dtd": {Data: []byte(`<!ENTITY payload "EXTERNAL">`)}}
+		fsys := fstest.MapFS{entitiesDTDPath: {Data: []byte(`<!ENTITY payload "EXTERNAL">`)}}
 		source, parseErr := helium.NewParser().
 			BlockXXE(false).
 			LoadExternalDTD(true).
 			FS(fsys).
-			Parse(t.Context(), []byte(`<!DOCTYPE root SYSTEM "entities.dtd"><root/>`))
+			Parse(t.Context(), []byte(externalDoctype+`<root/>`))
 		require.NoError(t, parseErr)
 
 		sourceExternal, found := source.ExtSubset().LookupEntity("payload")
@@ -517,13 +522,13 @@ func TestCopyEntityReference(t *testing.T) {
 
 	t.Run("document copy preserves replacement declaration identity", func(t *testing.T) {
 		fsys := fstest.MapFS{
-			"entities.dtd": {Data: []byte(`<!ENTITY payload "EXTERNAL"><!ENTITY holder "&payload;">`)},
+			entitiesDTDPath: {Data: []byte(`<!ENTITY payload "EXTERNAL"><!ENTITY holder "&payload;">`)},
 		}
 		source, parseErr := helium.NewParser().
 			BlockXXE(false).
 			LoadExternalDTD(true).
 			FS(fsys).
-			Parse(t.Context(), []byte(`<!DOCTYPE root SYSTEM "entities.dtd"><root>&holder;</root>`))
+			Parse(t.Context(), []byte(externalDoctype+`<root>&holder;</root>`))
 		require.NoError(t, parseErr)
 
 		sourceExternal, found := source.ExtSubset().LookupEntity("payload")
@@ -550,13 +555,12 @@ func TestCopyEntityReference(t *testing.T) {
 	})
 
 	t.Run("document copy resolves an internal reference to an external declaration", func(t *testing.T) {
-		fsys := fstest.MapFS{"entities.dtd": {Data: []byte(`<!ENTITY external "EXTERNAL">`)}}
+		fsys := fstest.MapFS{entitiesDTDPath: {Data: []byte(`<!ENTITY external "EXTERNAL">`)}}
 		source, parseErr := helium.NewParser().
 			BlockXXE(false).
 			LoadExternalDTD(true).
 			FS(fsys).
-			Parse(t.Context(), []byte(
-				`<!DOCTYPE root SYSTEM "entities.dtd" [<!ENTITY internal "&external;">]><root>&internal;</root>`))
+			Parse(t.Context(), []byte(externalIntSubset+`<root>&internal;</root>`))
 		require.NoError(t, parseErr)
 
 		copied, copyErr := helium.CopyDoc(source)

--- a/copy_test.go
+++ b/copy_test.go
@@ -421,7 +421,7 @@ func TestCopyEntityReference(t *testing.T) {
 	})
 }
 
-func TestCopyDTDReplacementCopyRunsOneDeepCyclePreflight(t *testing.T) {
+func TestCopyDTDReplacementCopyRunsOneGraphValidation(t *testing.T) {
 	const depth = 256
 
 	src := helium.NewDefaultDocument()
@@ -451,9 +451,27 @@ func TestCopyDTDReplacementCopyRunsOneDeepCyclePreflight(t *testing.T) {
 	})
 
 	// Both paths allocate the same fresh element chain. The DTD path may add only
-	// fixed declaration bookkeeping and one completed-subtree cycle preflight.
+	// fixed declaration bookkeeping and one shared-state graph validation.
 	// Running a preflight at every nested link adds roughly depth map allocations.
 	require.Less(t, dtdAllocs-normalAllocs, 64.0)
+}
+
+func TestCopyDTDReplacementCopyRejectsACycle(t *testing.T) {
+	src := helium.NewDefaultDocument()
+	dtd, err := src.CreateInternalSubset("root", "", "")
+	require.NoError(t, err)
+	entity, err := dtd.AddEntity("loop", enum.InternalGeneralEntity, "", "", "")
+	require.NoError(t, err)
+	ref, err := src.CreateReference("loop")
+	require.NoError(t, err)
+	require.NoError(t, helium.UnsafeAppendChildForTesting(entity, ref))
+
+	dst := helium.NewDefaultDocument()
+	err = helium.CopyDTDInfo(src, dst)
+	require.ErrorIs(t, err, helium.ErrCyclicNode)
+	copied, ok := dst.IntSubset().LookupEntity("loop")
+	require.True(t, ok)
+	require.Nil(t, copied.FirstChild(), "cycle rejection must happen before replacement roots are linked")
 }
 
 func TestCopyDoc(t *testing.T) {

--- a/copy_test.go
+++ b/copy_test.go
@@ -397,6 +397,63 @@ func TestCopyEntityReference(t *testing.T) {
 		require.Same(t, dstEntity, ref.FirstChild())
 		require.Same(t, copied, dstEntity.OwnerDocument())
 	})
+
+	t.Run("document copy resolves an internal reference to an external declaration", func(t *testing.T) {
+		fsys := fstest.MapFS{"entities.dtd": {Data: []byte(`<!ENTITY external "EXTERNAL">`)}}
+		source, parseErr := helium.NewParser().
+			BlockXXE(false).
+			LoadExternalDTD(true).
+			FS(fsys).
+			Parse(t.Context(), []byte(
+				`<!DOCTYPE root SYSTEM "entities.dtd" [<!ENTITY internal "&external;">]><root>&internal;</root>`))
+		require.NoError(t, parseErr)
+
+		copied, copyErr := helium.CopyDoc(source)
+		require.NoError(t, copyErr)
+		internal, found := copied.IntSubset().LookupEntity("internal")
+		require.True(t, found)
+		external, found := copied.ExtSubset().LookupEntity("external")
+		require.True(t, found)
+		ref := internal.FirstChild()
+		require.Equal(t, helium.EntityRefNode, ref.Type())
+		require.Same(t, external, ref.FirstChild())
+		require.Equal(t, "EXTERNAL", string(ref.Content()))
+	})
+}
+
+func TestCopyDTDReplacementCopyRunsOneDeepCyclePreflight(t *testing.T) {
+	const depth = 256
+
+	src := helium.NewDefaultDocument()
+	dtd, err := src.CreateInternalSubset("root", "", "")
+	require.NoError(t, err)
+	entity, err := dtd.AddEntity("payload", enum.InternalGeneralEntity, "", "", "")
+	require.NoError(t, err)
+	root, err := src.CreateElement("n")
+	require.NoError(t, err)
+	require.NoError(t, entity.AddChild(root))
+	parent := root
+	for range depth - 1 {
+		child, createErr := src.CreateElement("n")
+		require.NoError(t, createErr)
+		require.NoError(t, parent.AddChild(child))
+		parent = child
+	}
+
+	normalAllocs := testing.AllocsPerRun(5, func() {
+		dst := helium.NewDefaultDocument()
+		_, copyErr := helium.CopyNode(root, dst)
+		require.NoError(t, copyErr)
+	})
+	dtdAllocs := testing.AllocsPerRun(5, func() {
+		dst := helium.NewDefaultDocument()
+		require.NoError(t, helium.CopyDTDInfo(src, dst))
+	})
+
+	// Both paths allocate the same fresh element chain. The DTD path may add only
+	// fixed declaration bookkeeping and one completed-subtree cycle preflight.
+	// Running a preflight at every nested link adds roughly depth map allocations.
+	require.Less(t, dtdAllocs-normalAllocs, 64.0)
 }
 
 func TestCopyDoc(t *testing.T) {

--- a/copy_test.go
+++ b/copy_test.go
@@ -362,6 +362,24 @@ func TestCopyEntityReference(t *testing.T) {
 		require.Nil(t, copied.FirstChild())
 	})
 
+	t.Run("numeric reference ignores a same-name destination declaration", func(t *testing.T) {
+		numeric, createErr := src.CreateCharRef("#65")
+		require.NoError(t, createErr)
+
+		dst := helium.NewDefaultDocument()
+		dtd, createErr := dst.CreateInternalSubset("root", "", "")
+		require.NoError(t, createErr)
+		_, createErr = dtd.AddEntity(
+			"#65", enum.InternalGeneralEntity, "", "", "WRONG",
+		)
+		require.NoError(t, createErr)
+
+		copied, copyErr := helium.CopyNode(numeric, dst)
+		require.NoError(t, copyErr)
+		require.Nil(t, copied.FirstChild())
+		require.Empty(t, copied.Content())
+	})
+
 	t.Run("document copy shares only its own repeated declaration", func(t *testing.T) {
 		copied, copyErr := helium.CopyDoc(src)
 		require.NoError(t, copyErr)
@@ -378,6 +396,31 @@ func TestCopyEntityReference(t *testing.T) {
 		require.Same(t, copied, first.OwnerDocument())
 		require.Same(t, copied, second.OwnerDocument())
 		require.Same(t, copied, dstEntity.OwnerDocument())
+	})
+
+	t.Run("document copy preserves a childless late reference", func(t *testing.T) {
+		source := helium.NewDefaultDocument()
+		_, createErr := source.CreateInternalSubset("root", "", "")
+		require.NoError(t, createErr)
+		root, createErr := source.CreateElement("root")
+		require.NoError(t, createErr)
+		require.NoError(t, source.AddChild(root))
+
+		ref, createErr := source.CreateCharRef("payload")
+		require.NoError(t, createErr)
+		require.NoError(t, root.AddChild(ref))
+		_, createErr = source.IntSubset().AddEntity(
+			"payload", enum.InternalGeneralEntity, "", "", "PAYLOAD",
+		)
+		require.NoError(t, createErr)
+		require.Nil(t, ref.FirstChild())
+
+		copied, copyErr := helium.CopyDoc(source)
+		require.NoError(t, copyErr)
+		copiedRef := copied.DocumentElement().FirstChild()
+		require.Equal(t, helium.EntityRefNode, copiedRef.Type())
+		require.Nil(t, copiedRef.FirstChild())
+		require.Empty(t, copiedRef.Content())
 	})
 
 	t.Run("document copy resolves an external declaration", func(t *testing.T) {

--- a/copy_test.go
+++ b/copy_test.go
@@ -3,6 +3,7 @@ package helium_test
 import (
 	"os"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/lestrrat-go/helium"
@@ -311,6 +312,90 @@ func TestCopyNode(t *testing.T) {
 			require.NoError(t, err)
 			require.Contains(t, xml, `xmlns="http://docbook.org/ns/docbook"`)
 		})
+	})
+}
+
+func TestCopyEntityReference(t *testing.T) {
+	t.Parallel()
+
+	const srcXML = `<!DOCTYPE root [<!ENTITY payload "QUJD">]><root>&payload;&payload;</root>`
+	src, err := helium.NewParser().Parse(t.Context(), []byte(srcXML))
+	require.NoError(t, err)
+
+	srcFirst := src.DocumentElement().FirstChild()
+	require.Equal(t, helium.EntityRefNode, srcFirst.Type())
+	srcEntity, ok := helium.AsNode[*helium.Entity](srcFirst.FirstChild())
+	require.True(t, ok)
+	require.Same(t, src.IntSubset(), srcEntity.Parent())
+	require.NotNil(t, srcEntity.FirstChild(), "the parser must materialize replacement content on the declaration")
+
+	t.Run("direct copy resolves the destination declaration", func(t *testing.T) {
+		dst := helium.NewDefaultDocument()
+		require.NoError(t, helium.CopyDTDInfo(src, dst))
+
+		copied, copyErr := helium.CopyNode(srcFirst, dst)
+		require.NoError(t, copyErr)
+		dstEntity, found := dst.IntSubset().LookupEntity("payload")
+		require.True(t, found)
+		require.Same(t, dstEntity, copied.FirstChild())
+		require.NotSame(t, srcEntity, copied.FirstChild())
+		require.Same(t, dst, copied.OwnerDocument())
+		require.Same(t, dst, copied.FirstChild().OwnerDocument())
+		require.NotSame(t, srcEntity.FirstChild(), dstEntity.FirstChild())
+		require.Equal(t, srcEntity.FirstChild().Content(), dstEntity.FirstChild().Content())
+		require.NoError(t, dstEntity.FirstChild().(helium.MutableNode).AppendText([]byte("copy")))
+		require.Equal(t, []byte("QUJD"), srcEntity.FirstChild().Content())
+		require.Equal(t, []byte("QUJDcopy"), dstEntity.FirstChild().Content())
+	})
+
+	t.Run("missing destination declaration stays childless", func(t *testing.T) {
+		dst := helium.NewDefaultDocument()
+		copied, copyErr := helium.CopyNode(srcFirst, dst)
+		require.NoError(t, copyErr)
+		require.Nil(t, copied.FirstChild())
+
+		undeclared, createErr := src.CreateReference("missing")
+		require.NoError(t, createErr)
+		require.Nil(t, undeclared.FirstChild())
+		copied, copyErr = helium.CopyNode(undeclared, dst)
+		require.NoError(t, copyErr)
+		require.Nil(t, copied.FirstChild())
+	})
+
+	t.Run("document copy shares only its own repeated declaration", func(t *testing.T) {
+		copied, copyErr := helium.CopyDoc(src)
+		require.NoError(t, copyErr)
+		dstEntity, found := copied.IntSubset().LookupEntity("payload")
+		require.True(t, found)
+		require.NotSame(t, srcEntity, dstEntity)
+
+		first := copied.DocumentElement().FirstChild()
+		second := first.NextSibling()
+		require.Equal(t, helium.EntityRefNode, first.Type())
+		require.Equal(t, helium.EntityRefNode, second.Type())
+		require.Same(t, dstEntity, first.FirstChild())
+		require.Same(t, dstEntity, second.FirstChild())
+		require.Same(t, copied, first.OwnerDocument())
+		require.Same(t, copied, second.OwnerDocument())
+		require.Same(t, copied, dstEntity.OwnerDocument())
+	})
+
+	t.Run("document copy resolves an external declaration", func(t *testing.T) {
+		fsys := fstest.MapFS{"entities.dtd": {Data: []byte(`<!ENTITY payload "QUJD">`)}}
+		external, parseErr := helium.NewParser().
+			BlockXXE(false).
+			LoadExternalDTD(true).
+			FS(fsys).
+			Parse(t.Context(), []byte(`<!DOCTYPE root SYSTEM "entities.dtd"><root>&payload;</root>`))
+		require.NoError(t, parseErr)
+
+		copied, copyErr := helium.CopyDoc(external)
+		require.NoError(t, copyErr)
+		dstEntity, found := copied.ExtSubset().LookupEntity("payload")
+		require.True(t, found)
+		ref := copied.DocumentElement().FirstChild()
+		require.Same(t, dstEntity, ref.FirstChild())
+		require.Same(t, copied, dstEntity.OwnerDocument())
 	})
 }
 

--- a/copy_test.go
+++ b/copy_test.go
@@ -398,6 +398,71 @@ func TestCopyEntityReference(t *testing.T) {
 		require.Same(t, copied, dstEntity.OwnerDocument())
 	})
 
+	t.Run("document copy preserves declaration identity", func(t *testing.T) {
+		fsys := fstest.MapFS{"entities.dtd": {Data: []byte(`<!ENTITY payload "EXTERNAL">`)}}
+		source, parseErr := helium.NewParser().
+			BlockXXE(false).
+			LoadExternalDTD(true).
+			FS(fsys).
+			Parse(t.Context(), []byte(`<!DOCTYPE root SYSTEM "entities.dtd"><root/>`))
+		require.NoError(t, parseErr)
+
+		sourceExternal, found := source.ExtSubset().LookupEntity("payload")
+		require.True(t, found)
+		ref, createErr := source.CreateReference("payload")
+		require.NoError(t, createErr)
+		require.Same(t, sourceExternal, ref.FirstChild())
+		require.NoError(t, source.DocumentElement().AddChild(ref))
+
+		_, addErr := source.IntSubset().AddEntity(
+			"payload", enum.InternalGeneralEntity, "", "", "INTERNAL",
+		)
+		require.NoError(t, addErr)
+		require.Same(t, sourceExternal, ref.FirstChild())
+
+		copied, copyErr := helium.CopyDoc(source)
+		require.NoError(t, copyErr)
+		copiedExternal, found := copied.ExtSubset().LookupEntity("payload")
+		require.True(t, found)
+		copiedRef := copied.DocumentElement().FirstChild()
+		require.Same(t, copiedExternal, copiedRef.FirstChild())
+		require.Equal(t, "EXTERNAL", string(copiedRef.Content()))
+	})
+
+	t.Run("document copy preserves replacement declaration identity", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"entities.dtd": {Data: []byte(`<!ENTITY payload "EXTERNAL"><!ENTITY holder "&payload;">`)},
+		}
+		source, parseErr := helium.NewParser().
+			BlockXXE(false).
+			LoadExternalDTD(true).
+			FS(fsys).
+			Parse(t.Context(), []byte(`<!DOCTYPE root SYSTEM "entities.dtd"><root>&holder;</root>`))
+		require.NoError(t, parseErr)
+
+		sourceExternal, found := source.ExtSubset().LookupEntity("payload")
+		require.True(t, found)
+		sourceHolder, found := source.ExtSubset().LookupEntity("holder")
+		require.True(t, found)
+		require.Same(t, sourceExternal, sourceHolder.FirstChild().FirstChild())
+
+		_, addErr := source.IntSubset().AddEntity(
+			"payload", enum.InternalGeneralEntity, "", "", "INTERNAL",
+		)
+		require.NoError(t, addErr)
+		require.Same(t, sourceExternal, sourceHolder.FirstChild().FirstChild())
+
+		copied, copyErr := helium.CopyDoc(source)
+		require.NoError(t, copyErr)
+		copiedExternal, found := copied.ExtSubset().LookupEntity("payload")
+		require.True(t, found)
+		copiedHolder, found := copied.ExtSubset().LookupEntity("holder")
+		require.True(t, found)
+		copiedRef := copiedHolder.FirstChild()
+		require.Same(t, copiedExternal, copiedRef.FirstChild())
+		require.Equal(t, "EXTERNAL", string(copiedRef.Content()))
+	})
+
 	t.Run("document copy resolves an internal reference to an external declaration", func(t *testing.T) {
 		fsys := fstest.MapFS{"entities.dtd": {Data: []byte(`<!ENTITY external "EXTERNAL">`)}}
 		source, parseErr := helium.NewParser().

--- a/copy_test.go
+++ b/copy_test.go
@@ -362,6 +362,14 @@ func TestCopyEntityReference(t *testing.T) {
 		require.Nil(t, copied.FirstChild())
 	})
 
+	t.Run("nil destination creates a childless standalone reference", func(t *testing.T) {
+		copied, copyErr := helium.CopyNode(srcFirst, nil)
+		require.NoError(t, copyErr)
+		require.Equal(t, helium.EntityRefNode, copied.Type())
+		require.Nil(t, copied.OwnerDocument())
+		require.Nil(t, copied.FirstChild())
+	})
+
 	t.Run("numeric reference ignores a same-name destination declaration", func(t *testing.T) {
 		numeric, createErr := src.CreateCharRef("#65")
 		require.NoError(t, createErr)

--- a/copy_test.go
+++ b/copy_test.go
@@ -480,6 +480,41 @@ func TestCopyEntityReference(t *testing.T) {
 		require.Equal(t, "EXTERNAL", string(copiedRef.Content()))
 	})
 
+	t.Run("element copy preserves declaration subset identity", func(t *testing.T) {
+		fsys := fstest.MapFS{"entities.dtd": {Data: []byte(`<!ENTITY payload "EXTERNAL">`)}}
+		source, parseErr := helium.NewParser().
+			BlockXXE(false).
+			LoadExternalDTD(true).
+			FS(fsys).
+			Parse(t.Context(), []byte(`<!DOCTYPE root SYSTEM "entities.dtd"><root/>`))
+		require.NoError(t, parseErr)
+
+		sourceExternal, found := source.ExtSubset().LookupEntity("payload")
+		require.True(t, found)
+		ref, createErr := source.CreateReference("payload")
+		require.NoError(t, createErr)
+		require.Same(t, sourceExternal, ref.FirstChild())
+		require.NoError(t, source.DocumentElement().AddChild(ref))
+
+		_, addErr := source.IntSubset().AddEntity(
+			"payload", enum.InternalGeneralEntity, "", "", "INTERNAL",
+		)
+		require.NoError(t, addErr)
+		require.Same(t, sourceExternal, ref.FirstChild())
+
+		destination := helium.NewDefaultDocument()
+		_, copyErr := helium.CopyDTDSubsets(source, destination)
+		require.NoError(t, copyErr)
+		copiedRoot, copyErr := helium.CopyNode(source.DocumentElement(), destination)
+		require.NoError(t, copyErr)
+
+		destinationExternal, found := destination.ExtSubset().LookupEntity("payload")
+		require.True(t, found)
+		copiedRef := copiedRoot.FirstChild()
+		require.Same(t, destinationExternal, copiedRef.FirstChild())
+		require.Equal(t, "EXTERNAL", string(copiedRef.Content()))
+	})
+
 	t.Run("document copy preserves replacement declaration identity", func(t *testing.T) {
 		fsys := fstest.MapFS{
 			"entities.dtd": {Data: []byte(`<!ENTITY payload "EXTERNAL"><!ENTITY holder "&payload;">`)},

--- a/document.go
+++ b/document.go
@@ -433,15 +433,19 @@ func (d *Document) CreateReference(name string) (*EntityRef, error) {
 
 	ent, ok := d.GetEntity(n.name)
 	if ok {
-		n.content = []byte(ent.content)
-		// Original code says:
-		// The parent pointer in entity is a DTD pointer and thus is NOT
-		// updated.  Not sure if this is 100% correct.
-		setFirstChild(n, ent)
-		setLastChild(n, ent)
+		bindEntityReference(n, ent)
 	}
 
 	return n, nil
+}
+
+func bindEntityReference(ref *EntityRef, ent *Entity) {
+	ref.content = []byte(ent.content)
+	// Original code says:
+	// The parent pointer in entity is a DTD pointer and thus is NOT
+	// updated.  Not sure if this is 100% correct.
+	setFirstChild(ref, ent)
+	setLastChild(ref, ent)
 }
 
 // CreateAttribute builds an attribute node named name, with value parsed into

--- a/document.go
+++ b/document.go
@@ -109,8 +109,8 @@ type Document struct {
 	slabEscaped bool
 
 	// offChainChildClaim records that a node has been given this document as its
-	// parent WITHOUT being linked into the document's child list. CopyExtSubset
-	// is the one path in this package that does it: the copied external subset
+	// parent WITHOUT being linked into the document's child list. The DTD-subset
+	// copy paths do it when copying an external subset: the copied subset
 	// claims the destination document and is then reachable only through
 	// ExtSubset. An append through such a subset records its own result as the
 	// document's lastChild, which moves that record off the child list, so the
@@ -121,7 +121,7 @@ type Document struct {
 	// never for the elements the document owns, whose own lastChild records the
 	// claimant says nothing about. (CreateInternalSubset also gives a DTD this
 	// document as its parent, but it splices that DTD into the child list, so it
-	// creates no claim.) Set by copy_dtd.go CopyExtSubset; read through
+	// creates no claim.) Set by copy_dtd.go; read through
 	// node.go holdsOffChainChildClaim by tailJumpTarget and resolveOwnedTail.
 	offChainChildClaim bool
 }

--- a/internal/nodelink/nodelink.go
+++ b/internal/nodelink/nodelink.go
@@ -4,9 +4,10 @@
 //
 // xslt3's strip-space copier links freshly built nodes without the per-node
 // cycle and duplicate-attribute preflight that helium.MutableNode.AddChild
-// runs, and binds copied entity references to the copy of their exact source
-// declaration. The cycle-guard tests in xsd and xmldsig1 build deliberately
-// corrupt sibling chains. Package helium installs all five hooks in its init.
+// runs, binds copied entity references to the copy of their exact source
+// declaration, and creates private context-specific replacement views. The
+// cycle-guard tests in xsd and xmldsig1 build deliberately corrupt sibling
+// chains. Package helium installs all five hooks in its init.
 //
 // Hooks are typed with any, in place of helium.Node, to avoid an import cycle:
 // package helium imports this package to register them, so this package must
@@ -28,10 +29,13 @@ var AppendFastChild func(parent, child any) error
 // content are updated. Package helium installs it in init.
 var BindEntityReference func(ref, entity any)
 
-// Unlink detaches a helium.Node, passed as any, from its parent and sibling
-// chain. Unlike helium.UnlinkNode, it also accepts sealed non-MutableNode types
-// produced by a copier. Package helium installs it in init.
-var Unlink func(n any)
+// CloneEntityReferenceBinding creates a private copy of entity (a
+// *helium.Entity, passed as any), owned by ref's document, and binds ref (a
+// *helium.EntityRef, passed as any) to it. The copy starts without replacement
+// children so a sibling-package copier can build a context-specific replacement
+// view without changing the document's shared DTD declaration. Package helium
+// installs it in init.
+var CloneEntityReferenceBinding func(ref, entity any) any
 
 // CorruptSelfNextSibling writes n.next = n, making the node its own next
 // sibling. It is a raw pointer write with no cycle detection and no reciprocal

--- a/internal/nodelink/nodelink.go
+++ b/internal/nodelink/nodelink.go
@@ -6,7 +6,7 @@
 // cycle and duplicate-attribute preflight that helium.MutableNode.AddChild
 // runs, and binds copied entity references to the copy of their exact source
 // declaration. The cycle-guard tests in xsd and xmldsig1 build deliberately
-// corrupt sibling chains. Package helium installs all four hooks in its init.
+// corrupt sibling chains. Package helium installs all five hooks in its init.
 //
 // Hooks are typed with any, in place of helium.Node, to avoid an import cycle:
 // package helium imports this package to register them, so this package must
@@ -27,6 +27,11 @@ var AppendFastChild func(parent, child any) error
 // entity stays owned by its DTD; only ref's shared-child pointers and cached
 // content are updated. Package helium installs it in init.
 var BindEntityReference func(ref, entity any)
+
+// Unlink detaches a helium.Node, passed as any, from its parent and sibling
+// chain. Unlike helium.UnlinkNode, it also accepts sealed non-MutableNode types
+// produced by a copier. Package helium installs it in init.
+var Unlink func(n any)
 
 // CorruptSelfNextSibling writes n.next = n, making the node its own next
 // sibling. It is a raw pointer write with no cycle detection and no reciprocal

--- a/internal/nodelink/nodelink.go
+++ b/internal/nodelink/nodelink.go
@@ -4,8 +4,9 @@
 //
 // xslt3's strip-space copier links freshly built nodes without the per-node
 // cycle and duplicate-attribute preflight that helium.MutableNode.AddChild
-// runs. The cycle-guard tests in xsd and xmldsig1 build deliberately corrupt
-// sibling chains. Package helium installs all three hooks in its init.
+// runs, and binds copied entity references to the copy of their exact source
+// declaration. The cycle-guard tests in xsd and xmldsig1 build deliberately
+// corrupt sibling chains. Package helium installs all four hooks in its init.
 //
 // Hooks are typed with any, in place of helium.Node, to avoid an import cycle:
 // package helium imports this package to register them, so this package must
@@ -20,6 +21,12 @@ package nodelink
 // non-nil whenever package helium is linked in, which every caller of this hook
 // transitively is.
 var AppendFastChild func(parent, child any) error
+
+// BindEntityReference attaches entity (a *helium.Entity, passed as any) as the
+// declaration referenced by ref (a *helium.EntityRef, passed as any). The
+// entity stays owned by its DTD; only ref's shared-child pointers and cached
+// content are updated. Package helium installs it in init.
+var BindEntityReference func(ref, entity any)
 
 // CorruptSelfNextSibling writes n.next = n, making the node its own next
 // sibling. It is a raw pointer write with no cycle detection and no reciprocal

--- a/node.go
+++ b/node.go
@@ -901,9 +901,9 @@ func resolveOwnedTail(parent Node, pdn *docnode) Node {
 // parent, including every other parent in the same document, so it must never
 // be read from the owning document.
 //
-// The only claimant safe API creates is the external subset CopyExtSubset
-// copies, which is given the destination document as its parent and left
-// reachable only through ExtSubset. The claimed parent is that *Document
+// The only claimant safe API creates is an external subset copied through
+// CopyExtSubset or CopyDTDSubsets. It is given the destination document as its
+// parent and left reachable only through ExtSubset. The claimed parent is that *Document
 // itself, and Document.offChainChildClaim records it. (CreateInternalSubset
 // also gives a DTD the document as its parent, but it splices that DTD into the
 // child list, so it creates no claim.) Every other parent answers false in a
@@ -1015,8 +1015,8 @@ func reciprocalPrev(x *docnode) *docnode {
 // stake is the only one whose lastChild record the claim can invalidate, so a
 // claim on one parent must not cost every other parent in the same document its
 // O(1) resolution. The one parent safe API hands such a claimant is a *Document,
-// through CopyExtSubset, which gives the copied external subset the destination
-// document as its parent and then leaves it reachable only through ExtSubset,
+// through the DTD-subset copy paths, which give the copied external subset the
+// destination document as its parent and then leave it reachable only through ExtSubset,
 // never from the child list, so an append through that subset records its own
 // result as the document's tail and moves the record off the child list. That is
 // a condition, not a type: the shortcut is declined for a document that has

--- a/node_sibling_bench_test.go
+++ b/node_sibling_bench_test.go
@@ -246,7 +246,7 @@ func benchAddSiblingDocMiddle(b *testing.B, n int) {
 // parent, which is the parent a document-scale append actually uses and which
 // tracks the element arms exactly: the O(1) resolution is declined for the
 // CONDITION that makes a document's tail record untrustworthy (an off-chain
-// child claim, which only CopyExtSubset creates), never for the type.
+// child claim, which the DTD-subset copy paths create), never for the type.
 func BenchmarkAddSibling(b *testing.B) {
 	sizes := []int{500, 1000, 2000, 4000}
 

--- a/tree_fastpath.go
+++ b/tree_fastpath.go
@@ -16,6 +16,18 @@ type attrNamespaceCacheEntry struct {
 func init() {
 	nodelink.AppendFastChild = nodelinkAppendFastChild
 	nodelink.BindEntityReference = nodelinkBindEntityReference
+	nodelink.Unlink = nodelinkUnlink
+}
+
+// nodelinkUnlink adapts unlinkNode to the untyped internal/nodelink hook so a
+// sibling-package copier can detach any copied node, including a sealed
+// non-MutableNode, without adding a public mutation API.
+func nodelinkUnlink(n any) {
+	node, ok := n.(Node)
+	if !ok {
+		return
+	}
+	unlinkNode(node)
 }
 
 // nodelinkAppendFastChild adapts appendFastChild to the untyped

--- a/tree_fastpath.go
+++ b/tree_fastpath.go
@@ -16,18 +16,7 @@ type attrNamespaceCacheEntry struct {
 func init() {
 	nodelink.AppendFastChild = nodelinkAppendFastChild
 	nodelink.BindEntityReference = nodelinkBindEntityReference
-	nodelink.Unlink = nodelinkUnlink
-}
-
-// nodelinkUnlink adapts unlinkNode to the untyped internal/nodelink hook so a
-// sibling-package copier can detach any copied node, including a sealed
-// non-MutableNode, without adding a public mutation API.
-func nodelinkUnlink(n any) {
-	node, ok := n.(Node)
-	if !ok {
-		return
-	}
-	unlinkNode(node)
+	nodelink.CloneEntityReferenceBinding = nodelinkCloneEntityReferenceBinding
 }
 
 // nodelinkAppendFastChild adapts appendFastChild to the untyped
@@ -55,6 +44,21 @@ func nodelinkBindEntityReference(ref, entity any) {
 		return
 	}
 	bindEntityReference(r, e)
+}
+
+// nodelinkCloneEntityReferenceBinding gives the strip-space copier a private
+// entity replacement view for one reference context. The document's DTD keeps
+// its shared declaration unchanged; the private entity carries the declaration
+// metadata and receives context-filtered replacement children from the caller.
+func nodelinkCloneEntityReferenceBinding(ref, entity any) any {
+	r, refOK := ref.(*EntityRef)
+	e, entityOK := entity.(*Entity)
+	if !refOK || !entityOK {
+		return nil
+	}
+	cp := copyEntity(e, r.OwnerDocument())
+	bindEntityReference(r, cp)
+	return cp
 }
 
 // appendFastChild links child as the last child of parent without running the

--- a/tree_fastpath.go
+++ b/tree_fastpath.go
@@ -15,6 +15,7 @@ type attrNamespaceCacheEntry struct {
 
 func init() {
 	nodelink.AppendFastChild = nodelinkAppendFastChild
+	nodelink.BindEntityReference = nodelinkBindEntityReference
 }
 
 // nodelinkAppendFastChild adapts appendFastChild to the untyped
@@ -30,6 +31,18 @@ func nodelinkAppendFastChild(parent, child any) error {
 		return errors.New("child is not a node")
 	}
 	return appendFastChild(p, c)
+}
+
+// nodelinkBindEntityReference adapts bindEntityReference to the untyped
+// internal/nodelink hook so a sibling-package copier can retain declaration
+// identity without adding a public mutation API.
+func nodelinkBindEntityReference(ref, entity any) {
+	r, refOK := ref.(*EntityRef)
+	e, entityOK := entity.(*Entity)
+	if !refOK || !entityOK {
+		return
+	}
+	bindEntityReference(r, e)
 }
 
 // appendFastChild links child as the last child of parent without running the

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -242,6 +242,52 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 	})
 }
 
+func TestDecryptCopiedDeclaredEntityCipherValue(t *testing.T) {
+	t.Parallel()
+
+	sessionKey := []byte("0123456789abcdef0123456789abcdef")
+	doc := mustParseXML(t, `<secret>copy-safe</secret>`)
+	_, err := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		SessionKey(sessionKey).
+		EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	encryptedXML, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	const cipherOpen = `<xenc:CipherValue>`
+	cipherStart := strings.Index(encryptedXML, cipherOpen)
+	require.NotEqual(t, -1, cipherStart)
+	cipherStart += len(cipherOpen)
+	require.GreaterOrEqual(t, len(encryptedXML)-cipherStart, 4)
+	quantum := encryptedXML[cipherStart : cipherStart+4]
+	encryptedXML = encryptedXML[:cipherStart] + `&quantum;` + encryptedXML[cipherStart+4:]
+	rootStart := strings.Index(encryptedXML, `<xenc:EncryptedData`)
+	require.NotEqual(t, -1, rootStart)
+	encryptedXML = encryptedXML[:rootStart] +
+		`<!DOCTYPE xenc:EncryptedData [<!ENTITY quantum "` + quantum + `">]>` +
+		encryptedXML[rootStart:]
+
+	parsed := mustParseXML(t, encryptedXML)
+	copied, err := helium.CopyDoc(parsed)
+	require.NoError(t, err)
+
+	for name, candidate := range map[string]*helium.Document{"original": parsed, "copy": copied} {
+		t.Run(name, func(t *testing.T) {
+			encryptedData := findEncryptedData(t, candidate)
+			require.NotNil(t, encryptedData)
+			nodes, decryptErr := xmlenc1.NewDecryptor().
+				SessionKey(sessionKey).
+				Decrypt(t.Context(), encryptedData)
+			require.NoError(t, decryptErr)
+			require.Len(t, nodes, 1)
+			plaintext, writeErr := helium.WriteString(nodes[0])
+			require.NoError(t, writeErr)
+			require.Equal(t, `<secret>copy-safe</secret>`, plaintext)
+		})
+	}
+}
+
 // The default block algorithm is what a caller who configures nothing puts on
 // the wire, so it must be an identifier a standards-conforming peer
 // recognizes. W3C xmlenc-core1 §5.2 defines AES-GCM only in the XML

--- a/xslt3/execute_builtin.go
+++ b/xslt3/execute_builtin.go
@@ -526,23 +526,27 @@ func hasElementOnlyContent(elem *helium.Element) bool {
 // is resolved at compile time (nt.URI / nt.HasURI), using the namespace context
 // in scope at the declaration, so no runtime binding map is consulted here.
 func matchSpaceNameTest(nt nameTest, elem *helium.Element) bool {
+	return matchSpaceExpandedName(nt, elem.LocalName(), elem.URI())
+}
+
+func matchSpaceExpandedName(nt nameTest, local, uri string) bool {
 	if nt.Local == "*" && nt.Prefix == "" && !nt.HasURI {
 		return true // "*" matches all
 	}
 	if nt.Prefix == "*" {
 		// "*:NCName" matches elements with given local name in any namespace
-		return elem.LocalName() == nt.Local
+		return local == nt.Local
 	}
 	if nt.Local == "*" {
 		// "prefix:*" matches elements in the resolved namespace
-		return nt.HasURI && elem.URI() == nt.URI
+		return nt.HasURI && uri == nt.URI
 	}
 	// Named test: namespace URI was resolved at compile time.
 	if nt.HasURI {
-		return elem.LocalName() == nt.Local && elem.URI() == nt.URI
+		return local == nt.Local && uri == nt.URI
 	}
 	// "local" with no namespace binding matches the local name in no namespace.
-	return elem.LocalName() == nt.Local && elem.URI() == ""
+	return local == nt.Local && uri == ""
 }
 
 // nameTestPriority returns the priority of a nameTest for conflict resolution.

--- a/xslt3/strip_space_copy.go
+++ b/xslt3/strip_space_copy.go
@@ -112,6 +112,9 @@ func copyAndStrip(src *helium.Document, strip, preserve []nameTest, buildNodeMap
 		sc.nodeMap = make(map[helium.Node]helium.Node)
 		sc.nodeMap[src] = dst
 	}
+	if err := sc.copyEntityReplacementTrees(); err != nil {
+		return nil, nil, err
+	}
 
 	// Copy document-level children in source order, skipping the DTD (already
 	// handled above). The document root has no element parent and no inherited
@@ -212,6 +215,13 @@ func (sc *stripCopier) copyNode(src helium.Node, parent *helium.Element, inScope
 	case helium.ProcessingInstructionNode:
 		return sc.record(src, sc.dst.CreatePI(src.Name(), string(src.Content()))), nil
 	case helium.EntityRefNode:
+		// A whitespace-only replacement is a text node in the expanded XDM tree.
+		// Strip it using the reference's containing element and xml:space context;
+		// the shared declaration graph cannot carry a per-reference parent.
+		if _, ok := helium.AsNode[*helium.Entity](src.FirstChild()); ok &&
+			len(src.Content()) > 0 && !xmlSpacePreserve && sc.stripText(src, parent) {
+			return nil, nil //nolint:nilnil // omitted whitespace-only replacement
+		}
 		if srcEntity, ok := helium.AsNode[*helium.Entity](src.FirstChild()); ok {
 			if dstEntity := sc.entityCopies[srcEntity]; dstEntity != nil {
 				cp, err := sc.dst.CreateCharRef(src.Name())
@@ -234,6 +244,49 @@ func (sc *stripCopier) copyNode(src helium.Node, parent *helium.Element, inScope
 		// stays faithful (e.g. NamespaceNode handled the same way).
 		return helium.CopyNode(src, sc.dst)
 	}
+}
+
+// copyEntityReplacementTrees rebuilds each copied declaration's replacement
+// children through the active strip copier. References in both the DTD and the
+// document still bind to the one destination-owned declaration from
+// entityCopies; only its replacement subtree is replaced.
+func (sc *stripCopier) copyEntityReplacementTrees() error {
+	if len(sc.strip) == 0 && sc.schemaWS == nil {
+		return nil
+	}
+
+	type replacementCopy struct {
+		entity   *helium.Entity
+		children []helium.Node
+	}
+	replacements := make([]replacementCopy, 0, len(sc.entityCopies))
+	for srcEntity, dstEntity := range sc.entityCopies {
+		replacement := replacementCopy{entity: dstEntity}
+		for child := range helium.Children(srcEntity) {
+			cp, err := sc.copyNode(child, nil, nil, false)
+			if err != nil {
+				return err
+			}
+			if cp != nil {
+				replacement.children = append(replacement.children, cp)
+			}
+		}
+		replacements = append(replacements, replacement)
+	}
+
+	for _, replacement := range replacements {
+		for child := replacement.entity.FirstChild(); child != nil; {
+			next := child.NextSibling()
+			nodelink.Unlink(child)
+			child = next
+		}
+		for _, child := range replacement.children {
+			if err := nodelink.AppendFastChild(replacement.entity, child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // copyElement copies an element, reproducing its own namespace declarations

--- a/xslt3/strip_space_copy.go
+++ b/xslt3/strip_space_copy.go
@@ -1,6 +1,7 @@
 package xslt3
 
 import (
+	"fmt"
 	"maps"
 	"slices"
 
@@ -112,10 +113,6 @@ func copyAndStrip(src *helium.Document, strip, preserve []nameTest, buildNodeMap
 		sc.nodeMap = make(map[helium.Node]helium.Node)
 		sc.nodeMap[src] = dst
 	}
-	if err := sc.copyEntityReplacementTrees(); err != nil {
-		return nil, nil, err
-	}
-
 	// Copy document-level children in source order, skipping the DTD (already
 	// handled above). The document root has no element parent and no inherited
 	// namespace scope.
@@ -123,7 +120,7 @@ func copyAndStrip(src *helium.Document, strip, preserve []nameTest, buildNodeMap
 		if c.Type() == helium.DTDNode {
 			continue
 		}
-		child, err := sc.copyNode(c, nil, nil, false)
+		child, err := sc.copyNode(c, nil, nil, false, false)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -173,6 +170,18 @@ type stripCopier struct {
 	// entityCopies binds a copied EntityRef to the copy of its actual source
 	// declaration, even when the other DTD subset contains the same name.
 	entityCopies map[*helium.Entity]*helium.Entity
+	// replacementCopies stores context-specific private entity views. The shared
+	// DTD declaration stays byte-faithful; each view applies whitespace rules from
+	// the reference's containing element and inherited xml:space state. Replacement
+	// names keep prefix metadata without declaring a site binding, so equal
+	// whitespace contexts can share a view across namespace scopes.
+	replacementCopies map[entityReplacementContext]*helium.Entity
+}
+
+type entityReplacementContext struct {
+	entity           *helium.Entity
+	parent           *helium.Element
+	xmlSpacePreserve bool
 }
 
 // record stores the original->copy mapping when a node map is being built and
@@ -192,14 +201,20 @@ func (sc *stripCopier) record(src, cp helium.Node) helium.Node {
 //
 // Returns (nil, nil) when the node is a whitespace-only text/CDATA node that
 // strip-space removes.
-func (sc *stripCopier) copyNode(src helium.Node, parent *helium.Element, inScope map[string]*helium.Namespace, xmlSpacePreserve bool) (helium.Node, error) {
+func (sc *stripCopier) copyNode(
+	src helium.Node,
+	parent *helium.Element,
+	inScope map[string]*helium.Namespace,
+	xmlSpacePreserve bool,
+	entityReplacement bool,
+) (helium.Node, error) {
 	switch src.Type() {
 	case helium.ElementNode:
 		elem, ok := helium.AsNode[*helium.Element](src)
 		if !ok {
 			return nil, nil //nolint:nilnil // a nil node with no error means "omit from copy"
 		}
-		return sc.copyElement(elem, inScope, xmlSpacePreserve)
+		return sc.copyElement(elem, inScope, xmlSpacePreserve, entityReplacement)
 	case helium.TextNode:
 		if !xmlSpacePreserve && sc.stripText(src, parent) {
 			return nil, nil //nolint:nilnil // omitted whitespace-only node
@@ -228,7 +243,13 @@ func (sc *stripCopier) copyNode(src helium.Node, parent *helium.Element, inScope
 				if err != nil {
 					return nil, err
 				}
-				nodelink.BindEntityReference(cp, dstEntity)
+				if len(sc.strip) == 0 && sc.schemaWS == nil {
+					nodelink.BindEntityReference(cp, dstEntity)
+				} else if err := sc.bindContextualEntityReplacement(
+					cp, srcEntity, dstEntity, parent, inScope, xmlSpacePreserve,
+				); err != nil {
+					return nil, err
+				}
 				return sc.record(src, cp), nil
 			}
 		}
@@ -246,44 +267,46 @@ func (sc *stripCopier) copyNode(src helium.Node, parent *helium.Element, inScope
 	}
 }
 
-// copyEntityReplacementTrees rebuilds each copied declaration's replacement
-// children through the active strip copier. References in both the DTD and the
-// document still bind to the one destination-owned declaration from
-// entityCopies; only its replacement subtree is replaced.
-func (sc *stripCopier) copyEntityReplacementTrees() error {
-	if len(sc.strip) == 0 && sc.schemaWS == nil {
+// bindContextualEntityReplacement binds ref to a private entity view whose
+// replacement children are copied under the reference site's whitespace
+// context. Equal whitespace contexts share one view; different containing
+// elements or inherited states never rewrite the document's shared declaration.
+func (sc *stripCopier) bindContextualEntityReplacement(
+	ref *helium.EntityRef,
+	srcEntity, dstEntity *helium.Entity,
+	parent *helium.Element,
+	inScope map[string]*helium.Namespace,
+	xmlSpacePreserve bool,
+) error {
+	key := entityReplacementContext{
+		entity:           srcEntity,
+		parent:           parent,
+		xmlSpacePreserve: xmlSpacePreserve,
+	}
+	if entity := sc.replacementCopies[key]; entity != nil {
+		nodelink.BindEntityReference(ref, entity)
 		return nil
 	}
 
-	type replacementCopy struct {
-		entity   *helium.Entity
-		children []helium.Node
+	private, ok := nodelink.CloneEntityReferenceBinding(ref, dstEntity).(*helium.Entity)
+	if !ok {
+		return fmt.Errorf("xslt3: could not create a private entity replacement for %q", ref.Name())
 	}
-	replacements := make([]replacementCopy, 0, len(sc.entityCopies))
-	for srcEntity, dstEntity := range sc.entityCopies {
-		replacement := replacementCopy{entity: dstEntity}
-		for child := range helium.Children(srcEntity) {
-			cp, err := sc.copyNode(child, nil, nil, false)
-			if err != nil {
-				return err
-			}
-			if cp != nil {
-				replacement.children = append(replacement.children, cp)
-			}
-		}
-		replacements = append(replacements, replacement)
+	if sc.replacementCopies == nil {
+		sc.replacementCopies = make(map[entityReplacementContext]*helium.Entity)
 	}
+	sc.replacementCopies[key] = private
 
-	for _, replacement := range replacements {
-		for child := replacement.entity.FirstChild(); child != nil; {
-			next := child.NextSibling()
-			nodelink.Unlink(child)
-			child = next
+	for child := range helium.Children(srcEntity) {
+		cp, err := sc.copyNode(child, parent, inScope, xmlSpacePreserve, true)
+		if err != nil {
+			return err
 		}
-		for _, child := range replacement.children {
-			if err := nodelink.AppendFastChild(replacement.entity, child); err != nil {
-				return err
-			}
+		if cp == nil {
+			continue
+		}
+		if err := nodelink.AppendFastChild(private, cp); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -293,7 +316,12 @@ func (sc *stripCopier) copyEntityReplacementTrees() error {
 // verbatim and binding its active namespace to an in-scope declaration without
 // over-declaring it. It then copies attributes and recurses into children using
 // nodelink.AppendFastChild for direct linkage.
-func (sc *stripCopier) copyElement(src *helium.Element, inScope map[string]*helium.Namespace, xmlSpacePreserve bool) (helium.Node, error) {
+func (sc *stripCopier) copyElement(
+	src *helium.Element,
+	inScope map[string]*helium.Namespace,
+	xmlSpacePreserve bool,
+	entityReplacement bool,
+) (helium.Node, error) {
 	elem, err := sc.dst.CreateElement(src.LocalName())
 	if err != nil {
 		return nil, err
@@ -330,23 +358,32 @@ func (sc *stripCopier) copyElement(src *helium.Element, inScope map[string]*heli
 	if ns := src.Namespace(); ns != nil && ns.URI() != "" {
 		active := childScope[ns.Prefix()]
 		if active == nil || active.URI() != ns.URI() {
-			// No in-scope declaration matches (degenerate source); declare it here
-			// to keep the copy serializable, mirroring helium.CopyDoc's fallback.
-			decl, err := sc.dst.CreateNamespace(ns.Prefix(), ns.URI())
-			if err != nil {
-				return nil, err
+			if entityReplacement {
+				if err := elem.SetActiveNamespace(ns.Prefix(), ns.URI()); err != nil {
+					return nil, err
+				}
+				active = nil
+			} else {
+				// No in-scope declaration matches (degenerate source); declare it here
+				// to keep the copy serializable, mirroring helium.CopyDoc's fallback.
+				decl, err := sc.dst.CreateNamespace(ns.Prefix(), ns.URI())
+				if err != nil {
+					return nil, err
+				}
+				if err := elem.AddNamespaceDecl(decl); err != nil {
+					return nil, err
+				}
+				if childScope == nil || len(ownDecls) == 0 {
+					childScope = make(map[string]*helium.Namespace, len(inScope)+1)
+					maps.Copy(childScope, inScope)
+				}
+				childScope[ns.Prefix()] = decl
+				active = decl
 			}
-			if err := elem.AddNamespaceDecl(decl); err != nil {
-				return nil, err
-			}
-			if childScope == nil || len(ownDecls) == 0 {
-				childScope = make(map[string]*helium.Namespace, len(inScope)+1)
-				maps.Copy(childScope, inScope)
-			}
-			childScope[ns.Prefix()] = decl
-			active = decl
 		}
-		elem.SetNamespace(active)
+		if active != nil {
+			elem.SetNamespace(active)
+		}
 	}
 
 	// Copy attributes, preserving namespace information. Use the literal setters
@@ -388,7 +425,7 @@ func (sc *stripCopier) copyElement(src *helium.Element, inScope map[string]*heli
 	}
 
 	for c := src.FirstChild(); c != nil; c = c.NextSibling() {
-		child, err := sc.copyNode(c, src, childScope, childPreserve)
+		child, err := sc.copyNode(c, src, childScope, childPreserve, entityReplacement)
 		if err != nil {
 			return nil, err
 		}

--- a/xslt3/strip_space_copy.go
+++ b/xslt3/strip_space_copy.go
@@ -72,15 +72,7 @@ func copyAndStrip(src *helium.Document, strip, preserve []nameTest, buildNodeMap
 	srcIDs := src.IDTable()
 	rebuildIDs := !src.SkipIDs() && len(srcIDs) > 0
 
-	// Deep-copy the internal DTD subset first (metadata + entities/elements/
-	// attributes/notations), matching helium.CopyDoc's ordering so the copy
-	// round-trips identically.
-	if err := helium.CopyDTDInfo(src, dst); err != nil {
-		return nil, nil, err
-	}
-
-	// Carry over the source's EXTERNAL DTD subset too. CopyDTDInfo (like
-	// helium.CopyDoc) only handles the internal subset, but GetElementByID's lazy
+	// Carry over both DTD subsets. GetElementByID's lazy
 	// tree walk consults BOTH subsets for ID-typed attribute declarations. The
 	// copy drops the source ID table (it points at the source's elements), so id()
 	// on the copy falls back to that walk; without the external subset, IDs
@@ -90,9 +82,13 @@ func copyAndStrip(src *helium.Document, strip, preserve []nameTest, buildNodeMap
 	// Deep-copy the external subset, sharing no pointer: the copy
 	// document can be exposed to user code via raw-result capture, and *DTD has
 	// mutators, so an aliased external subset would let a handler mutating the
-	// copy's ExtSubset corrupt the source. CopyExtSubset gives the copy its own
-	// independent external subset while keeping ID resolution identical.
-	helium.CopyExtSubset(src, dst)
+	// copy's ExtSubset corrupt the source. CopyDTDSubsets gives the copy its own
+	// independent external subset while keeping ID resolution identical. The
+	// combined copy registers both subsets before resolving entity replacement
+	// trees, so references across the subset boundary retain their expansion.
+	if err := helium.CopyDTDSubsets(src, dst); err != nil {
+		return nil, nil, err
+	}
 
 	sc := &stripCopier{dst: dst, strip: strip, preserve: preserve, schemaWS: schemaWS}
 	// When rebuilding the ID table, record source-element->copy-element so the

--- a/xslt3/strip_space_copy.go
+++ b/xslt3/strip_space_copy.go
@@ -86,11 +86,18 @@ func copyAndStrip(src *helium.Document, strip, preserve []nameTest, buildNodeMap
 	// independent external subset while keeping ID resolution identical. The
 	// combined copy registers both subsets before resolving entity replacement
 	// trees, so references across the subset boundary retain their expansion.
-	if err := helium.CopyDTDSubsets(src, dst); err != nil {
+	entityCopies, err := helium.CopyDTDSubsets(src, dst)
+	if err != nil {
 		return nil, nil, err
 	}
 
-	sc := &stripCopier{dst: dst, strip: strip, preserve: preserve, schemaWS: schemaWS}
+	sc := &stripCopier{
+		dst:          dst,
+		strip:        strip,
+		preserve:     preserve,
+		schemaWS:     schemaWS,
+		entityCopies: entityCopies,
+	}
 	// When rebuilding the ID table, record source-element->copy-element so the
 	// source's ID entries can be translated onto the copy after the walk.
 	if rebuildIDs {
@@ -160,6 +167,9 @@ type stripCopier struct {
 	// elemMap, when non-nil, records source-element->copy-element correspondence so
 	// the copy's ID table can be rebuilt by translating the source's ID entries.
 	elemMap map[*helium.Element]*helium.Element
+	// entityCopies binds a copied EntityRef to the copy of its actual source
+	// declaration, even when the other DTD subset contains the same name.
+	entityCopies map[*helium.Entity]*helium.Entity
 }
 
 // record stores the original->copy mapping when a node map is being built and
@@ -202,6 +212,16 @@ func (sc *stripCopier) copyNode(src helium.Node, parent *helium.Element, inScope
 	case helium.ProcessingInstructionNode:
 		return sc.record(src, sc.dst.CreatePI(src.Name(), string(src.Content()))), nil
 	case helium.EntityRefNode:
+		if srcEntity, ok := helium.AsNode[*helium.Entity](src.FirstChild()); ok {
+			if dstEntity := sc.entityCopies[srcEntity]; dstEntity != nil {
+				cp, err := sc.dst.CreateCharRef(src.Name())
+				if err != nil {
+					return nil, err
+				}
+				nodelink.BindEntityReference(cp, dstEntity)
+				return sc.record(src, cp), nil
+			}
+		}
 		cp, err := sc.dst.CreateReference(src.Name())
 		if err != nil {
 			return nil, err

--- a/xslt3/strip_space_copy.go
+++ b/xslt3/strip_space_copy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -172,15 +173,15 @@ type stripCopier struct {
 	entityCopies map[*helium.Entity]*helium.Entity
 	// replacementCopies stores context-specific private entity views. The shared
 	// DTD declaration stays byte-faithful; each view applies whitespace rules from
-	// the reference's containing element and inherited xml:space state. Replacement
-	// names keep prefix metadata without declaring a site binding, so equal
-	// whitespace contexts can share a view across namespace scopes.
+	// the reference's containing element, inherited xml:space state, and namespace
+	// scope. Replacement names are resolved against that site-specific scope.
 	replacementCopies map[entityReplacementContext]*helium.Entity
 }
 
 type entityReplacementContext struct {
 	entity           *helium.Entity
 	parent           *helium.Element
+	namespaceContext string
 	xmlSpacePreserve bool
 }
 
@@ -216,12 +217,12 @@ func (sc *stripCopier) copyNode(
 		}
 		return sc.copyElement(elem, inScope, xmlSpacePreserve, entityReplacement)
 	case helium.TextNode:
-		if !xmlSpacePreserve && sc.stripText(src, parent) {
+		if !xmlSpacePreserve && sc.stripText(src, parent, inScope, entityReplacement) {
 			return nil, nil //nolint:nilnil // omitted whitespace-only node
 		}
 		return sc.record(src, sc.dst.CreateText(slices.Clone(src.Content()))), nil
 	case helium.CDATASectionNode:
-		if !xmlSpacePreserve && sc.stripText(src, parent) {
+		if !xmlSpacePreserve && sc.stripText(src, parent, inScope, entityReplacement) {
 			return nil, nil //nolint:nilnil // omitted whitespace-only node
 		}
 		return sc.record(src, sc.dst.CreateCDATASection(slices.Clone(src.Content()))), nil
@@ -234,7 +235,8 @@ func (sc *stripCopier) copyNode(
 		// Strip it using the reference's containing element and xml:space context;
 		// the shared declaration graph cannot carry a per-reference parent.
 		if _, ok := helium.AsNode[*helium.Entity](src.FirstChild()); ok &&
-			len(src.Content()) > 0 && !xmlSpacePreserve && sc.stripText(src, parent) {
+			len(src.Content()) > 0 && !xmlSpacePreserve &&
+			sc.stripText(src, parent, inScope, entityReplacement) {
 			return nil, nil //nolint:nilnil // omitted whitespace-only replacement
 		}
 		if srcEntity, ok := helium.AsNode[*helium.Entity](src.FirstChild()); ok {
@@ -281,6 +283,7 @@ func (sc *stripCopier) bindContextualEntityReplacement(
 	key := entityReplacementContext{
 		entity:           srcEntity,
 		parent:           parent,
+		namespaceContext: namespaceContextKey(inScope),
 		xmlSpacePreserve: xmlSpacePreserve,
 	}
 	if entity := sc.replacementCopies[key]; entity != nil {
@@ -310,6 +313,22 @@ func (sc *stripCopier) bindContextualEntityReplacement(
 		}
 	}
 	return nil
+}
+
+// namespaceContextKey returns a stable identity for the effective prefix bindings
+// at an entity reference site. XML names and namespace URIs cannot contain NUL,
+// so NUL separators keep the sorted prefix/URI sequence unambiguous.
+func namespaceContextKey(inScope map[string]*helium.Namespace) string {
+	var b strings.Builder
+	for _, prefix := range slices.Sorted(maps.Keys(inScope)) {
+		b.WriteString(prefix)
+		b.WriteByte(0)
+		if ns := inScope[prefix]; ns != nil {
+			b.WriteString(ns.URI())
+		}
+		b.WriteByte(0)
+	}
+	return b.String()
 }
 
 // copyElement copies an element, reproducing its own namespace declarations
@@ -352,38 +371,42 @@ func (sc *stripCopier) copyElement(
 		}
 	}
 
-	// Bind the active namespace to a declaration in scope on the copy. The source
-	// tree is well-formed, so a matching (prefix, URI) declaration always exists
-	// either on this element or an ancestor; reuse it instead of declaring anew.
-	if ns := src.Namespace(); ns != nil && ns.URI() != "" {
-		active := childScope[ns.Prefix()]
-		if active == nil || active.URI() != ns.URI() {
-			if entityReplacement {
-				if err := elem.SetActiveNamespace(ns.Prefix(), ns.URI()); err != nil {
-					return nil, err
-				}
-				active = nil
-			} else {
-				// No in-scope declaration matches (degenerate source); declare it here
-				// to keep the copy serializable, mirroring helium.CopyDoc's fallback.
-				decl, err := sc.dst.CreateNamespace(ns.Prefix(), ns.URI())
-				if err != nil {
-					return nil, err
-				}
-				if err := elem.AddNamespaceDecl(decl); err != nil {
-					return nil, err
-				}
-				if childScope == nil || len(ownDecls) == 0 {
-					childScope = make(map[string]*helium.Namespace, len(inScope)+1)
-					maps.Copy(childScope, inScope)
-				}
-				childScope[ns.Prefix()] = decl
-				active = decl
+	// Entity replacement names are shared by the source DTD, but their prefixes
+	// resolve at each reference site. Bind them from the current site scope instead
+	// of retaining the namespace URI recorded on the shared source replacement.
+	if entityReplacement {
+		prefix := src.Prefix()
+		if prefix == lexicon.PrefixXML {
+			if err := elem.SetActiveNamespace(prefix, lexicon.NamespaceXML); err != nil {
+				return nil, err
 			}
-		}
-		if active != nil {
+		} else if active := childScope[prefix]; active != nil && active.URI() != "" {
 			elem.SetNamespace(active)
 		}
+	} else if ns := src.Namespace(); ns != nil && ns.URI() != "" {
+		// Bind the active namespace to a declaration in scope on the copy. The
+		// source tree is well-formed, so a matching (prefix, URI) declaration always
+		// exists either on this element or an ancestor; reuse it instead of declaring
+		// anew.
+		active := childScope[ns.Prefix()]
+		if active == nil || active.URI() != ns.URI() {
+			// No in-scope declaration matches (degenerate source); declare it here
+			// to keep the copy serializable, mirroring helium.CopyDoc's fallback.
+			decl, err := sc.dst.CreateNamespace(ns.Prefix(), ns.URI())
+			if err != nil {
+				return nil, err
+			}
+			if err := elem.AddNamespaceDecl(decl); err != nil {
+				return nil, err
+			}
+			if childScope == nil || len(ownDecls) == 0 {
+				childScope = make(map[string]*helium.Namespace, len(inScope)+1)
+				maps.Copy(childScope, inScope)
+			}
+			childScope[ns.Prefix()] = decl
+			active = decl
+		}
+		elem.SetNamespace(active)
 	}
 
 	// Copy attributes, preserving namespace information. Use the literal setters
@@ -446,7 +469,12 @@ func (sc *stripCopier) copyElement(
 // in, and xml:space inheritance is already handled by the caller via the
 // xmlSpacePreserve flag, so only the element's strip/preserve match and DTD
 // element-only content are evaluated here.
-func (sc *stripCopier) stripText(src helium.Node, parent *helium.Element) bool {
+func (sc *stripCopier) stripText(
+	src helium.Node,
+	parent *helium.Element,
+	inScope map[string]*helium.Namespace,
+	entityReplacement bool,
+) bool {
 	if parent == nil {
 		return false
 	}
@@ -463,7 +491,11 @@ func (sc *stripCopier) stripText(src helium.Node, parent *helium.Element) bool {
 	case schemaWSPreserve:
 		return false
 	}
-	if isElementStrippedBy(parent, sc.strip, sc.preserve) {
+	uri := parent.URI()
+	if entityReplacement {
+		uri = replacementElementURI(parent, inScope)
+	}
+	if isElementStrippedBy(parent.LocalName(), uri, sc.strip, sc.preserve) {
 		return true
 	}
 	// A copyAndStrip call with no strip rules AND no schema classifier is a PURE
@@ -478,16 +510,27 @@ func (sc *stripCopier) stripText(src helium.Node, parent *helium.Element) bool {
 	return hasElementOnlyContent(parent)
 }
 
+func replacementElementURI(elem *helium.Element, inScope map[string]*helium.Namespace) string {
+	prefix := elem.Prefix()
+	if prefix == lexicon.PrefixXML {
+		return lexicon.NamespaceXML
+	}
+	if ns := inScope[prefix]; ns != nil {
+		return ns.URI()
+	}
+	return ""
+}
+
 // isElementStrippedBy is the exec-context-free form of execContext.isElementStripped:
 // it resolves the most authoritative matching strip rule and checks whether a
 // preserve rule of at least equal authority overrides it.
-func isElementStrippedBy(elem *helium.Element, strip, preserve []nameTest) bool {
+func isElementStrippedBy(local, uri string, strip, preserve []nameTest) bool {
 	if len(strip) == 0 {
 		return false
 	}
 	stripPrec, stripPriority, stripped := -1, -1, false
 	for _, nt := range strip {
-		if !matchSpaceNameTest(nt, elem) {
+		if !matchSpaceExpandedName(nt, local, uri) {
 			continue
 		}
 		if !stripped || rankSpaceRule(nt) > packSpaceRank(stripPrec, stripPriority) {
@@ -501,7 +544,7 @@ func isElementStrippedBy(elem *helium.Element, strip, preserve []nameTest) bool 
 	}
 	stripRank := packSpaceRank(stripPrec, stripPriority)
 	for _, nt := range preserve {
-		if matchSpaceNameTest(nt, elem) && rankSpaceRule(nt) >= stripRank {
+		if matchSpaceExpandedName(nt, local, uri) && rankSpaceRule(nt) >= stripRank {
 			return false
 		}
 	}

--- a/xslt3/strip_space_copy.go
+++ b/xslt3/strip_space_copy.go
@@ -222,7 +222,9 @@ func (sc *stripCopier) copyNode(src helium.Node, parent *helium.Element, inScope
 				return sc.record(src, cp), nil
 			}
 		}
-		cp, err := sc.dst.CreateReference(src.Name())
+		// This copier has already copied the source DTD. Preserve an unbound
+		// source reference as bare instead of resolving it against that DTD.
+		cp, err := sc.dst.CreateCharRef(src.Name())
 		if err != nil {
 			return nil, err
 		}

--- a/xslt3/strip_space_copy.go
+++ b/xslt3/strip_space_copy.go
@@ -206,7 +206,7 @@ func (sc *stripCopier) copyNode(src helium.Node, parent *helium.Element, inScope
 	case helium.ProcessingInstructionNode:
 		return sc.record(src, sc.dst.CreatePI(src.Name(), string(src.Content()))), nil
 	case helium.EntityRefNode:
-		cp, err := sc.dst.CreateCharRef(src.Name())
+		cp, err := sc.dst.CreateReference(src.Name())
 		if err != nil {
 			return nil, err
 		}

--- a/xslt3/strip_space_copy_internal_test.go
+++ b/xslt3/strip_space_copy_internal_test.go
@@ -23,9 +23,13 @@ func TestCopyAndStrip(t *testing.T) {
 
 		first := cp.DocumentElement().FirstChild()
 		second := first.NextSibling()
-		require.Same(t, cpEntity, first.FirstChild())
-		require.Same(t, cpEntity, second.FirstChild())
-		require.Nil(t, cpEntity.FirstChild().FirstChild())
+		firstEntity, ok := helium.AsNode[*helium.Entity](first.FirstChild())
+		require.True(t, ok)
+		require.NotSame(t, cpEntity, firstEntity)
+		require.Same(t, firstEntity, second.FirstChild())
+		require.Nil(t, firstEntity.FirstChild().FirstChild())
+		require.NotNil(t, cpEntity.FirstChild().FirstChild(),
+			"the shared DTD declaration must stay byte-faithful")
 	})
 
 	t.Run("whitespace-only entity uses reference parent", func(t *testing.T) {

--- a/xslt3/strip_space_copy_internal_test.go
+++ b/xslt3/strip_space_copy_internal_test.go
@@ -1,0 +1,56 @@
+package xslt3
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyAndStrip(t *testing.T) {
+	t.Run("entity replacement whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		const source = `<!DOCTYPE root [<!ENTITY payload "<a>   </a>">]><root>&payload;&payload;</root>`
+		src, err := helium.NewParser().Parse(t.Context(), []byte(source))
+		require.NoError(t, err)
+
+		cp, _, err := copyAndStrip(src, []nameTest{{Local: "*"}}, nil, false, nil)
+		require.NoError(t, err)
+		cpEntity, found := cp.IntSubset().LookupEntity("payload")
+		require.True(t, found)
+		require.NotSame(t, src.IntSubset(), cpEntity.Parent())
+
+		first := cp.DocumentElement().FirstChild()
+		second := first.NextSibling()
+		require.Same(t, cpEntity, first.FirstChild())
+		require.Same(t, cpEntity, second.FirstChild())
+		require.Nil(t, cpEntity.FirstChild().FirstChild())
+	})
+
+	t.Run("whitespace-only entity uses reference parent", func(t *testing.T) {
+		t.Parallel()
+
+		const source = `<!DOCTYPE root [<!ENTITY ws "   ">]><root>&ws;</root>`
+		src, err := helium.NewParser().Parse(t.Context(), []byte(source))
+		require.NoError(t, err)
+
+		cp, _, err := copyAndStrip(src, []nameTest{{Local: "*"}}, nil, false, nil)
+		require.NoError(t, err)
+		require.Nil(t, cp.DocumentElement().FirstChild())
+	})
+
+	t.Run("xml space preserves entity replacement whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		const source = `<!DOCTYPE root [<!ENTITY payload "<a xml:space='preserve'>   </a>">]><root>&payload;</root>`
+		src, err := helium.NewParser().Parse(t.Context(), []byte(source))
+		require.NoError(t, err)
+
+		cp, _, err := copyAndStrip(src, []nameTest{{Local: "*"}}, nil, false, nil)
+		require.NoError(t, err)
+		cpEntity, found := cp.IntSubset().LookupEntity("payload")
+		require.True(t, found)
+		require.Equal(t, "   ", string(cpEntity.FirstChild().FirstChild().Content()))
+	})
+}

--- a/xslt3/strip_space_test.go
+++ b/xslt3/strip_space_test.go
@@ -816,6 +816,36 @@ func TestStripSpace(t *testing.T) {
 		require.Same(t, cp, cpEntity.OwnerDocument())
 	})
 
+	t.Run("copy preserves a childless late entity reference", func(t *testing.T) {
+		t.Parallel()
+
+		src := helium.NewDefaultDocument()
+		_, err := src.CreateInternalSubset("root", "", "")
+		require.NoError(t, err)
+		root, err := src.CreateElement("root")
+		require.NoError(t, err)
+		require.NoError(t, src.AddChild(root))
+		ref, err := src.CreateCharRef("payload")
+		require.NoError(t, err)
+		require.NoError(t, root.AddChild(ref))
+		_, err = src.IntSubset().AddEntity(
+			"payload", enum.InternalGeneralEntity, "", "", "PAYLOAD",
+		)
+		require.NoError(t, err)
+		require.Nil(t, ref.FirstChild())
+
+		const stylesheet = `<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <xsl:strip-space elements="*"/>
+  <xsl:output method="text"/>
+  <xsl:template match="/"><xsl:value-of select="/root"/></xsl:template>
+</xsl:stylesheet>`
+		ss, err := xslt3.NewCompiler().Compile(t.Context(), mustParse(t, stylesheet))
+		require.NoError(t, err)
+		out, err := xslt3.TransformString(t.Context(), src, ss)
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
+
 	t.Run("copy preserves entity declaration identity", func(t *testing.T) {
 		t.Parallel()
 

--- a/xslt3/strip_space_test.go
+++ b/xslt3/strip_space_test.go
@@ -798,6 +798,24 @@ func TestStripSpace(t *testing.T) {
 		require.True(t, foundID, "copy's external subset must contain the ID-typed attribute declaration")
 	})
 
+	t.Run("copy preserves declared entity references", func(t *testing.T) {
+		t.Parallel()
+
+		const source = `<!DOCTYPE root [<!ENTITY payload "QUJD">]><root>&payload;&payload;</root>`
+		src, err := helium.NewParser().Parse(t.Context(), []byte(source))
+		require.NoError(t, err)
+
+		cp, err := xslt3.CopyAndStripForTest(src)
+		require.NoError(t, err)
+		cpEntity, found := cp.IntSubset().LookupEntity("payload")
+		require.True(t, found)
+		first := cp.DocumentElement().FirstChild()
+		second := first.NextSibling()
+		require.Same(t, cpEntity, first.FirstChild())
+		require.Same(t, cpEntity, second.FirstChild())
+		require.Same(t, cp, cpEntity.OwnerDocument())
+	})
+
 	// TestStripSpacePreservesExternalDTDIDs verifies that running a transform whose
 	// stylesheet declares xsl:strip-space keeps id()/GetElementByID working for IDs
 	// declared in an EXTERNAL DTD subset.

--- a/xslt3/strip_space_test.go
+++ b/xslt3/strip_space_test.go
@@ -21,6 +21,31 @@ import (
 const importedModuleURI = "mem:/imported.xsl"
 
 func TestStripSpace(t *testing.T) {
+	t.Run("entity replacement uses each reference context", func(t *testing.T) {
+		t.Parallel()
+
+		const stylesheet = `<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <xsl:strip-space elements="*"/>
+  <xsl:output method="text"/>
+  <xsl:template match="/">
+    <xsl:value-of select="/root/strip"/>
+    <xsl:text>|</xsl:text>
+    <xsl:value-of select="/root/keep"/>
+  </xsl:template>
+</xsl:stylesheet>`
+		const source = `<!DOCTYPE root [<!ENTITY payload "   <a>X</a>   ">]>` +
+			`<root><strip>&payload;</strip><keep xml:space="preserve">&payload;</keep></root>`
+
+		ss, err := xslt3.NewCompiler().Compile(t.Context(), mustParse(t, stylesheet))
+		require.NoError(t, err)
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(source))
+		require.NoError(t, err)
+
+		out, err := xslt3.TransformString(t.Context(), doc, ss)
+		require.NoError(t, err)
+		require.Equal(t, "X|   X   ", out)
+	})
+
 	// TestStripSpaceImportPrecedence verifies that a conflicting strip-space /
 	// preserve-space NameTest across an import boundary is resolved by import
 	// precedence (the importing module wins), raising no false XTSE0270,

--- a/xslt3/strip_space_test.go
+++ b/xslt3/strip_space_test.go
@@ -46,6 +46,41 @@ func TestStripSpace(t *testing.T) {
 		require.Equal(t, "X|   X   ", out)
 	})
 
+	t.Run("entity replacement uses each reference namespace", func(t *testing.T) {
+		t.Parallel()
+
+		const stylesheet = `<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:one="urn:one" xmlns:two="urn:two" version="3.0">
+  <xsl:strip-space elements="one:a"/>
+  <xsl:preserve-space elements="two:a"/>
+  <xsl:output method="text"/>
+  <xsl:template match="/">
+    <xsl:value-of select="/root/direct-one"/><xsl:text>|</xsl:text>
+    <xsl:value-of select="/root/direct-two"/><xsl:text>;</xsl:text>
+    <xsl:value-of select="/root/nested-one"/><xsl:text>|</xsl:text>
+    <xsl:value-of select="/root/nested-two"/>
+  </xsl:template>
+</xsl:stylesheet>`
+		const source = `<!DOCTYPE root [
+<!ENTITY payload "<p:a>   </p:a>">
+<!ENTITY outer "<wrapper>&payload;</wrapper>">
+]><root>` +
+			`<direct-one xmlns:p="urn:one">&payload;</direct-one>` +
+			`<direct-two xmlns:p="urn:two">&payload;</direct-two>` +
+			`<nested-one xmlns:p="urn:one">&outer;</nested-one>` +
+			`<nested-two xmlns:p="urn:two">&outer;</nested-two>` +
+			`</root>`
+
+		ss, err := xslt3.NewCompiler().Compile(t.Context(), mustParse(t, stylesheet))
+		require.NoError(t, err)
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(source))
+		require.NoError(t, err)
+
+		out, err := xslt3.TransformString(t.Context(), doc, ss)
+		require.NoError(t, err)
+		require.Equal(t, "|   ;|   ", out)
+	})
+
 	// TestStripSpaceImportPrecedence verifies that a conflicting strip-space /
 	// preserve-space NameTest across an import boundary is resolved by import
 	// precedence (the importing module wins), raising no false XTSE0270,

--- a/xslt3/strip_space_test.go
+++ b/xslt3/strip_space_test.go
@@ -816,6 +816,30 @@ func TestStripSpace(t *testing.T) {
 		require.Same(t, cp, cpEntity.OwnerDocument())
 	})
 
+	t.Run("copy resolves an internal entity reference to an external declaration", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{"ext.dtd": {Data: []byte(`<!ENTITY external "EXTERNAL">`)}}
+		const source = `<!DOCTYPE root SYSTEM "ext.dtd" [<!ENTITY internal "&external;">]><root>&internal;</root>`
+		doc, err := helium.NewParser().
+			BlockXXE(false).
+			LoadExternalDTD(true).
+			FS(fsys).
+			Parse(t.Context(), []byte(source))
+		require.NoError(t, err)
+
+		const stylesheet = `<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <xsl:strip-space elements="*"/>
+  <xsl:output method="text"/>
+  <xsl:template match="/"><xsl:value-of select="/root"/></xsl:template>
+</xsl:stylesheet>`
+		ss, err := xslt3.NewCompiler().Compile(t.Context(), mustParse(t, stylesheet))
+		require.NoError(t, err)
+		out, err := xslt3.TransformString(t.Context(), doc, ss)
+		require.NoError(t, err)
+		require.Equal(t, "EXTERNAL", out)
+	})
+
 	// TestStripSpacePreservesExternalDTDIDs verifies that running a transform whose
 	// stylesheet declares xsl:strip-space keeps id()/GetElementByID working for IDs
 	// declared in an EXTERNAL DTD subset.

--- a/xslt3/strip_space_test.go
+++ b/xslt3/strip_space_test.go
@@ -816,6 +816,39 @@ func TestStripSpace(t *testing.T) {
 		require.Same(t, cp, cpEntity.OwnerDocument())
 	})
 
+	t.Run("copy preserves entity declaration identity", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{"ext.dtd": {Data: []byte(`<!ENTITY payload "EXTERNAL">`)}}
+		src, err := helium.NewParser().
+			BlockXXE(false).
+			LoadExternalDTD(true).
+			FS(fsys).
+			Parse(t.Context(), []byte(`<!DOCTYPE root SYSTEM "ext.dtd"><root/>`))
+		require.NoError(t, err)
+
+		srcExternal, found := src.ExtSubset().LookupEntity("payload")
+		require.True(t, found)
+		ref, err := src.CreateReference("payload")
+		require.NoError(t, err)
+		require.Same(t, srcExternal, ref.FirstChild())
+		require.NoError(t, src.DocumentElement().AddChild(ref))
+
+		_, err = src.IntSubset().AddEntity(
+			"payload", enum.InternalGeneralEntity, "", "", "INTERNAL",
+		)
+		require.NoError(t, err)
+		require.Same(t, srcExternal, ref.FirstChild())
+
+		cp, err := xslt3.CopyAndStripForTest(src)
+		require.NoError(t, err)
+		cpExternal, found := cp.ExtSubset().LookupEntity("payload")
+		require.True(t, found)
+		cpRef := cp.DocumentElement().FirstChild()
+		require.Same(t, cpExternal, cpRef.FirstChild())
+		require.Equal(t, "EXTERNAL", string(cpRef.Content()))
+	})
+
 	t.Run("copy resolves an internal entity reference to an external declaration", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
- Preserve declared entity replacement semantics across DOM copies.
- Keep copied references and replacement trees owned by destination documents.
- Cover canonicalization and encrypted CipherValue regressions.
