### PR TITLE
fix fu97 exclusive c14n xml namespace output

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -445,7 +445,10 @@ W3C Canonical XML. 3 modes: C14N10, ExclusiveC14N10, C14N11.
 - **NewCanonicalizer(Mode) → Canonicalizer** — create fluent builder for the given mode
 - Canonicalizer methods: Comments(), NodeSet([]Node), InclusiveNamespaces([]string), StrictXMLAttributes()
 - Terminal: **Canonicalize(*Document, io.Writer) → error**, **CanonicalizeTo(*Document) → ([]byte, error)**
-- C14N 1.1 xml:base is the lexical join (W3C §2.4 / libxml2 xmlC14NFixupBaseAttr) of in-document xml:base values — no external base URI. See `xmlbase.go` (joinURIReference).
+- Predefined `xml` namespace binding is implicit and never renders as `xmlns:xml` in whole-document or
+  node-set output. `xml:*` names and inherited attributes retain mode-specific canonicalization behavior.
+- C14N 1.1 xml:base is the lexical join (W3C §2.4 / libxml2 xmlC14NFixupBaseAttr) of in-document xml:base
+  values — no external base URI. See `xmlbase.go` (joinURIReference).
 - StrictXMLAttributes() opts into W3C-strict node-set xml:base/lang/space handling; default matches libxml2 (a
   rendered element's own excluded xml:* attribute is still emitted — XMLDSig digest interop). Strict mode is
   also fail-closed on xml:base: a degenerate/un-canonicalizable value (malformed URI, empty-authority

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -582,6 +582,36 @@ func TestEntityReferenceReplacementReservedXMLPrefixAttr(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestPredefinedXMLNamespaceOmitted(t *testing.T) {
+	t.Parallel()
+
+	const src = `<r xml:base="sub/" xml:lang="en" xml:space="preserve"><xml:e/></r>`
+	const want = `<r xml:base="sub/" xml:lang="en" xml:space="preserve"><xml:e></xml:e></r>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+	nodes := evaluateNodeSet(t, doc, "//. | //@* | //namespace::*", nil)
+
+	for _, mode := range []c14n.Mode{c14n.C14N10, c14n.C14N11, c14n.ExclusiveC14N10} {
+		whole, err := c14n.NewCanonicalizer(mode).CanonicalizeTo(doc)
+		require.NoError(t, err, "mode %d", mode)
+		require.Equal(t, want, string(whole), "whole document, mode %d", mode)
+		require.NotContains(t, string(whole), "xmlns:xml", "whole document, mode %d", mode)
+
+		selected, err := c14n.NewCanonicalizer(mode).NodeSet(nodes).CanonicalizeTo(doc)
+		require.NoError(t, err, "mode %d", mode)
+		require.Equal(t, string(whole), string(selected), "whole tree node set, mode %d", mode)
+	}
+
+	canon := c14n.NewCanonicalizer(c14n.ExclusiveC14N10).InclusiveNamespaces([]string{"xml"})
+	whole, err := canon.CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t, want, string(whole))
+	selected, err := canon.NodeSet(nodes).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t, string(whole), string(selected))
+}
+
 func TestEntityReferenceReplacementReservedXMLPrefixElementName(t *testing.T) {
 	t.Parallel()
 	// An entity-replacement element whose NAME uses the reserved "xml" prefix is

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -796,6 +796,11 @@ func (c *canonicalizer) renderNamespacesExclusive(e *helium.Element) error {
 
 	var toOutput []nsSortEntry
 	for prefix, uri := range utilized {
+		// The predefined xml binding is implicit and never rendered as a
+		// namespace declaration, even when an xml-prefixed name visibly utilizes it.
+		if prefix == lexicon.PrefixXML {
+			continue
+		}
 		if c.nsStack.needsOutput(prefix, uri) {
 			toOutput = append(toOutput, nsSortEntry{prefix: prefix, uri: uri})
 			c.nsStack.add(prefix, uri)

--- a/xmldsig1/transforms_internal_test.go
+++ b/xmldsig1/transforms_internal_test.go
@@ -212,6 +212,36 @@ func TestCanonicalizeSubtreeKeepsNamespaceDecls(t *testing.T) {
 	})
 }
 
+func TestExclusiveC14NEquivalentDocumentReferencesMatch(t *testing.T) {
+	const src = `<r Id="r" xml:base="sub/" xml:lang="en" xml:space="preserve"><child/></r>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	cfg := &signerConfig{}
+	reference := ReferenceConfig{
+		DigestAlgorithm: DigestSHA256,
+		Transforms:      []Transform{ExcC14NTransform()},
+	}
+
+	reference.URI = ""
+	whole, err := signReferenceOctets(t.Context(), cfg, doc, nil, reference, nil)
+	require.NoError(t, err)
+
+	reference.URI = "#r"
+	selected, err := signReferenceOctets(t.Context(), cfg, doc, nil, reference, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, string(selected), string(whole))
+	require.NotContains(t, string(whole), "xmlns:xml")
+
+	wholeDigest, err := computeDigest(DigestSHA256, whole, false)
+	require.NoError(t, err)
+	selectedDigest, err := computeDigest(DigestSHA256, selected, false)
+	require.NoError(t, err)
+	require.Equal(t, selectedDigest, wholeDigest)
+}
+
 // dtdEntityDecl returns the DTD entity-declaration node named name, or nil.
 func dtdEntityDecl(doc *helium.Document, name string) helium.Node {
 	for c := range helium.Children(doc) {


### PR DESCRIPTION
- keep whole-document and node-set Exclusive C14N bytes identical for equivalent selections
- preserve `xml:*` attributes while omitting the implicit `xmlns:xml` declaration
