### PR TITLE
fix xslt3 word numbering on 32-bit

### DIFF
--- a/xslt3/compile_instructions_nodes.go
+++ b/xslt3/compile_instructions_nodes.go
@@ -3,7 +3,6 @@ package xslt3
 import (
 	"context"
 	"maps"
-	"strconv"
 	"strings"
 
 	"github.com/lestrrat-go/helium"
@@ -557,10 +556,8 @@ func (c *compiler) compileNumber(_ context.Context, elem *helium.Element) (*numb
 		}
 		// Validate static start-at: must be a space-separated list of integers
 		if !strings.Contains(sa, "{") {
-			for part := range strings.FieldsSeq(sa) {
-				if _, err := strconv.Atoi(part); err != nil {
-					return nil, staticError(errCodeXTSE0020, "%q is not a valid value for xsl:number/@start-at", sa)
-				}
+			if _, ok := parseStartAt(sa); !ok {
+				return nil, staticError(errCodeXTSE0020, "%q is not a valid value for xsl:number/@start-at", sa)
 			}
 		}
 		inst.StartAt = avt

--- a/xslt3/execute_number.go
+++ b/xslt3/execute_number.go
@@ -427,6 +427,10 @@ func isAlphanumeric(r rune) bool {
 }
 
 func formatSingleNumber(num int, token string, groupSep string, groupSize int, lang string, ordinal string) string {
+	if formatted, ok := formatWordNumber(int64(num), token, lang, ordinal); ok {
+		return formatted
+	}
+
 	switch token {
 	case "a":
 		return toLowerAlpha(num)
@@ -436,12 +440,6 @@ func formatSingleNumber(num int, token string, groupSep string, groupSize int, l
 		return strings.ToLower(toRoman(num))
 	case "I":
 		return toRoman(num)
-	case "w":
-		return numberToWordsLang(num, "lower", lang, ordinal)
-	case "W":
-		return numberToWordsLang(num, "upper", lang, ordinal)
-	case "Ww":
-		return numberToWordsLang(num, "title", lang, ordinal)
 	default:
 		runes := []rune(token)
 		firstRune := runes[0]
@@ -480,6 +478,19 @@ func formatSingleNumber(num int, token string, groupSep string, groupSize int, l
 			s += numericOrdinalSuffix(num, lang)
 		}
 		return s
+	}
+}
+
+func formatWordNumber(num int64, token string, lang string, ordinal string) (string, bool) {
+	switch token {
+	case "w":
+		return numberToWordsLang(num, "lower", lang, ordinal), true
+	case "W":
+		return numberToWordsLang(num, "upper", lang, ordinal), true
+	case "Ww":
+		return numberToWordsLang(num, "title", lang, ordinal), true
+	default:
+		return "", false
 	}
 }
 
@@ -619,11 +630,16 @@ func formatBigNumberList(bigNums []*big.Int, format string, groupSep string, gro
 		if tokIdx >= len(tokens) {
 			tokIdx = len(tokens) - 1
 		}
-		// If the number fits in an int, use the standard formatter for full
-		// support of roman numerals, alphabetic, words, etc.
+		// Word formatting supports every int64 value on every architecture.
+		// Other non-decimal formats still require a native int.
 		if num.IsInt64() {
-			n := int(num.Int64())
-			if int64(n) == num.Int64() {
+			n64 := num.Int64()
+			if formatted, ok := formatWordNumber(n64, tokens[tokIdx].format, lang, ordinal); ok {
+				buf.WriteString(formatted)
+				continue
+			}
+			n := int(n64)
+			if int64(n) == n64 {
 				buf.WriteString(formatSingleNumber(n, tokens[tokIdx].format, groupSep, groupSize, lang, ordinal))
 				continue
 			}
@@ -871,7 +887,7 @@ func ordinalRangeLength(r rune) int {
 }
 
 // numberToWords converts a number to English words.
-func numberToWords(n int, upper bool) string { //nolint:unparam // upper always false but kept for XSLT number-to-words spec
+func numberToWords(n int64, upper bool) string { //nolint:unparam // upper always false but kept for XSLT number-to-words spec
 	if n == 0 {
 		if upper {
 			return "ZERO"
@@ -882,23 +898,23 @@ func numberToWords(n int, upper bool) string { //nolint:unparam // upper always 
 		"ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"}
 	var tens = []string{"", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"}
 
-	var words func(int) string
-	words = func(n int) string {
+	var words func(int64) string
+	words = func(n int64) string {
 		if n < 0 {
 			return "minus " + words(-n)
 		}
 		if n < 20 {
-			return ones[n]
+			return ones[int(n)]
 		}
 		if n < 100 {
-			w := tens[n/10]
+			w := tens[int(n/10)]
 			if n%10 != 0 {
-				w += " " + ones[n%10]
+				w += " " + ones[int(n%10)]
 			}
 			return w
 		}
 		if n < 1000 {
-			w := ones[n/100] + " hundred"
+			w := ones[int(n/100)] + " hundred"
 			if n%100 != 0 {
 				w += " and " + words(n%100)
 			}
@@ -911,21 +927,21 @@ func numberToWords(n int, upper bool) string { //nolint:unparam // upper always 
 			}
 			return w
 		}
-		if n < 1000000000 {
+		if n < numberBillion {
 			w := words(n/1000000) + " million"
 			if n%1000000 != 0 {
 				w += " " + words(n%1000000)
 			}
 			return w
 		}
-		if n < 1000000000000 {
-			w := words(n/1000000000) + " billion"
-			if n%1000000000 != 0 {
-				w += " " + words(n%1000000000)
+		if n < numberTrillion {
+			w := words(n/numberBillion) + " billion"
+			if n%numberBillion != 0 {
+				w += " " + words(n%numberBillion)
 			}
 			return w
 		}
-		return strconv.Itoa(n)
+		return strconv.FormatInt(n, 10)
 	}
 	result := words(n)
 	if upper {

--- a/xslt3/execute_number.go
+++ b/xslt3/execute_number.go
@@ -712,6 +712,10 @@ func formatBigNumberList(bigNums []*big.Int, format string, groupSep string, gro
 func formatBigSingleNumber(num *big.Int, token string, groupSep string, groupSize int, lang string, ordinal string) string {
 	runes := []rune(token)
 	firstRune := runes[0]
+	// Roman numbering falls back to plain decimal outside its bounded range.
+	if token == "i" || token == "I" {
+		return num.String()
+	}
 
 	// Non-ASCII digit system (e.g., Arabic-Indic ٠)
 	if firstRune > 127 && unicode.IsDigit(firstRune) {
@@ -720,6 +724,11 @@ func formatBigSingleNumber(num *big.Int, token string, groupSep string, groupSiz
 			s = applyGroupingSeparator(s, groupSep, groupSize)
 		}
 		return s
+	}
+	// Non-ASCII number tokens use a bounded ordinal system. A number beyond
+	// that range falls back to plain decimal without a numeric ordinal suffix.
+	if firstRune > 127 && unicode.IsNumber(firstRune) {
+		return num.String()
 	}
 
 	// Default: decimal with optional grouping and min-width

--- a/xslt3/execute_number.go
+++ b/xslt3/execute_number.go
@@ -795,10 +795,14 @@ func digitZeroOf(r rune) rune {
 // formatWithDigitSystem formats a number using a decimal digit system
 // starting at the given zero codepoint.
 func formatWithDigitSystem(num int, zero rune, minWidth int) string {
-	if num < 0 {
-		return "-" + formatWithDigitSystem(-num, zero, minWidth)
+	negative := num < 0
+	var magnitude uint
+	if negative {
+		magnitude = uint(-(num + 1)) + 1
+	} else {
+		magnitude = uint(num)
 	}
-	if num == 0 {
+	if magnitude == 0 {
 		s := string(zero)
 		for len([]rune(s)) < minWidth {
 			s = string(zero) + s
@@ -806,15 +810,18 @@ func formatWithDigitSystem(num int, zero rune, minWidth int) string {
 		return s
 	}
 	var runes []rune
-	n := num
-	for n > 0 {
-		runes = append([]rune{zero + rune(n%10)}, runes...)
-		n /= 10
+	for magnitude > 0 {
+		runes = append([]rune{zero + rune(magnitude%10)}, runes...)
+		magnitude /= 10
 	}
 	for len(runes) < minWidth {
 		runes = append([]rune{zero}, runes...)
 	}
-	return string(runes)
+	formatted := string(runes)
+	if negative {
+		return "-" + formatted
+	}
+	return formatted
 }
 
 // ordinalSystem describes a Unicode numbering system with potentially

--- a/xslt3/execute_number.go
+++ b/xslt3/execute_number.go
@@ -453,9 +453,9 @@ func formatSingleNumber(num int, token string, groupSep string, groupSize int, l
 
 	switch token {
 	case "a":
-		return toLowerAlpha(num)
+		return toLowerAlpha(int64(num))
 	case "A":
-		return toUpperAlpha(num)
+		return toUpperAlpha(int64(num))
 	case "i":
 		return strings.ToLower(toRoman(num))
 	case "I":
@@ -481,7 +481,7 @@ func formatSingleNumber(num int, token string, groupSep string, groupSize int, l
 		// Non-ASCII letter: alphabetic numbering from that codepoint
 		// (e.g., α = U+03B1 for Greek lowercase: α, β, γ, ..., ω, αα, αβ, ...)
 		if firstRune > 127 && unicode.IsLetter(firstRune) {
-			return formatWithAlphaSystem(num, firstRune)
+			return formatWithAlphaSystem(int64(num), firstRune)
 		}
 
 		// ASCII numeric format: determine minimum width from token (e.g., "001" = width 3)
@@ -514,6 +514,21 @@ func formatWordNumber(num int64, token string, lang string, ordinal string) (str
 	}
 }
 
+func formatAlphabeticNumber(num int64, token string) (string, bool) {
+	switch token {
+	case "a":
+		return toLowerAlpha(num), true
+	case "A":
+		return toUpperAlpha(num), true
+	}
+
+	runes := []rune(token)
+	if len(runes) > 0 && runes[0] > 127 && unicode.IsLetter(runes[0]) {
+		return formatWithAlphaSystem(num, runes[0]), true
+	}
+	return "", false
+}
+
 // numericOrdinalSuffix returns the suffix for a numeric ordinal (e.g., "st", "nd", "rd", "th").
 func numericOrdinalSuffix(num int, _ string) string {
 	// Default to English ordinal suffixes
@@ -522,6 +537,23 @@ func numericOrdinalSuffix(num int, _ string) string {
 		return "th"
 	}
 	switch num % 10 {
+	case 1:
+		return "st"
+	case 2:
+		return "nd"
+	case 3:
+		return "rd"
+	default:
+		return "th"
+	}
+}
+
+func numericOrdinalSuffixBig(num *big.Int, _ string) string {
+	n := new(big.Int).Rem(num, big.NewInt(100)).Int64()
+	if n >= 11 && n <= 13 {
+		return "th"
+	}
+	switch n % 10 {
 	case 1:
 		return "st"
 	case 2:
@@ -548,9 +580,9 @@ var knownAlphabetLengths = map[rune]int{
 // formatWithAlphaSystem formats using alphabetic numbering (like a-z but with
 // non-ASCII letters). Wraps at the end of the alphabet:
 // α=1, β=2, ..., ω=25, αα=26, αβ=27, etc.
-func formatWithAlphaSystem(num int, start rune) string {
+func formatWithAlphaSystem(num int64, start rune) string {
 	if num <= 0 {
-		return strconv.Itoa(num)
+		return strconv.FormatInt(num, 10)
 	}
 
 	// Use known alphabet length if available, otherwise detect
@@ -565,7 +597,7 @@ func formatWithAlphaSystem(num int, start rune) string {
 		}
 	}
 	if seqLen == 0 {
-		return strconv.Itoa(num)
+		return strconv.FormatInt(num, 10)
 	}
 
 	// Convert to base-N alphabetic representation (1-based, like a=1, b=2, ..., z=26, aa=27)
@@ -573,8 +605,8 @@ func formatWithAlphaSystem(num int, start rune) string {
 	n := num
 	for n > 0 {
 		n-- // convert to 0-based
-		result = append([]rune{start + rune(n%seqLen)}, result...)
-		n /= seqLen
+		result = append([]rune{start + rune(n%int64(seqLen))}, result...)
+		n /= int64(seqLen)
 	}
 	return string(result)
 }
@@ -650,11 +682,15 @@ func formatBigNumberList(bigNums []*big.Int, format string, groupSep string, gro
 		if tokIdx >= len(tokens) {
 			tokIdx = len(tokens) - 1
 		}
-		// Word formatting supports every int64 value on every architecture.
-		// Other non-decimal formats still require a native int.
+		// Word and alphabetic formatting support every int64 value on every architecture.
+		// The remaining non-decimal formats require a native int.
 		if num.IsInt64() {
 			n64 := num.Int64()
 			if formatted, ok := formatWordNumber(n64, tokens[tokIdx].format, lang, ordinal); ok {
+				buf.WriteString(formatted)
+				continue
+			}
+			if formatted, ok := formatAlphabeticNumber(n64, tokens[tokIdx].format); ok {
 				buf.WriteString(formatted)
 				continue
 			}
@@ -665,7 +701,7 @@ func formatBigNumberList(bigNums []*big.Int, format string, groupSep string, gro
 			}
 		}
 		// Large number: only decimal digit formatting is meaningful
-		buf.WriteString(formatBigSingleNumber(num, tokens[tokIdx].format, groupSep, groupSize))
+		buf.WriteString(formatBigSingleNumber(num, tokens[tokIdx].format, groupSep, groupSize, lang, ordinal))
 	}
 	buf.WriteString(suffix)
 	return buf.String()
@@ -673,7 +709,7 @@ func formatBigNumberList(bigNums []*big.Int, format string, groupSep string, gro
 
 // formatBigSingleNumber formats a *big.Int using a decimal format token.
 // Supports ASCII digits with grouping and non-ASCII digit systems.
-func formatBigSingleNumber(num *big.Int, token string, groupSep string, groupSize int) string {
+func formatBigSingleNumber(num *big.Int, token string, groupSep string, groupSize int, lang string, ordinal string) string {
 	runes := []rune(token)
 	firstRune := runes[0]
 
@@ -694,6 +730,9 @@ func formatBigSingleNumber(num *big.Int, token string, groupSep string, groupSiz
 	}
 	if groupSep != "" && groupSize > 0 {
 		s = applyGroupingSeparator(s, groupSep, groupSize)
+	}
+	if ordinal != "" {
+		s += numericOrdinalSuffixBig(num, lang)
 	}
 	return s
 }
@@ -914,6 +953,13 @@ func numberToWords(n int64, upper bool) string { //nolint:unparam // upper alway
 		}
 		return "zero"
 	}
+	if magnitude, ok := minInt64MagnitudeString(n); ok {
+		result := "minus " + magnitude
+		if upper {
+			return strings.ToUpper(result)
+		}
+		return result
+	}
 	var ones = []string{"", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
 		"ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"}
 	var tens = []string{"", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"}
@@ -994,9 +1040,9 @@ func applyGroupingSeparator(s string, sep string, size int) string {
 	return string(result)
 }
 
-func toLowerAlpha(n int) string {
+func toLowerAlpha(n int64) string {
 	if n <= 0 {
-		return strconv.Itoa(n)
+		return strconv.FormatInt(n, 10)
 	}
 	var buf []byte
 	for n > 0 {
@@ -1007,7 +1053,7 @@ func toLowerAlpha(n int) string {
 	return string(buf)
 }
 
-func toUpperAlpha(n int) string {
+func toUpperAlpha(n int64) string {
 	return strings.ToUpper(toLowerAlpha(n))
 }
 

--- a/xslt3/execute_number.go
+++ b/xslt3/execute_number.go
@@ -126,17 +126,20 @@ func (ec *execContext) execNumber(ctx context.Context, inst *numberInst) error {
 		if err != nil {
 			return err
 		}
-		// start-at can be a space-separated list of integers, one per level
-		saParts := strings.Fields(saStr)
+		startAt, ok := parseStartAt(saStr)
+		if !ok {
+			return dynamicError(errCodeXTDE0030,
+				"%q is not a valid value for xsl:number/@start-at", saStr)
+		}
+		one := big.NewInt(1)
 		for i, n := range bigNums {
-			offset := 0
-			if i < len(saParts) {
-				offset, _ = strconv.Atoi(saParts[i])
-			} else if len(saParts) > 0 {
-				offset, _ = strconv.Atoi(saParts[len(saParts)-1])
+			offset := startAt[len(startAt)-1]
+			if i < len(startAt) {
+				offset = startAt[i]
 			}
 			// start-at shifts numbering: number = number + startAt - 1
-			bigNums[i] = new(big.Int).Add(n, big.NewInt(int64(offset-1)))
+			bigNums[i] = new(big.Int).Add(n, offset)
+			bigNums[i].Sub(bigNums[i], one)
 		}
 	}
 
@@ -192,6 +195,23 @@ func (ec *execContext) execNumber(ctx context.Context, inst *numberInst) error {
 	formatted := formatBigNumberList(bigNums, format, groupSep, groupSize, lang, ordinal)
 	text := ec.resultDoc.CreateText([]byte(formatted))
 	return ec.addNode(text)
+}
+
+func parseStartAt(value string) ([]*big.Int, bool) {
+	parts := strings.Fields(value)
+	if len(parts) == 0 {
+		return nil, false
+	}
+
+	numbers := make([]*big.Int, len(parts))
+	for i, part := range parts {
+		n, ok := new(big.Int).SetString(part, 10)
+		if !ok {
+			return nil, false
+		}
+		numbers[i] = n
+	}
+	return numbers, true
 }
 
 // numberNodeMatches tests if a node matches the count pattern.

--- a/xslt3/execute_number_test.go
+++ b/xslt3/execute_number_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const ordinalYes = "yes"
+
 func TestExecNumberStartAt(t *testing.T) {
 	testCases := []struct {
 		name    string
@@ -36,7 +38,7 @@ func TestExecNumberStartAt(t *testing.T) {
 		{
 			name:    "minimum signed 64-bit ordinal in words",
 			startAt: "-9223372036854775808",
-			ordinal: "yes",
+			ordinal: ordinalYes,
 			want:    "minus 9223372036854775808th",
 		},
 		{
@@ -49,7 +51,7 @@ func TestExecNumberStartAt(t *testing.T) {
 			name:    "numeric ordinal above signed 32-bit range",
 			startAt: "2147483648",
 			format:  "1",
-			ordinal: "yes",
+			ordinal: ordinalYes,
 			want:    "2147483648th",
 		},
 	}
@@ -131,13 +133,13 @@ func TestFormatBigNumberListWordTokens(t *testing.T) {
 		{
 			name:    "ordinal at trillion",
 			number:  numberTrillion,
-			ordinal: "yes",
+			ordinal: ordinalYes,
 			want:    "one trillionth",
 		},
 		{
 			name:    "ordinal above trillion",
 			number:  numberTrillion + 1,
-			ordinal: "yes",
+			ordinal: ordinalYes,
 			want:    "one trillion first",
 		},
 		{
@@ -148,7 +150,7 @@ func TestFormatBigNumberListWordTokens(t *testing.T) {
 		{
 			name:    "minimum signed 64-bit ordinal",
 			number:  minInt64,
-			ordinal: "yes",
+			ordinal: ordinalYes,
 			want:    "minus 9223372036854775808th",
 		},
 	}

--- a/xslt3/execute_number_test.go
+++ b/xslt3/execute_number_test.go
@@ -1,0 +1,67 @@
+package xslt3
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatBigNumberListWordTokens(t *testing.T) {
+	testCases := []struct {
+		name    string
+		number  int64
+		ordinal string
+		want    string
+	}{
+		{
+			name:   "largest signed 32-bit integer",
+			number: 2_147_483_647,
+			want: "two billion one hundred and forty seven million four hundred and eighty three thousand " +
+				"six hundred and forty seven",
+		},
+		{
+			name:   "first integer above signed 32-bit range",
+			number: 2_147_483_648,
+			want: "two billion one hundred and forty seven million four hundred and eighty three thousand " +
+				"six hundred and forty eight",
+		},
+		{
+			name:   "largest cardinal below trillion fallback",
+			number: numberTrillion - 1,
+			want: "nine hundred and ninety nine billion nine hundred and ninety nine million " +
+				"nine hundred and ninety nine thousand nine hundred and ninety nine",
+		},
+		{
+			name:   "cardinal at trillion fallback",
+			number: numberTrillion,
+			want:   "1000000000000",
+		},
+		{
+			name:    "ordinal at trillion",
+			number:  numberTrillion,
+			ordinal: "yes",
+			want:    "one trillionth",
+		},
+		{
+			name:    "ordinal above trillion",
+			number:  numberTrillion + 1,
+			ordinal: "yes",
+			want:    "one trillion first",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := formatBigNumberList(
+				[]*big.Int{big.NewInt(testCase.number)},
+				"w",
+				"",
+				0,
+				"en",
+				testCase.ordinal,
+			)
+			require.Equal(t, testCase.want, got)
+		})
+	}
+}

--- a/xslt3/execute_number_test.go
+++ b/xslt3/execute_number_test.go
@@ -12,6 +12,8 @@ func TestExecNumberStartAt(t *testing.T) {
 	testCases := []struct {
 		name    string
 		startAt string
+		format  string
+		ordinal string
 		want    string
 	}{
 		{
@@ -26,13 +28,45 @@ func TestExecNumberStartAt(t *testing.T) {
 			want: "two billion one hundred and forty seven million four hundred and eighty three thousand " +
 				"six hundred and forty eight",
 		},
+		{
+			name:    "minimum signed 64-bit integer in words",
+			startAt: "-9223372036854775808",
+			want:    "minus 9223372036854775808",
+		},
+		{
+			name:    "minimum signed 64-bit ordinal in words",
+			startAt: "-9223372036854775808",
+			ordinal: "yes",
+			want:    "minus 9223372036854775808th",
+		},
+		{
+			name:    "alphabetic above signed 32-bit range",
+			startAt: "2147483648",
+			format:  "a",
+			want:    "fxshrxx",
+		},
+		{
+			name:    "numeric ordinal above signed 32-bit range",
+			startAt: "2147483648",
+			format:  "1",
+			ordinal: "yes",
+			want:    "2147483648th",
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			format := testCase.format
+			if format == "" {
+				format = "w"
+			}
+			ordinal := ""
+			if testCase.ordinal != "" {
+				ordinal = ` ordinal="` + testCase.ordinal + `"`
+			}
 			stylesheet := `<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:output method="text"/>
-<xsl:template match="/"><xsl:number value="1" start-at="` + testCase.startAt + `" format="w"/></xsl:template>
+<xsl:template match="/"><xsl:number value="1" start-at="` + testCase.startAt + `" format="` + format + `"` + ordinal + `/></xsl:template>
 </xsl:stylesheet>`
 			doc, err := helium.NewParser().Parse(t.Context(), []byte(stylesheet))
 			require.NoError(t, err)
@@ -105,6 +139,17 @@ func TestFormatBigNumberListWordTokens(t *testing.T) {
 			number:  numberTrillion + 1,
 			ordinal: "yes",
 			want:    "one trillion first",
+		},
+		{
+			name:   "minimum signed 64-bit integer",
+			number: minInt64,
+			want:   "minus 9223372036854775808",
+		},
+		{
+			name:    "minimum signed 64-bit ordinal",
+			number:  minInt64,
+			ordinal: "yes",
+			want:    "minus 9223372036854775808th",
 		},
 	}
 

--- a/xslt3/execute_number_test.go
+++ b/xslt3/execute_number_test.go
@@ -4,8 +4,65 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/lestrrat-go/helium"
 	"github.com/stretchr/testify/require"
 )
+
+func TestExecNumberStartAt(t *testing.T) {
+	testCases := []struct {
+		name    string
+		startAt string
+		want    string
+	}{
+		{
+			name:    "static integer above signed 32-bit range",
+			startAt: "2147483648",
+			want: "two billion one hundred and forty seven million four hundred and eighty three thousand " +
+				"six hundred and forty eight",
+		},
+		{
+			name:    "dynamic integer above signed 32-bit range",
+			startAt: "{2147483648}",
+			want: "two billion one hundred and forty seven million four hundred and eighty three thousand " +
+				"six hundred and forty eight",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			stylesheet := `<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="text"/>
+<xsl:template match="/"><xsl:number value="1" start-at="` + testCase.startAt + `" format="w"/></xsl:template>
+</xsl:stylesheet>`
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(stylesheet))
+			require.NoError(t, err)
+			ss, err := NewCompiler().Compile(t.Context(), doc)
+			require.NoError(t, err)
+
+			source, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+			require.NoError(t, err)
+			got, err := ss.Transform(source).Serialize(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, testCase.want, got)
+		})
+	}
+
+	t.Run("invalid dynamic value raises XTDE0030", func(t *testing.T) {
+		stylesheet := `<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="text"/>
+<xsl:template match="/"><xsl:number value="1" start-at="{'invalid'}"/></xsl:template>
+</xsl:stylesheet>`
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(stylesheet))
+		require.NoError(t, err)
+		ss, err := NewCompiler().Compile(t.Context(), doc)
+		require.NoError(t, err)
+
+		source, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+		require.NoError(t, err)
+		_, err = ss.Transform(source).Serialize(t.Context())
+		require.ErrorContains(t, err, errCodeXTDE0030)
+	})
+}
 
 func TestFormatBigNumberListWordTokens(t *testing.T) {
 	testCases := []struct {

--- a/xslt3/execute_number_test.go
+++ b/xslt3/execute_number_test.go
@@ -42,6 +42,12 @@ func TestExecNumberStartAt(t *testing.T) {
 			want:    "minus 9223372036854775808th",
 		},
 		{
+			name:    "minimum signed 64-bit integer with Unicode digits",
+			startAt: "-9223372036854775808",
+			format:  "٠",
+			want:    "-٩٢٢٣٣٧٢٠٣٦٨٥٤٧٧٥٨٠٨",
+		},
+		{
 			name:    "alphabetic above signed 32-bit range",
 			startAt: "2147483648",
 			format:  "a",

--- a/xslt3/execute_number_test.go
+++ b/xslt3/execute_number_test.go
@@ -54,6 +54,20 @@ func TestExecNumberStartAt(t *testing.T) {
 			ordinal: ordinalYes,
 			want:    "2147483648th",
 		},
+		{
+			name:    "Roman ordinal fallback above signed 32-bit range",
+			startAt: "2147483648",
+			format:  "I",
+			ordinal: ordinalYes,
+			want:    "2147483648",
+		},
+		{
+			name:    "Unicode ordinal fallback above signed 32-bit range",
+			startAt: "2147483648",
+			format:  "①",
+			ordinal: ordinalYes,
+			want:    "2147483648",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/xslt3/number_words.go
+++ b/xslt3/number_words.go
@@ -14,7 +14,15 @@ const (
 	germanOnePrefix       = "ein"
 	numberBillion   int64 = 1_000_000_000
 	numberTrillion  int64 = 1_000_000_000_000
+	minInt64              = -1 << 63
 )
+
+func minInt64MagnitudeString(n int64) (string, bool) {
+	if n != minInt64 {
+		return "", false
+	}
+	return strconv.FormatUint(uint64(1)<<63, 10), true
+}
 
 // numberToWordsLang converts a number to words in the given language and case.
 // caseMode is "lower", "upper", or "title".
@@ -98,6 +106,9 @@ func englishOrdinal(n int64) string {
 	if n == 0 {
 		return "zeroth"
 	}
+	if magnitude, ok := minInt64MagnitudeString(n); ok {
+		return "minus " + magnitude + "th"
+	}
 	if n < 0 {
 		return "minus " + englishOrdinal(-n)
 	}
@@ -177,6 +188,9 @@ func englishTensOrdinal(n int64) string {
 func germanCardinal(n int64) string {
 	if n == 0 {
 		return "null"
+	}
+	if magnitude, ok := minInt64MagnitudeString(n); ok {
+		return "minus " + magnitude
 	}
 	if n < 0 {
 		return "minus " + germanCardinal(-n)
@@ -331,6 +345,9 @@ func italianCardinal(n int64) string {
 	if n == 0 {
 		return "zero"
 	}
+	if magnitude, ok := minInt64MagnitudeString(n); ok {
+		return "meno " + magnitude
+	}
 	if n < 0 {
 		return "meno " + italianCardinal(-n)
 	}
@@ -426,6 +443,9 @@ func italianOrdinal(n int64, ordinal string) string {
 func frenchCardinal(n int64) string {
 	if n == 0 {
 		return "zéro"
+	}
+	if magnitude, ok := minInt64MagnitudeString(n); ok {
+		return "moins " + magnitude
 	}
 	if n < 0 {
 		return "moins " + frenchCardinal(-n)

--- a/xslt3/number_words.go
+++ b/xslt3/number_words.go
@@ -10,14 +10,16 @@ import (
 // ones-table and in special-case logic that switches to the prefix form "ein"
 // when followed by another component.
 const (
-	germanOne       = "eins"
-	germanOnePrefix = "ein"
+	germanOne             = "eins"
+	germanOnePrefix       = "ein"
+	numberBillion   int64 = 1_000_000_000
+	numberTrillion  int64 = 1_000_000_000_000
 )
 
 // numberToWordsLang converts a number to words in the given language and case.
 // caseMode is "lower", "upper", or "title".
 // ordinal is the ordinal hint (e.g., "yes", "%spellout-ordinal-masculine").
-func numberToWordsLang(n int, caseMode string, lang string, ordinal string) string {
+func numberToWordsLang(n int64, caseMode string, lang string, ordinal string) string {
 	// Normalize language tag to base language
 	baseLang := strings.ToLower(lang)
 	if idx := strings.IndexAny(baseLang, "-_"); idx >= 0 {
@@ -61,7 +63,7 @@ func toTitleCase(s string) string {
 }
 
 // numberToCardinalWords returns a cardinal number word in the given language.
-func numberToCardinalWords(n int, lang string) string {
+func numberToCardinalWords(n int64, lang string) string {
 	switch lang {
 	case "de":
 		return germanCardinal(n)
@@ -75,7 +77,7 @@ func numberToCardinalWords(n int, lang string) string {
 }
 
 // numberToOrdinalWords returns an ordinal number word in the given language.
-func numberToOrdinalWords(n int, lang string, ordinal string) string {
+func numberToOrdinalWords(n int64, lang string, ordinal string) string {
 	switch lang {
 	case "de":
 		return germanOrdinal(n, ordinal)
@@ -92,7 +94,7 @@ func numberToOrdinalWords(n int, lang string, ordinal string) string {
 // English ordinals
 // ============================================================
 
-func englishOrdinal(n int) string {
+func englishOrdinal(n int64) string {
 	if n == 0 {
 		return "zeroth"
 	}
@@ -100,15 +102,15 @@ func englishOrdinal(n int) string {
 		return "minus " + englishOrdinal(-n)
 	}
 	// For compound numbers, only the last component is ordinal
-	if n >= 1000000000000 {
-		q, r := n/1000000000000, n%1000000000000
+	if n >= numberTrillion {
+		q, r := n/numberTrillion, n%numberTrillion
 		if r == 0 {
 			return numberToWords(q, false) + " trillionth"
 		}
 		return numberToWords(q, false) + " trillion " + englishOrdinal(r)
 	}
-	if n >= 1000000000 {
-		q, r := n/1000000000, n%1000000000
+	if n >= numberBillion {
+		q, r := n/numberBillion, n%numberBillion
 		if r == 0 {
 			return numberToWords(q, false) + " billionth"
 		}
@@ -146,33 +148,33 @@ func englishOrdinal(n int) string {
 	return englishOnesOrdinal(n)
 }
 
-func englishOnesOrdinal(n int) string {
+func englishOnesOrdinal(n int64) string {
 	ords := []string{
 		"zeroth", "first", "second", "third", "fourth", "fifth",
 		"sixth", "seventh", "eighth", "ninth", "tenth",
 		"eleventh", "twelfth", "thirteenth", "fourteenth", "fifteenth",
 		"sixteenth", "seventeenth", "eighteenth", "nineteenth",
 	}
-	if n >= 0 && n < len(ords) {
-		return ords[n]
+	if n >= 0 && n < int64(len(ords)) {
+		return ords[int(n)]
 	}
-	return strconv.Itoa(n) + "th"
+	return strconv.FormatInt(n, 10) + "th"
 }
 
-func englishTensOrdinal(n int) string {
+func englishTensOrdinal(n int64) string {
 	ords := []string{"", "", "twentieth", "thirtieth", "fortieth", "fiftieth",
 		"sixtieth", "seventieth", "eightieth", "ninetieth"}
-	if n >= 0 && n < len(ords) {
-		return ords[n]
+	if n >= 0 && n < int64(len(ords)) {
+		return ords[int(n)]
 	}
-	return strconv.Itoa(n*10) + "th"
+	return strconv.FormatInt(n*10, 10) + "th"
 }
 
 // ============================================================
 // German
 // ============================================================
 
-func germanCardinal(n int) string {
+func germanCardinal(n int64) string {
 	if n == 0 {
 		return "null"
 	}
@@ -184,20 +186,20 @@ func germanCardinal(n int) string {
 	tens := []string{"", "", "zwanzig", "dreißig", "vierzig", "fünfzig", "sechzig", "siebzig", "achtzig", "neunzig"}
 
 	if n < 20 {
-		return ones[n]
+		return ones[int(n)]
 	}
 	if n < 100 {
 		if n%10 == 0 {
-			return tens[n/10]
+			return tens[int(n/10)]
 		}
-		o := ones[n%10]
+		o := ones[int(n%10)]
 		if o == germanOne {
 			o = germanOnePrefix
 		}
-		return o + "und" + tens[n/10]
+		return o + "und" + tens[int(n/10)]
 	}
 	if n < 1000 {
-		w := ones[n/100]
+		w := ones[int(n/100)]
 		if w == germanOne {
 			w = germanOnePrefix
 		}
@@ -221,7 +223,7 @@ func germanCardinal(n int) string {
 		}
 		return w
 	}
-	if n < 1000000000 {
+	if n < numberBillion {
 		q := n / 1000000
 		w := ""
 		if q == 1 {
@@ -234,10 +236,10 @@ func germanCardinal(n int) string {
 		}
 		return w
 	}
-	return strconv.Itoa(n)
+	return strconv.FormatInt(n, 10)
 }
 
-func germanOrdinal(n int, ordinal string) string {
+func germanOrdinal(n int64, ordinal string) string {
 	if n <= 0 {
 		return germanCardinal(n)
 	}
@@ -257,7 +259,7 @@ func germanOrdinal(n int, ordinal string) string {
 // germanOrdinalStem returns the ordinal stem for n, ready for suffix attachment.
 // Irregular stems: erst, dritt, siebt, acht.
 // Regular: cardinal + "t" (1-19) or cardinal + "st" (20+).
-func germanOrdinalStem(n int) string {
+func germanOrdinalStem(n int64) string {
 	// Handle compound numbers recursively: only the last component is ordinal
 	if n >= 1000000 {
 		q := n / 1000000
@@ -292,7 +294,7 @@ func germanOrdinalStem(n int) string {
 		q := n / 100
 		r := n % 100
 		ones := []string{"", germanOne, "zwei", "drei", "vier", "fünf", "sechs", "sieben", "acht", "neun"}
-		w := ones[q]
+		w := ones[int(q)]
 		if w == germanOne {
 			w = germanOnePrefix
 		}
@@ -325,7 +327,7 @@ func germanOrdinalStem(n int) string {
 // Italian
 // ============================================================
 
-func italianCardinal(n int) string {
+func italianCardinal(n int64) string {
 	if n == 0 {
 		return "zero"
 	}
@@ -338,10 +340,10 @@ func italianCardinal(n int) string {
 	tens := []string{"", "", "venti", "trenta", "quaranta", "cinquanta", "sessanta", "settanta", "ottanta", "novanta"}
 
 	if n < 20 {
-		return ones[n]
+		return ones[int(n)]
 	}
 	if n < 100 {
-		t := tens[n/10]
+		t := tens[int(n/10)]
 		o := n % 10
 		if o == 0 {
 			return t
@@ -350,7 +352,7 @@ func italianCardinal(n int) string {
 		if o == 1 || o == 8 {
 			t = t[:len(t)-1]
 		}
-		return t + ones[o]
+		return t + ones[int(o)]
 	}
 	if n < 1000 {
 		q := n / 100
@@ -358,7 +360,7 @@ func italianCardinal(n int) string {
 		if q == 1 {
 			w = "cento"
 		} else {
-			w = ones[q] + "cento"
+			w = ones[int(q)] + "cento"
 		}
 		r := n % 100
 		if r != 0 {
@@ -380,10 +382,10 @@ func italianCardinal(n int) string {
 		}
 		return w
 	}
-	return strconv.Itoa(n)
+	return strconv.FormatInt(n, 10)
 }
 
-func italianOrdinal(n int, ordinal string) string {
+func italianOrdinal(n int64, ordinal string) string {
 	if n <= 0 {
 		return italianCardinal(n)
 	}
@@ -396,11 +398,11 @@ func italianOrdinal(n int, ordinal string) string {
 		if feminine {
 			ords := []string{"", "prima", "seconda", "terza", "quarta", "quinta",
 				"sesta", "settima", "ottava", "nona", "decima"}
-			return ords[n]
+			return ords[int(n)]
 		}
 		ords := []string{"", "primo", "secondo", "terzo", "quarto", "quinto",
 			"sesto", "settimo", "ottavo", "nono", "decimo"}
-		return ords[n]
+		return ords[int(n)]
 	}
 
 	// Regular Italian ordinals: cardinal stem + -esimo/-esima
@@ -421,7 +423,7 @@ func italianOrdinal(n int, ordinal string) string {
 // French
 // ============================================================
 
-func frenchCardinal(n int) string {
+func frenchCardinal(n int64) string {
 	if n == 0 {
 		return "zéro"
 	}
@@ -433,7 +435,7 @@ func frenchCardinal(n int) string {
 		"dix", "onze", "douze", "treize", "quatorze", "quinze", "seize", "dix-sept", "dix-huit", "dix-neuf"}
 
 	if n < 20 {
-		return ones[n]
+		return ones[int(n)]
 	}
 	if n < 100 {
 		tens := []string{"", "", "vingt", "trente", "quarante", "cinquante", "soixante", "soixante", "quatre-vingt", "quatre-vingt"}
@@ -447,7 +449,7 @@ func frenchCardinal(n int) string {
 			if t == 8 {
 				return "quatre-vingts"
 			}
-			return tens[t]
+			return tens[int(t)]
 		}
 		sep := "-"
 		if o == 1 && t != 8 && t != 9 {
@@ -456,7 +458,7 @@ func frenchCardinal(n int) string {
 		if o == 11 && t == 7 {
 			sep = " et "
 		}
-		return tens[t] + sep + ones[o]
+		return tens[int(t)] + sep + ones[int(o)]
 	}
 	if n < 1000 {
 		q := n / 100
@@ -464,7 +466,7 @@ func frenchCardinal(n int) string {
 		if q == 1 {
 			w = "cent"
 		} else {
-			w = ones[q] + " cent"
+			w = ones[int(q)] + " cent"
 		}
 		r := n % 100
 		if r == 0 && q > 1 {
@@ -489,10 +491,10 @@ func frenchCardinal(n int) string {
 		}
 		return w
 	}
-	return strconv.Itoa(n)
+	return strconv.FormatInt(n, 10)
 }
 
-func frenchOrdinal(n int, _ string) string {
+func frenchOrdinal(n int64, _ string) string {
 	if n == 1 {
 		return "premier"
 	}

--- a/xslt3/number_words_test.go
+++ b/xslt3/number_words_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestFrenchCardinalTens(t *testing.T) {
 	cases := []struct {
-		n    int
+		n    int64
 		want string
 	}{
 		{40, "quarante"},


### PR DESCRIPTION
- Preserve `xsl:number` word and ordinal output across 32-bit and 64-bit targets.
- Cover signed 32-bit and trillion formatting boundaries.
