### PR TITLE
fix xmlenc1 GCM compatibility wording

### DIFF
--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -39,8 +39,8 @@ Import path: `github.com/lestrrat-go/helium/xmlenc1`
   document's is used when none is set, and a pair that disagrees fails with
   `ErrConflictingBlockAlgorithm`. A document can therefore never override a
   caller who stated the algorithm out of band. Whichever URI the resolution
-  returns is what the CBC opt-in, the legacy GCM additional authenticated data,
-  and every key-length binding act on.
+  returns is what the CBC opt-in, Helium's nonstandard 2001-namespace GCM
+  additional authenticated data, and every key-length binding act on.
 - AES-CBC is unauthenticated and vulnerable to padding-oracle attacks
   (Jager/Somorovsky 2011).
   - **Encryption:** selecting a CBC `BlockAlgorithm` requires

--- a/xmlenc1/decrypt_block_algorithm_test.go
+++ b/xmlenc1/decrypt_block_algorithm_test.go
@@ -150,10 +150,11 @@ func TestDecryptBlockAlgorithm(t *testing.T) {
 		require.Len(t, nodes, 1)
 	})
 
-	// Legacy-namespace GCM binds the algorithm URI into the AEAD additional
-	// authenticated data. The resolved URI must feed that same slot, so a
-	// legacy ciphertext opens under its own URI and fails under any other.
-	t.Run("legacy GCM binds the resolved URI as additional data", func(t *testing.T) {
+	// Helium's nonstandard 2001-namespace GCM compatibility extension binds the
+	// algorithm URI into the AEAD additional authenticated data. The resolved URI
+	// must feed that same slot, so its ciphertext opens under its own URI and fails
+	// under any other.
+	t.Run("Helium's 2001-namespace GCM extension binds the resolved URI as additional data", func(t *testing.T) {
 		sessionKey := randKey(t, 32)
 		elem := encryptedDataWithoutEncryptionMethod(t, xmlenc1.AES256GCM, sessionKey, []byte(plaintext))
 


### PR DESCRIPTION
- identify Helium's 2001-namespace GCM identifiers as a nonstandard compatibility extension
- preserve resolved-URI authentication coverage without implying a standard legacy profile
