### PR TITLE
limit xpath1 diagnostic excerpts

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -10,15 +10,15 @@ xinclude       → helium, xpointer, internal/encoding, internal/iofs, internal/
                   → xpath1 (via xpointer)
                   → internal/xmlchar (via xpointer)
                   (helium.Parser.XInclude injects an xinclude.Processor through the helium.XIncludeProcessor interface — dependency inversion keeps this edge one-way; helium does NOT import xinclude)
-xpath1         → helium, internal/lexicon, internal/domutil
+xpath1         → helium, internal/lexicon, internal/domutil, internal/xpath1/lexer
 xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex, internal/xmlchar, internal/domutil, internal/writerctl
 xslt3          → helium, xpath3, xsd, html, internal/iofs, internal/lexicon, internal/nodelink, internal/sequence, internal/uripath, internal/xpathstream, internal/domutil, internal/writerctl, xslt3/internal/elements
-xsd            → helium, xpath1, xpath3, internal/domutil, internal/lexicon, internal/xsd/value, internal/xsdregex, internal/uripath, internal/iofs
+xsd            → helium, xpath1, xpath3, internal/domutil, internal/lexicon, internal/xpath1/lexer, internal/xsd/value, internal/xsdregex, internal/uripath, internal/iofs
 relaxng        → helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xsdregex, internal/xmlchar, internal/uripath
-schematron     → helium, xpath1, xpath3, internal/xpath, internal/xpath1/number
-xpointer       → helium, xpath1, internal/xmlchar
+schematron     → helium, xpath1, xpath3, internal/xpath, internal/xpath1/lexer, internal/xpath1/number
+xpointer       → helium, xpath1, internal/xpath1/lexer, internal/xmlchar
 c14n           → helium, internal/lexicon, internal/domutil
-xmldsig1       → helium, c14n, xpath1, internal/lexicon, internal/domutil, internal/xmlbase64, internal/xmlchar
+xmldsig1       → helium, c14n, xpath1, internal/lexicon, internal/domutil, internal/xpath1/lexer, internal/xmlbase64, internal/xmlchar
 xmldsig1/transform → helium, xmldsig1, xslt3  (opt-in xslt3-backed XSLTTransformer; kept out of xmldsig1 so the core never imports xslt3)
 xmlenc1        → helium, c14n, internal/domutil, internal/xmlbase64  (c14n converts the node-set a same-document xenc:CipherReference names into octets; c14n imports neither xmlenc1 nor xmldsig1, so the edge is one-way)
 html           → helium, sax, push, internal/xmlchar
@@ -37,6 +37,7 @@ push → (none)
 internal/heliumtest → (none)
 internal/sequence → (none)
 internal/strcursor → (none)
+internal/xpath1/lexer → (none)
 internal/unparsedtext → internal/xmlchar, internal/uripath, internal/iofs
 internal/catalog → internal/uripath
 internal/uripath → (none)
@@ -52,7 +53,9 @@ test           → helium
 ```
 
 ## Leaf packages (no helium deps)
-sink, enum, internal/bitset, internal/heliumtest, internal/parser, push, internal/stack, internal/cliutil, internal/encoding, internal/lexicon, internal/icu, internal/nodelink, internal/nslookup, internal/sequence, internal/strcursor, internal/writerctl, internal/xsdregex, internal/uripath
+sink, enum, internal/bitset, internal/heliumtest, internal/parser, push, internal/stack, internal/cliutil,
+internal/encoding, internal/lexicon, internal/icu, internal/nodelink, internal/nslookup, internal/sequence, internal/strcursor,
+internal/writerctl, internal/xpath1/lexer, internal/xsdregex, internal/uripath
 
 ## Core layer
 helium (root) → sax, enum, internal/*
@@ -61,10 +64,16 @@ helium (root) → sax, enum, internal/*
 c14n, xpath1, xpath3, html, catalog, relaxng, stream
 
 ## Security layer (depends on processing)
-xmldsig1 (root + c14n + xpath1 + internal/lexicon + internal/xmlchar; xpath1 backs the XPath filter transform), xmlenc1 (root + c14n; c14n converts the node-set a same-document xenc:CipherReference names into octets)
+xmldsig1 (root + c14n + xpath1 + internal/lexicon + internal/xpath1/lexer + internal/xmlchar; xpath1 backs the XPath filter
+transform), xmlenc1 (root + c14n; c14n converts the node-set a same-document xenc:CipherReference names into
+octets)
 
 ## Composition layer (depends on processing)
-xsd (root + xpath1 + xpath3 + internal/lexicon), xpointer (root + xpath1 + internal/xmlchar), schematron (root + xpath1 + xpath3 + internal/xpath + internal/xpath1/number; xpath1 backs the XPath 1.0 queryBinding, xpath3 the XPath 3.1 one), xinclude (root + xpointer + internal/encoding + internal/iofs + internal/lexicon), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)
+xsd (root + xpath1 + xpath3 + internal/lexicon + internal/xpath1/lexer), xpointer (root + xpath1 +
+internal/xpath1/lexer + internal/xmlchar), schematron (root + xpath1 + xpath3 + internal/xpath +
+internal/xpath1/lexer + internal/xpath1/number; xpath1 backs the XPath 1.0 queryBinding, xpath3 the XPath 3.1
+one), xinclude (root + xpointer + internal/encoding + internal/iofs + internal/lexicon), xslt3 (root + xpath3 +
+xsd + html + internal/elements), shim (root + stream)
 
 ## Application layer
 internal/cli/heliumcmd (CLI implementation)

--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -153,12 +153,15 @@ loads) and the caller owns its lifecycle, closing it once the resulting value is
 
 ## Package-Specific Error Formatting
 
-### XPath 1.0 (`xpath1`)
+### XPath expression excerpts (`internal/xpath1/lexer/diagnostic.go`)
 
-Diagnostics bound each caller-controlled token, QName, namespace prefix, namespace URI, variable name, or
-expression excerpt to 128 bytes, including a `...[truncated]` marker. Excerpts end on a UTF-8 rune boundary;
-invalid UTF-8 is replaced before formatting. Short valid excerpts retain their existing wording, and wrapped
-sentinels such as `ErrUnexpectedToken` and `ErrUnknownNamespacePrefix` remain matchable with `errors.Is`.
+`lexer.DiagnosticExcerpt` bounds each caller-controlled token, QName, namespace prefix, namespace URI,
+variable name, or expression excerpt to 128 bytes, including a `...[truncated]` marker. Excerpts end on a UTF-8
+rune boundary; invalid UTF-8 is replaced before formatting. Short valid excerpts retain their wording.
+`xpath1` uses it for its own diagnostics. `xpointer` XPath-scheme compilation, `xmldsig1` general-XPointer
+preparation, XSD identity-constraint selector/field compilation, and Schematron context/test/name/value-of
+compilation use the same helper before reinserting source expressions. Wrapped sentinels remain matchable via
+the package's existing error chain.
 
 ### XSD (`xsd/errors.go`)
 

--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -153,6 +153,13 @@ loads) and the caller owns its lifecycle, closing it once the resulting value is
 
 ## Package-Specific Error Formatting
 
+### XPath 1.0 (`xpath1`)
+
+Diagnostics bound each caller-controlled token, QName, namespace prefix, namespace URI, variable name, or
+expression excerpt to 128 bytes, including a `...[truncated]` marker. Excerpts end on a UTF-8 rune boundary;
+invalid UTF-8 is replaced before formatting. Short valid excerpts retain their existing wording, and wrapped
+sentinels such as `ErrUnexpectedToken` and `ErrUnknownNamespacePrefix` remain matchable with `errors.Is`.
+
 ### XSD (`xsd/errors.go`)
 
 | Function | Format |

--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -158,10 +158,11 @@ loads) and the caller owns its lifecycle, closing it once the resulting value is
 `lexer.DiagnosticExcerpt` bounds each caller-controlled token, QName, namespace prefix, namespace URI,
 variable name, or expression excerpt to 128 bytes, including a `...[truncated]` marker. Excerpts end on a UTF-8
 rune boundary; invalid UTF-8 is replaced before formatting. Short valid excerpts retain their wording.
-`xpath1` uses it for its own diagnostics. `xpointer` XPath-scheme compilation, `xmldsig1` general-XPointer
-preparation, XSD identity-constraint selector/field compilation, and Schematron context/test/name/value-of
-compilation use the same helper before reinserting source expressions. Wrapped sentinels remain matchable via
-the package's existing error chain.
+`xpath1` uses it for its own diagnostics. `xpointer` syntax and XPath-scheme diagnostics, `xmldsig1`
+general-XPointer preparation/resolution and per-reference URI rendering, XSD identity-constraint
+selector/field compilation and runtime field diagnostics, and Schematron context/test/name/value-of
+compilation use the same helper before reinserting source values. Wrapped sentinels remain matchable via the
+package's existing error chain.
 
 ### XSD (`xsd/errors.go`)
 
@@ -299,11 +300,17 @@ symmetrically. Both hold `Reference int` (0-based index), `URI string`, `Err err
 cause so sentinels (`ErrReferenceNotFound`, `ErrUnsupportedTransform`, `ErrDigestMismatch`, …) stay
 `errors.Is`/`errors.As`-reachable through the wrapper.
 
-- `ReferenceError` (signing): adds `Op string` (`"sign"`). Format: `xmldsig1: sign reference N ("URI") failed:
-  <cause>`. Wrapped both in the `processReference` loops of `signEnveloped`/`signEnveloping`/`signDetached`
-  and in the pre-mutation `preflightSignerTransforms` transform-pipeline validation (`transforms.go`), so a
-  rejected pipeline still names its Reference.
-- `VerificationError` (verification): `Reference == -1` marks a SignatureValue failure (`xmldsig1: signature value verification failed: <cause>`); otherwise `xmldsig1: reference N ("URI") verification failed: <cause>`.
+- `ReferenceError` (signing): adds `Op string` (`"sign"`). Format: `xmldsig1: sign reference N ("URI excerpt")
+  failed: <cause>`. Wrapped both in the `processReference` loops of
+  `signEnveloped`/`signEnveloping`/`signDetached` and in the pre-mutation `preflightSignerTransforms`
+  transform-pipeline validation (`transforms.go`), so a rejected pipeline still names its Reference.
+- `VerificationError` (verification): `Reference == -1` marks a SignatureValue failure (`xmldsig1: signature
+  value verification failed: <cause>`); otherwise `xmldsig1: reference N ("URI excerpt") verification
+  failed: <cause>`.
+
+The wrapper structs retain the complete `URI` for programmatic inspection. Their `Error()` methods render a
+bounded valid-UTF-8 excerpt, and same-document/general-XPointer resolution errors apply the same bound before
+wrapping so the cause cannot repeat the complete URI.
 
 External-reference resolution sentinels (`errors.go`, `reference_resolver.go`): `ErrReferenceNotFound` is the
 fail-closed default for an external Reference with no configured `ReferenceResolver`, AND every

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1258,8 +1258,9 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
     key resolution, SignatureValue authentication, or the top-level Reference digest loop. Each parsed
     Reference caches its ordered transform steps plus any prepared general-XPointer evaluator for execution,
     so no Reference resolver or XSLT transformer runs when a later Reference has a static XPath failure.
-    Per-reference errors keep their `VerificationError` index and URI. Opt-in Manifest inner references use a
-    separate all-siblings preparation pass and remain advisory.
+    Per-reference errors keep their `VerificationError` index and complete URI fields, while `Error()` renders
+    the URI through `lexer.DiagnosticExcerpt`. Opt-in Manifest inner references use a separate all-siblings
+    preparation pass and remain advisory.
 - **NewEnvelopedReference() → ReferenceConfig** — WHOLE-DOCUMENT enveloped defaults: empty URI (always resolves to the document element, regardless of the `SignEnveloped` parent) + enveloped-signature transform + ExcC14N + SHA-256
 - **NewEnvelopedReferenceByID(id) → ReferenceConfig** — element-scoped enveloped defaults: `URI="#id"` (covers
   only the element carrying that id) + enveloped-signature transform + ExcC14N + SHA-256. Correct for signing
@@ -1408,8 +1409,9 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   (`Document.GetElementByID`, which resolves a duplicate id to the last-registered element — an XSW bypass): a
   whole-expression `id('X')` selector in any XML S spelling (`id('X')`, `id ('X')`, `id( "X" )`;
   `parseXPointerIDSelector`) resolves through the duplicate-detecting `domutil.FindElementsByID`
-  (`ErrAmbiguousReference` on a duplicate), and ANY other id() use — a wrapping paren, a predicate, a path
-  step (`expressionReferencesID`) — is rejected fail-closed as `ErrReferenceNotFound` and never reaches the
+  (`ErrAmbiguousReference` on a duplicate); zero-match and duplicate diagnostics render the id through
+  `lexer.DiagnosticExcerpt`. ANY other id() use — a wrapping paren, a predicate, a path step
+  (`expressionReferencesID`) — is rejected fail-closed as `ErrReferenceNotFound` and never reaches the
   built-in. Before compilation, non-XML-S Unicode whitespace outside quoted XPath literals is rejected, while
   the same characters inside literals remain data. The selected element is fed into the existing subtree
   canonicalization path (comments included).
@@ -1492,7 +1494,8 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   transform-pipeline check), verification wraps each in `*VerificationError{Reference, URI, Err}` (`Reference
   == -1` marks a SignatureValue failure). Both `Unwrap()` to the cause, so a sentinel like
   `ErrReferenceNotFound`/`ErrUnsupportedTransform` stays `errors.Is`-matchable and the failing reference's
-  index+URI is reachable via `errors.As`. The verify-side weak-digest preflight
+  index+complete URI is reachable via `errors.As`; `Error()` renders only a bounded valid-UTF-8 URI excerpt,
+  and same-document/nil-resolver causes bound any URI they repeat. The verify-side weak-digest preflight
   (`preflightParsedWeakAlgorithms`) also wraps a per-reference `ErrWeakAlgorithm` in `*VerificationError`
   carrying the failing reference's index+URI, symmetric with the sign-side preflight's `*ReferenceError`. A
   malformed ECDSA/DSA `SignatureValue` length on verify is classified as `ErrVerificationFailed` (not an

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -883,7 +883,7 @@ Toggle" section in CLAUDE.md for what is implemented in 1.1.
   (open content), `override.go` (xs:override), `inherited_attrs.go` (XSD 1.1 inherited attributes),
   `schema_decls.go` (schema-aware XPath adapter), `errors.go`
 - Imports: helium, xpath1/, xpath3/ (XSD 1.1 assertions + conditional type assignment), internal/domutil,
-  internal/lexicon
+  internal/lexicon, internal/xpath1/lexer
 - Status: see `.claude/docs/libxml2-parity.md` for libxml2 golden counts and W3C XSD 1.1 conformance run policy; do not cache branch-specific counts here
 
 ## relaxng/
@@ -1018,7 +1018,7 @@ XPointer expression evaluation with scheme cascading.
 - `ErrNilExpression` — sentinel returned by `Expression.Evaluate` when the receiver is nil or an uncompiled (zero-value) `Expression`
 - `ErrNilDocument` — sentinel returned by `Expression.Evaluate`/`Evaluate` when the document is nil
 - Files: `xpointer.go`
-- Imports: helium, xpath1/, internal/xmlchar/
+- Imports: helium, xpath1/, internal/xpath1/lexer, internal/xmlchar/
 
 ## schematron/
 
@@ -1045,7 +1045,7 @@ Schematron schema compilation and validation.
 - Files: `schematron.go` (API + config), `schema.go` (data model), `parse.go` (compilation), `validate.go`
   (validation), `errors.go` (error types + formatting), `querybinding.go` (binding resolution), `engine.go`
   (engine/runner/value seam), `engine_xpath1.go` + `engine_xpath3.go` (per-binding engines)
-- Imports: helium, internal/xpath, xpath1/, xpath3/, internal/xpath1/number
+- Imports: helium, internal/xpath, xpath1/, xpath3/, internal/xpath1/lexer, internal/xpath1/number
 
 ## catalog/
 
@@ -1525,7 +1525,7 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   Manifest inner-reference validation), `xslt_transform.go` (XSLT transform seam: `XSLTTransformer` +
   `parseXSLTTransform`), `reference_resolver.go` (external-reference resolver API + FSReferenceResolver),
   `keyinfo.go`, `retrieval_method.go` (ds:RetrievalMethod dereferencing), `errors.go`
-- Imports: helium, c14n/, xpath1/ (XPath filter transform)
+- Imports: helium, c14n/, xpath1/ (XPath filter transform), internal/xpath1/lexer
 
 ## xmlenc1/
 

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -1487,7 +1487,9 @@ include/redefine, else `c.filename` — for an import sub-compiler that is the i
 location), and `checkKeyRefRefers` reports with `idc.Source`+`idc.Line` in place of the top-level compiler's
 filename, so an IMPORTED keyref's dangling-refer error cites the imported schema (where its line number is
 meaningful), not the importing schema. At validation time, an IDC whose selector/field XPath fails to evaluate
-is reported as a validity error (`Failed to evaluate identity-constraint '…'`), not swallowed.
+is reported as a validity error (`Failed to evaluate identity-constraint '…'`), not swallowed. Every runtime
+field-XPath diagnostic uses `lexer.DiagnosticExcerpt`, including compile/evaluate failures, non-simple nodes,
+and multi-member node sets, so a valid long expression cannot make validation output grow with its source.
 
 **Pass 2 — Identity Constraints** (`validateIDConstraints` via second `helium.Walk()`):
 - **Host declaration resolution** (`idcHostDecl`): the declaration whose IDCs apply

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -1453,7 +1453,9 @@ permits reluctant quantifiers and `(?:…)`. Stray-hyphen character-class ranges
 (`[^a-d-b-c]`) are a known remaining false-accept, deferred.
 
 **Compile-time IDC checks:** a malformed `xs:selector`/`xs:field` `@xpath` is a fatal schema parser error
-(`parseIDConstraint` → `reportIDCXPathError`). A silently-dropped `xpath1.Compile` failure would disable the
+(`parseIDConstraint` → `reportIDCXPathError`). The quoted source uses `lexer.DiagnosticExcerpt`, so the
+ErrorHandler diagnostic stays bounded and valid UTF-8 while short wording stays unchanged. A silently-dropped
+`xpath1.Compile` failure would disable the
 whole constraint. A structurally malformed IDC declaration is likewise fatal (`parseIDConstraint` →
 `reportIDCStructureError`, src-identity-constraint): a missing required `@name` (`The attribute 'name' is
 required but missing.`, drops the constraint), a missing `<selector>` child (`A child element is missing.`,
@@ -2114,6 +2116,9 @@ Structural attributes (`context`, `test`, `select`, `name`, `id`, `prefix`, `uri
 `ErrorLevelFatal` diagnostic is emitted (no pattern, pattern with no rule, rule with no test, etc.),
 `Compile`/`CompileFile` return `ErrCompileFailed` with a **nil** `*Schema` — even when no error handler is
 configured, so a broken schema can never validate as success.
+
+Compilation errors that quote a rule context, assert/report test, name path, or value-of select bound the
+source through `lexer.DiagnosticExcerpt`; diagnostics stay valid UTF-8 and short wording stays unchanged.
 
 ### Validate: Document + Schema → Errors
 

--- a/.claude/docs/xsd11-identity-constraints.md
+++ b/.claude/docs/xsd11-identity-constraints.md
@@ -43,6 +43,8 @@
     tolerated), and a name-test prefix unbound in the SELECTOR/FIELD element's OWN in-scope namespaces
     (`collectNSContext(ce)`; `xml` always bound; compile-time scope per selector/field element,
     `idc.Namespaces` runtime unchanged).
+    `reportIDCXPathError` bounds the quoted `@xpath` through `lexer.DiagnosticExcerpt`; malformed expressions
+    cannot make the ErrorHandler diagnostic grow with the source attribute, and short wording stays unchanged.
   - Known remaining IDC gap (still accepted): a `fixed` value on a repeating `xs:ID` attribute.
 - **identity-constraint field-node classification** (cvc-identity-constraint.3 / XSD 1.1 §3.11.4):
   `evaluateIDC` (`validate_idc.go`) classifies each `xs:key`/`xs:unique`/`xs:keyref` `<xs:field>` result node

--- a/.claude/docs/xsd11-identity-constraints.md
+++ b/.claude/docs/xsd11-identity-constraints.md
@@ -45,6 +45,8 @@
     `idc.Namespaces` runtime unchanged).
     `reportIDCXPathError` bounds the quoted `@xpath` through `lexer.DiagnosticExcerpt`; malformed expressions
     cannot make the ErrorHandler diagnostic grow with the source attribute, and short wording stays unchanged.
+    `evaluateIDC` applies the same bound to every runtime field-XPath diagnostic, including compile/evaluate
+    failures, non-simple selected nodes, and multi-member node sets.
   - Known remaining IDC gap (still accepted): a `fixed` value on a repeating `xs:ID` attribute.
 - **identity-constraint field-node classification** (cvc-identity-constraint.3 / XSD 1.1 §3.11.4):
   `evaluateIDC` (`validate_idc.go`) classifies each `xs:key`/`xs:unique`/`xs:keyref` `<xs:field>` result node

--- a/internal/xpath1/lexer/diagnostic.go
+++ b/internal/xpath1/lexer/diagnostic.go
@@ -1,0 +1,27 @@
+package lexer
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// DiagnosticExcerptByteLimit is the maximum byte length returned by
+// DiagnosticExcerpt, including its truncation marker.
+const DiagnosticExcerptByteLimit = 128
+
+const diagnosticTruncationMarker = "...[truncated]"
+
+// DiagnosticExcerpt returns a bounded, valid UTF-8 excerpt for diagnostics.
+// Valid UTF-8 strings within DiagnosticExcerptByteLimit are returned unchanged.
+func DiagnosticExcerpt(s string) string {
+	s = strings.ToValidUTF8(s, "\uFFFD")
+	if len(s) <= DiagnosticExcerptByteLimit {
+		return s
+	}
+
+	end := DiagnosticExcerptByteLimit - len(diagnosticTruncationMarker)
+	for !utf8.RuneStart(s[end]) {
+		end--
+	}
+	return s[:end] + diagnosticTruncationMarker
+}

--- a/internal/xpath1/lexer/diagnostic.go
+++ b/internal/xpath1/lexer/diagnostic.go
@@ -14,11 +14,21 @@ const diagnosticTruncationMarker = "...[truncated]"
 // DiagnosticExcerpt returns a bounded, valid UTF-8 excerpt for diagnostics.
 // Valid UTF-8 strings within DiagnosticExcerptByteLimit are returned unchanged.
 func DiagnosticExcerpt(s string) string {
-	s = strings.ToValidUTF8(s, "\uFFFD")
-	if len(s) <= DiagnosticExcerptByteLimit {
-		return s
-	}
+	var excerpt strings.Builder
+	excerpt.Grow(DiagnosticExcerptByteLimit)
+	for len(s) > 0 {
+		r, size := utf8.DecodeRuneInString(s)
+		s = s[size:]
 
+		if excerpt.Len()+utf8.RuneLen(r) > DiagnosticExcerptByteLimit {
+			return truncateDiagnosticExcerpt(excerpt.String())
+		}
+		excerpt.WriteRune(r)
+	}
+	return excerpt.String()
+}
+
+func truncateDiagnosticExcerpt(s string) string {
 	end := DiagnosticExcerptByteLimit - len(diagnosticTruncationMarker)
 	for !utf8.RuneStart(s[end]) {
 		end--

--- a/internal/xpath1/lexer/diagnostic_test.go
+++ b/internal/xpath1/lexer/diagnostic_test.go
@@ -36,9 +36,16 @@ func TestDiagnosticExcerpt(t *testing.T) {
 	})
 
 	t.Run("invalid UTF-8 is replaced", func(t *testing.T) {
-		got := lexer.DiagnosticExcerpt(string([]byte{'a', 0xff, 'b'}))
-		require.Equal(t, "a\uFFFDb", got)
+		got := lexer.DiagnosticExcerpt(string([]byte{'a', 0xff, 0xff, 'b'}))
+		require.Equal(t, "a\uFFFD\uFFFDb", got)
 		require.True(t, utf8.ValidString(got))
+	})
+
+	t.Run("invalid UTF-8 input is bounded", func(t *testing.T) {
+		got := lexer.DiagnosticExcerpt(strings.Repeat("\xff", 1<<20))
+		require.LessOrEqual(t, len(got), lexer.DiagnosticExcerptByteLimit)
+		require.True(t, utf8.ValidString(got))
+		require.Contains(t, got, "[truncated]")
 	})
 }
 

--- a/internal/xpath1/lexer/diagnostic_test.go
+++ b/internal/xpath1/lexer/diagnostic_test.go
@@ -1,0 +1,58 @@
+package lexer_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiagnosticExcerpt(t *testing.T) {
+	t.Run("short text is unchanged", func(t *testing.T) {
+		const input = "short 世界"
+		require.Equal(t, input, lexer.DiagnosticExcerpt(input))
+	})
+
+	t.Run("ASCII is bounded", func(t *testing.T) {
+		within := strings.Repeat("a", lexer.DiagnosticExcerptByteLimit)
+		require.Equal(t, within, lexer.DiagnosticExcerpt(within))
+
+		got := lexer.DiagnosticExcerpt(within + "a")
+		require.LessOrEqual(t, len(got), lexer.DiagnosticExcerptByteLimit)
+		require.True(t, utf8.ValidString(got))
+		require.Contains(t, got, "[truncated]")
+	})
+
+	t.Run("multibyte text ends on a rune boundary", func(t *testing.T) {
+		within := strings.Repeat("界", lexer.DiagnosticExcerptByteLimit/len("界"))
+		require.Equal(t, within, lexer.DiagnosticExcerpt(within))
+
+		got := lexer.DiagnosticExcerpt(within + "界")
+		require.LessOrEqual(t, len(got), lexer.DiagnosticExcerptByteLimit)
+		require.True(t, utf8.ValidString(got))
+		require.Contains(t, got, "[truncated]")
+	})
+
+	t.Run("invalid UTF-8 is replaced", func(t *testing.T) {
+		got := lexer.DiagnosticExcerpt(string([]byte{'a', 0xff, 'b'}))
+		require.Equal(t, "a\uFFFDb", got)
+		require.True(t, utf8.ValidString(got))
+	})
+}
+
+func TestTokenStringDiagnosticExcerpt(t *testing.T) {
+	t.Run("short quoted value is unchanged", func(t *testing.T) {
+		tok := lexer.Token{Type: lexer.TokenString, Value: "a\n\"b"}
+		require.Equal(t, `String("a\n\"b")`, tok.String())
+	})
+
+	t.Run("escaped value is bounded", func(t *testing.T) {
+		tok := lexer.Token{Type: lexer.TokenString, Value: strings.Repeat("\x00", 1<<20)}
+		got := tok.String()
+		require.LessOrEqual(t, len(got), 4*lexer.DiagnosticExcerptByteLimit+32)
+		require.True(t, utf8.ValidString(got))
+		require.Contains(t, got, "[truncated]")
+	})
+}

--- a/internal/xpath1/lexer/token.go
+++ b/internal/xpath1/lexer/token.go
@@ -94,7 +94,7 @@ type Token struct {
 
 func (t Token) String() string {
 	if t.Value != "" {
-		return fmt.Sprintf("%s(%q)", t.Type, t.Value)
+		return fmt.Sprintf("%s(%q)", t.Type, DiagnosticExcerpt(t.Value))
 	}
 	return t.Type.String()
 }

--- a/schematron/parse.go
+++ b/schematron/parse.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 )
 
 const (
@@ -168,7 +169,8 @@ func (sp *schemaParser) compileRule(compileCtx context.Context, elem *helium.Ele
 
 	compiled, err := sp.engine.compile(xpathExpr)
 	if err != nil {
-		sp.eh.Handle(compileCtx, helium.NewLeveledError(fmt.Sprintf("element rule: Failed to compile context expression '%s': %s\n", ctxExpr, err), helium.ErrorLevelFatal))
+		sp.eh.Handle(compileCtx, helium.NewLeveledError(fmt.Sprintf("element rule: Failed to compile context expression '%s': %s\n",
+			lexer.DiagnosticExcerpt(ctxExpr), err), helium.ErrorLevelFatal))
 		return nil
 	}
 
@@ -250,7 +252,8 @@ func (sp *schemaParser) compileTest(compileCtx context.Context, elem *helium.Ele
 
 	compiled, err := sp.engine.compile(testExpr)
 	if err != nil {
-		sp.eh.Handle(compileCtx, helium.NewLeveledError(fmt.Sprintf("element %s: Failed to compile test expression '%s': %s\n", testTypeName(typ), testExpr, err), helium.ErrorLevelFatal))
+		sp.eh.Handle(compileCtx, helium.NewLeveledError(fmt.Sprintf("element %s: Failed to compile test expression '%s': %s\n",
+			testTypeName(typ), lexer.DiagnosticExcerpt(testExpr), err), helium.ErrorLevelFatal))
 		return nil
 	}
 
@@ -300,7 +303,8 @@ func (sp *schemaParser) parseMessageElement(compileCtx context.Context, childEle
 		}
 		compiled, err := sp.engine.compile(path)
 		if err != nil {
-			sp.eh.Handle(compileCtx, helium.NewLeveledError(fmt.Sprintf("element name: Failed to compile path '%s': %s\n", path, err), helium.ErrorLevelFatal))
+			sp.eh.Handle(compileCtx, helium.NewLeveledError(fmt.Sprintf("element name: Failed to compile path '%s': %s\n",
+				lexer.DiagnosticExcerpt(path), err), helium.ErrorLevelFatal))
 			return append(parts, namePart{path: path})
 		}
 		return append(parts, namePart{path: path, expr: compiled})
@@ -315,7 +319,8 @@ func (sp *schemaParser) parseMessageElement(compileCtx context.Context, childEle
 			// Report the compile error through the handler (mirroring the
 			// <name path="..."> case and compileTest), then still add the
 			// part so the message structure is preserved.
-			sp.eh.Handle(compileCtx, helium.NewLeveledError(fmt.Sprintf("element value-of: Failed to compile select expression '%s': %s\n", sel, err), helium.ErrorLevelFatal))
+			sp.eh.Handle(compileCtx, helium.NewLeveledError(fmt.Sprintf("element value-of: Failed to compile select expression '%s': %s\n",
+				lexer.DiagnosticExcerpt(sel), err), helium.ErrorLevelFatal))
 			return append(parts, valueOfPart{sel: sel})
 		}
 		return append(parts, valueOfPart{sel: sel, expr: compiled})

--- a/schematron/parse_test.go
+++ b/schematron/parse_test.go
@@ -18,7 +18,7 @@ func TestCompileXPathDiagnosticExcerpt(t *testing.T) {
 		name        string
 		schema      func(string) string
 		shortNeedle string
-		maxAlloc    uint64
+		maxGrowth   uint64
 	}{
 		{
 			name: "rule context",
@@ -26,7 +26,7 @@ func TestCompileXPathDiagnosticExcerpt(t *testing.T) {
 				return prefix + `<rule context="` + expr + `"><assert test="true()">ok</assert></rule>` + suffix
 			},
 			shortNeedle: "Failed to compile context expression '1 foo'",
-			maxAlloc:    5 << 20,
+			maxGrowth:   3 << 20,
 		},
 		{
 			name: "assert test",
@@ -34,7 +34,7 @@ func TestCompileXPathDiagnosticExcerpt(t *testing.T) {
 				return prefix + `<rule context="/root"><assert test="` + expr + `">ok</assert></rule>` + suffix
 			},
 			shortNeedle: "Failed to compile test expression '1 foo'",
-			maxAlloc:    4 << 20,
+			maxGrowth:   5 << 19,
 		},
 		{
 			name: "name path",
@@ -42,7 +42,7 @@ func TestCompileXPathDiagnosticExcerpt(t *testing.T) {
 				return prefix + `<rule context="/root"><assert test="false()"><name path="` + expr + `"/></assert></rule>` + suffix
 			},
 			shortNeedle: "Failed to compile path '1 foo'",
-			maxAlloc:    4 << 20,
+			maxGrowth:   5 << 19,
 		},
 		{
 			name: "value-of select",
@@ -50,7 +50,7 @@ func TestCompileXPathDiagnosticExcerpt(t *testing.T) {
 				return prefix + `<rule context="/root"><assert test="false()"><value-of select="` + expr + `"/></assert></rule>` + suffix
 			},
 			shortNeedle: "Failed to compile select expression '1 foo'",
-			maxAlloc:    4 << 20,
+			maxGrowth:   5 << 19,
 		},
 	}
 
@@ -59,29 +59,48 @@ func TestCompileXPathDiagnosticExcerpt(t *testing.T) {
 			_, shortErrs := compileTestSchema(t, tc.schema("1 foo"))
 			require.Contains(t, shortErrs, tc.shortNeedle)
 
-			doc, err := helium.NewParser().Parse(t.Context(),
-				[]byte(tc.schema("1 "+strings.Repeat("界", (1<<20)/len("界")))))
-			require.NoError(t, err)
-			collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
-			compiler := schematron.NewCompiler().ErrorHandler(collector)
+			small := measureSchematronCompile(t, tc.schema("1 "+strings.Repeat("界", (1<<19)/len("界"))))
+			large := measureSchematronCompile(t, tc.schema("1 "+strings.Repeat("界", (1<<20)/len("界"))))
 
-			var compileErr error
-			allocated := schematronCompileAllocatedBytes(t, func() {
-				_, compileErr = compiler.Compile(t.Context(), doc)
-			})
-			require.NoError(t, collector.Close())
-			var diagnostic strings.Builder
-			for _, err := range collector.Errors() {
-				diagnostic.WriteString(err.Error())
-			}
-			message := diagnostic.String()
-
-			require.ErrorIs(t, compileErr, schematron.ErrCompileFailed)
-			require.LessOrEqual(t, len(message), 2048)
-			require.True(t, utf8.ValidString(message))
-			require.Contains(t, message, "[truncated]")
-			require.Less(t, allocated, tc.maxAlloc)
+			require.ErrorIs(t, small.compileErr, schematron.ErrCompileFailed)
+			require.ErrorIs(t, large.compileErr, schematron.ErrCompileFailed)
+			require.LessOrEqual(t, len(large.diagnostic), 2048)
+			require.True(t, utf8.ValidString(large.diagnostic))
+			require.Contains(t, large.diagnostic, "[truncated]")
+			// The differential removes fixed compiler and race-runtime allocations.
+			// Reintroducing the extra source-sized diagnostic string exceeds this bound.
+			require.GreaterOrEqual(t, large.allocated, small.allocated)
+			require.Less(t, large.allocated-small.allocated, tc.maxGrowth)
 		})
+	}
+}
+
+type schematronCompileMeasurement struct {
+	allocated  uint64
+	compileErr error
+	diagnostic string
+}
+
+func measureSchematronCompile(t *testing.T, schemaXML string) schematronCompileMeasurement {
+	t.Helper()
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	compiler := schematron.NewCompiler().ErrorHandler(collector)
+
+	var compileErr error
+	allocated := schematronCompileAllocatedBytes(t, func() {
+		_, compileErr = compiler.Compile(t.Context(), doc)
+	})
+	require.NoError(t, collector.Close())
+	var diagnostic strings.Builder
+	for _, err := range collector.Errors() {
+		diagnostic.WriteString(err.Error())
+	}
+	return schematronCompileMeasurement{
+		allocated:  allocated,
+		compileErr: compileErr,
+		diagnostic: diagnostic.String(),
 	}
 }
 

--- a/schematron/parse_test.go
+++ b/schematron/parse_test.go
@@ -1,0 +1,97 @@
+package schematron_test
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/schematron"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileXPathDiagnosticExcerpt(t *testing.T) {
+	const prefix = `<schema xmlns="http://purl.oclc.org/dsdl/schematron"><pattern>`
+	const suffix = `</pattern></schema>`
+	cases := []struct {
+		name        string
+		schema      func(string) string
+		shortNeedle string
+		maxAlloc    uint64
+	}{
+		{
+			name: "rule context",
+			schema: func(expr string) string {
+				return prefix + `<rule context="` + expr + `"><assert test="true()">ok</assert></rule>` + suffix
+			},
+			shortNeedle: "Failed to compile context expression '1 foo'",
+			maxAlloc:    5 << 20,
+		},
+		{
+			name: "assert test",
+			schema: func(expr string) string {
+				return prefix + `<rule context="/root"><assert test="` + expr + `">ok</assert></rule>` + suffix
+			},
+			shortNeedle: "Failed to compile test expression '1 foo'",
+			maxAlloc:    4 << 20,
+		},
+		{
+			name: "name path",
+			schema: func(expr string) string {
+				return prefix + `<rule context="/root"><assert test="false()"><name path="` + expr + `"/></assert></rule>` + suffix
+			},
+			shortNeedle: "Failed to compile path '1 foo'",
+			maxAlloc:    4 << 20,
+		},
+		{
+			name: "value-of select",
+			schema: func(expr string) string {
+				return prefix + `<rule context="/root"><assert test="false()"><value-of select="` + expr + `"/></assert></rule>` + suffix
+			},
+			shortNeedle: "Failed to compile select expression '1 foo'",
+			maxAlloc:    4 << 20,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, shortErrs := compileTestSchema(t, tc.schema("1 foo"))
+			require.Contains(t, shortErrs, tc.shortNeedle)
+
+			doc, err := helium.NewParser().Parse(t.Context(),
+				[]byte(tc.schema("1 "+strings.Repeat("界", (1<<20)/len("界")))))
+			require.NoError(t, err)
+			collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+			compiler := schematron.NewCompiler().ErrorHandler(collector)
+
+			var compileErr error
+			allocated := schematronCompileAllocatedBytes(t, func() {
+				_, compileErr = compiler.Compile(t.Context(), doc)
+			})
+			require.NoError(t, collector.Close())
+			var diagnostic strings.Builder
+			for _, err := range collector.Errors() {
+				diagnostic.WriteString(err.Error())
+			}
+			message := diagnostic.String()
+
+			require.ErrorIs(t, compileErr, schematron.ErrCompileFailed)
+			require.LessOrEqual(t, len(message), 2048)
+			require.True(t, utf8.ValidString(message))
+			require.Contains(t, message, "[truncated]")
+			require.Less(t, allocated, tc.maxAlloc)
+		})
+	}
+}
+
+func schematronCompileAllocatedBytes(t *testing.T, fn func()) uint64 {
+	t.Helper()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
+}

--- a/xmldsig1/errors.go
+++ b/xmldsig1/errors.go
@@ -3,6 +3,8 @@ package xmldsig1
 import (
 	"errors"
 	"fmt"
+
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 )
 
 var (
@@ -123,7 +125,8 @@ type ReferenceError struct {
 }
 
 func (e *ReferenceError) Error() string {
-	return fmt.Sprintf("xmldsig1: %s reference %d (%q) failed: %v", e.Op, e.Reference, e.URI, e.Err)
+	return fmt.Sprintf("xmldsig1: %s reference %d (%q) failed: %v",
+		e.Op, e.Reference, lexer.DiagnosticExcerpt(e.URI), e.Err)
 }
 
 func (e *ReferenceError) Unwrap() error {
@@ -145,7 +148,8 @@ func (e *VerificationError) Error() string {
 	if e.Reference < 0 {
 		return fmt.Sprintf("xmldsig1: signature value verification failed: %v", e.Err)
 	}
-	return fmt.Sprintf("xmldsig1: reference %d (%q) verification failed: %v", e.Reference, e.URI, e.Err)
+	return fmt.Sprintf("xmldsig1: reference %d (%q) verification failed: %v",
+		e.Reference, lexer.DiagnosticExcerpt(e.URI), e.Err)
 }
 
 func (e *VerificationError) Unwrap() error {

--- a/xmldsig1/sign.go
+++ b/xmldsig1/sign.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 )
 
 func signEnveloped(ctx context.Context, cfg *signerConfig, doc *helium.Document, parent *helium.Element, key any) error {
@@ -562,7 +563,8 @@ func signReferenceOctets(ctx context.Context, cfg *signerConfig, doc *helium.Doc
 	// An external reference is dereferenced only through a configured resolver.
 	if _, _, _, ok := referenceURIForm(ref.URI); !ok {
 		if cfg.referenceResolver == nil {
-			return nil, fmt.Errorf("%w: unsupported reference URI: %s", ErrReferenceNotFound, ref.URI)
+			return nil, fmt.Errorf("%w: unsupported reference URI: %s",
+				ErrReferenceNotFound, lexer.DiagnosticExcerpt(ref.URI))
 		}
 		steps := transformSteps(ref)
 		joined, err := joinReferenceURI(doc.URL(), ref.URI)

--- a/xmldsig1/sign_test.go
+++ b/xmldsig1/sign_test.go
@@ -3,7 +3,9 @@ package xmldsig1_test
 import (
 	"context"
 	"crypto/elliptic"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xmldsig1"
@@ -296,6 +298,27 @@ func TestSign(t *testing.T) {
 			})
 		_, err := signer.SignDetached(t.Context(), doc, key)
 		require.ErrorIs(t, err, xmldsig1.ErrReferenceNotFound)
+	})
+
+	t.Run("long XPointer URI diagnostic is bounded", func(t *testing.T) {
+		key := generateRSAKey(t)
+		doc := mustParseXML(t, samlAssertion)
+		uri := "#xpointer(id('" + strings.Repeat("a", 1<<20) + "'))"
+		signer := xmldsig1.NewSigner().
+			SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+			Reference(xmldsig1.ReferenceConfig{
+				URI:             uri,
+				DigestAlgorithm: xmldsig1.DigestSHA256,
+			})
+
+		_, err := signer.SignDetached(t.Context(), doc, key)
+		require.ErrorIs(t, err, xmldsig1.ErrReferenceNotFound)
+		require.LessOrEqual(t, len(err.Error()), 1024)
+		require.True(t, utf8.ValidString(err.Error()))
+		require.Contains(t, err.Error(), "[truncated]")
+		var refErr *xmldsig1.ReferenceError
+		require.ErrorAs(t, err, &refErr)
+		require.Equal(t, uri, refErr.URI)
 	})
 
 	// A per-reference signing failure must identify WHICH reference failed

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -1486,11 +1486,13 @@ func resolvePreparedGeneralXPointerTarget(ctx context.Context, doc *helium.Docum
 		matches := domutil.FindElementsByID(doc.DocumentElement(), prepared.id)
 		switch len(matches) {
 		case 0:
-			return nil, fmt.Errorf("%w: xpointer(id(%q))", ErrReferenceNotFound, prepared.id)
+			return nil, fmt.Errorf("%w: xpointer(id(%q))",
+				ErrReferenceNotFound, lexer.DiagnosticExcerpt(prepared.id))
 		case 1:
 			return matches[0], nil
 		default:
-			return nil, fmt.Errorf("%w: xpointer id %q matched %d elements", ErrAmbiguousReference, prepared.id, len(matches))
+			return nil, fmt.Errorf("%w: xpointer id %q matched %d elements",
+				ErrAmbiguousReference, lexer.DiagnosticExcerpt(prepared.id), len(matches))
 		}
 	}
 
@@ -1641,7 +1643,8 @@ func effectiveC14NMethod(method string, includeComments bool) string {
 func resolveReference(doc *helium.Document, uri string, extraRoots ...helium.Node) (*helium.Element, error) {
 	id, wholeDoc, _, ok := referenceURIForm(uri)
 	if !ok {
-		return nil, fmt.Errorf("%w: unsupported reference URI: %s", ErrReferenceNotFound, uri)
+		return nil, fmt.Errorf("%w: unsupported reference URI: %s",
+			ErrReferenceNotFound, lexer.DiagnosticExcerpt(uri))
 	}
 	if wholeDoc {
 		return doc.DocumentElement(), nil
@@ -1667,10 +1670,11 @@ func resolveReference(doc *helium.Document, uri string, extraRoots ...helium.Nod
 	}
 	switch len(matches) {
 	case 0:
-		return nil, fmt.Errorf("%w: %s", ErrReferenceNotFound, uri)
+		return nil, fmt.Errorf("%w: %s", ErrReferenceNotFound, lexer.DiagnosticExcerpt(uri))
 	case 1:
 		return matches[0], nil
 	default:
-		return nil, fmt.Errorf("%w: %s (matched %d elements)", ErrAmbiguousReference, uri, len(matches))
+		return nil, fmt.Errorf("%w: %s (matched %d elements)",
+			ErrAmbiguousReference, lexer.DiagnosticExcerpt(uri), len(matches))
 	}
 }

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lestrrat-go/helium/internal/domutil"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 	"github.com/lestrrat-go/helium/xpath1"
 
 	helium "github.com/lestrrat-go/helium"
@@ -1426,11 +1427,13 @@ func singleElementApex(nodes []helium.Node) (*helium.Element, error) {
 // context, the shared operation limit, and here() disabled (nil bearing node).
 func prepareGeneralXPointer(doc *helium.Document, overrides map[string]string, expr string) (*preparedGeneralXPointer, error) {
 	if containsNonXMLSWhitespaceOutsideLiteral(expr) {
-		return nil, fmt.Errorf("%w: invalid XPointer expression %q", ErrReferenceNotFound, expr)
+		return nil, fmt.Errorf("%w: invalid XPointer expression %q",
+			ErrReferenceNotFound, lexer.DiagnosticExcerpt(expr))
 	}
 	if id, isIDCall, ok := parseXPointerIDSelector(expr); isIDCall {
 		if !ok {
-			return nil, fmt.Errorf("%w: unsupported XPointer id() selector %q", ErrReferenceNotFound, expr)
+			return nil, fmt.Errorf("%w: unsupported XPointer id() selector %q",
+				ErrReferenceNotFound, lexer.DiagnosticExcerpt(expr))
 		}
 		return &preparedGeneralXPointer{id: id, idSelector: true}, nil
 	}
@@ -1438,16 +1441,19 @@ func prepareGeneralXPointer(doc *helium.Document, overrides map[string]string, e
 		// id() appears somewhere other than as the whole-expression selector
 		// handled above (a wrapping paren, a predicate, a path step). xpath1's
 		// built-in id() cannot be trusted under duplicate ids, so fail closed.
-		return nil, fmt.Errorf("%w: unsupported XPointer id() use %q", ErrReferenceNotFound, expr)
+		return nil, fmt.Errorf("%w: unsupported XPointer id() use %q",
+			ErrReferenceNotFound, lexer.DiagnosticExcerpt(expr))
 	}
 
 	compiled, err := xpath1.Compile(expr)
 	if err != nil {
-		return nil, fmt.Errorf("%w: invalid XPointer expression %q: %v", ErrReferenceNotFound, expr, err)
+		return nil, fmt.Errorf("%w: invalid XPointer expression %q: %v",
+			ErrReferenceNotFound, lexer.DiagnosticExcerpt(expr), err)
 	}
 	eval := newDSigXPathEvaluator(xpointerNamespaces(doc, overrides), nil, defaultXPathOpLimit)
 	if err := eval.Validate(compiled); err != nil {
-		return nil, fmt.Errorf("%w: invalid XPointer expression %q: %v", ErrReferenceNotFound, expr, err)
+		return nil, fmt.Errorf("%w: invalid XPointer expression %q: %v",
+			ErrReferenceNotFound, lexer.DiagnosticExcerpt(expr), err)
 	}
 	return &preparedGeneralXPointer{compiled: compiled, eval: eval}, nil
 }

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -10,6 +10,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/domutil"
 	"github.com/lestrrat-go/helium/internal/xmlbase64"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 )
 
 // isNilInterface reports whether v is effectively nil. A plain `v == nil` only
@@ -474,7 +475,8 @@ func canonicalizeGeneralXPointer(ctx context.Context, cfg *verifierConfig, doc *
 // Reference's transform pipeline (see externalReferenceDigestInput).
 func resolveExternalReference(ctx context.Context, cfg *verifierConfig, doc *helium.Document, ref parsedReference) ([]byte, error) {
 	if cfg.referenceResolver == nil {
-		return nil, fmt.Errorf("%w: unsupported reference URI: %s", ErrReferenceNotFound, ref.uri)
+		return nil, fmt.Errorf("%w: unsupported reference URI: %s",
+			ErrReferenceNotFound, lexer.DiagnosticExcerpt(ref.uri))
 	}
 
 	prepared := ref.prepared

--- a/xmldsig1/xpath_features_internal_test.go
+++ b/xmldsig1/xpath_features_internal_test.go
@@ -545,6 +545,56 @@ func TestGeneralXPointerDiagnosticExcerpt(t *testing.T) {
 		require.Contains(t, err.Error(), "[truncated]")
 		require.Less(t, allocated, uint64(1<<20))
 	})
+
+	t.Run("long missing id is bounded", func(t *testing.T) {
+		id := strings.Repeat("a", 1<<20)
+		ref := parsedReference{uri: "#xpointer(id ('" + id + "'))"}
+		_, _, _, err := canonicalizeReference(t.Context(), cfg, doc, nil, ref)
+
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+		require.LessOrEqual(t, len(err.Error()), 1024)
+		require.True(t, utf8.ValidString(err.Error()))
+		require.Contains(t, err.Error(), "[truncated]")
+	})
+
+	t.Run("long duplicate id is bounded", func(t *testing.T) {
+		id := strings.Repeat("a", 1<<20)
+		duplicateDoc := mustParse(t, `<root><a/><b/></root>`)
+		require.NoError(t, findLocal(duplicateDoc.DocumentElement(), "a").SetAttribute("Id", id))
+		require.NoError(t, findLocal(duplicateDoc.DocumentElement(), "b").SetAttribute("Id", id))
+		ref := parsedReference{uri: "#xpointer(id ('" + id + "'))"}
+		_, _, _, err := canonicalizeReference(t.Context(), cfg, duplicateDoc, nil, ref)
+
+		require.ErrorIs(t, err, ErrAmbiguousReference)
+		require.LessOrEqual(t, len(err.Error()), 1024)
+		require.True(t, utf8.ValidString(err.Error()))
+		require.Contains(t, err.Error(), "[truncated]")
+	})
+
+	t.Run("public Verify bounds the URI wrapper", func(t *testing.T) {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		uri := "#xpointer(1 " + strings.Repeat("a", 1<<20) + ")"
+		verifyDoc := mustParse(t, `<root><ds:Signature xmlns:ds="`+NamespaceDSig+`">`+
+			`<ds:SignedInfo>`+
+			`<ds:CanonicalizationMethod Algorithm="`+ExcC14N10+`"/>`+
+			`<ds:SignatureMethod Algorithm="`+AlgRSASHA256+`"/>`+
+			`<ds:Reference URI="`+uri+`">`+
+			`<ds:DigestMethod Algorithm="`+DigestSHA256+`"/>`+
+			`<ds:DigestValue>AA==</ds:DigestValue>`+
+			`</ds:Reference></ds:SignedInfo>`+
+			`<ds:SignatureValue>AA==</ds:SignatureValue>`+
+			`</ds:Signature></root>`)
+
+		_, err = NewVerifier(StaticKey(&key.PublicKey)).AllowXPointer(true).Verify(t.Context(), verifyDoc)
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+		require.LessOrEqual(t, len(err.Error()), 1024)
+		require.True(t, utf8.ValidString(err.Error()))
+		require.Contains(t, err.Error(), "[truncated]")
+		var verifyErr *VerificationError
+		require.ErrorAs(t, err, &verifyErr)
+		require.Equal(t, uri, verifyErr.URI)
+	})
 }
 
 func generalXPointerAllocatedBytes(t *testing.T, fn func()) uint64 {

--- a/xmldsig1/xpath_features_internal_test.go
+++ b/xmldsig1/xpath_features_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xpath1"
@@ -516,6 +517,45 @@ func TestGeneralXPointerEvaluationErrorIdentity(t *testing.T) {
 		require.ErrorIs(t, err, ErrReferenceNotFound)
 		require.ErrorIs(t, err, xpath1.ErrNotNodeSet)
 	})
+}
+
+func TestGeneralXPointerDiagnosticExcerpt(t *testing.T) {
+	doc := mustParse(t, `<root/>`)
+	cfg := &verifierConfig{allowXPointer: true}
+
+	t.Run("short wording is unchanged", func(t *testing.T) {
+		ref := parsedReference{uri: "#xpointer(1 foo)"}
+		_, _, _, err := canonicalizeReference(t.Context(), cfg, doc, nil, ref)
+		require.EqualError(t, err,
+			`xmldsig1: reference URI not resolved: invalid XPointer expression "1 foo": `+
+				`xpath: unexpected token: Name("foo") after expression`)
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+	})
+
+	t.Run("long multibyte expression is bounded", func(t *testing.T) {
+		ref := parsedReference{uri: "#xpointer(1 " + strings.Repeat("界", 1<<19) + ")"}
+		var err error
+		allocated := generalXPointerAllocatedBytes(t, func() {
+			_, _, _, err = canonicalizeReference(t.Context(), cfg, doc, nil, ref)
+		})
+
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+		require.LessOrEqual(t, len(err.Error()), 1024)
+		require.True(t, utf8.ValidString(err.Error()))
+		require.Contains(t, err.Error(), "[truncated]")
+		require.Less(t, allocated, uint64(1<<20))
+	})
+}
+
+func generalXPointerAllocatedBytes(t *testing.T, fn func()) uint64 {
+	t.Helper()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
 }
 
 func TestGeneralXPointerValidatesBeforeXSLT(t *testing.T) {

--- a/xpath1/diagnostic_test.go
+++ b/xpath1/diagnostic_test.go
@@ -1,0 +1,90 @@
+package xpath1_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/lestrrat-go/helium/xpath1"
+	"github.com/stretchr/testify/require"
+)
+
+const maxXPathDiagnosticBytes = 768
+
+func TestCompileDiagnosticExcerpt(t *testing.T) {
+	t.Run("short diagnostic is unchanged", func(t *testing.T) {
+		_, err := xpath1.NewCompiler().Compile("1 foo")
+		require.EqualError(t, err, `xpath: unexpected token: Name("foo") after expression`)
+		require.ErrorIs(t, err, xpath1.ErrUnexpectedToken)
+	})
+
+	for _, tc := range []struct {
+		name  string
+		token string
+	}{
+		{name: "ASCII", token: strings.Repeat("a", 1<<20)},
+		{name: "multibyte UTF-8", token: strings.Repeat("界", 1<<18)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := xpath1.NewCompiler().Compile("1 " + tc.token)
+			require.ErrorIs(t, err, xpath1.ErrUnexpectedToken)
+			requireBoundedXPathDiagnostic(t, err)
+		})
+	}
+}
+
+func TestValidateDiagnosticExcerpt(t *testing.T) {
+	t.Run("short diagnostic is unchanged", func(t *testing.T) {
+		expr := xpath1.MustCompile("missing:node")
+		err := xpath1.NewEvaluator().Validate(expr)
+		require.EqualError(t, err, "xpath: unknown namespace prefix: missing")
+		require.ErrorIs(t, err, xpath1.ErrUnknownNamespacePrefix)
+	})
+
+	t.Run("long prefix", func(t *testing.T) {
+		prefix := strings.Repeat("界", 1<<18)
+		expr := xpath1.MustCompile(prefix + ":node")
+		err := xpath1.NewEvaluator().Validate(expr)
+		require.ErrorIs(t, err, xpath1.ErrUnknownNamespacePrefix)
+		requireBoundedXPathDiagnostic(t, err)
+	})
+
+	t.Run("long namespace URI", func(t *testing.T) {
+		expr := xpath1.MustCompile("p:missing()")
+		err := xpath1.NewEvaluator().
+			Namespaces(map[string]string{"p": strings.Repeat("urn:x:", 1<<18)}).
+			Validate(expr)
+		require.ErrorIs(t, err, xpath1.ErrUnknownFunction)
+		requireBoundedXPathDiagnostic(t, err)
+	})
+}
+
+func TestEvaluateDiagnosticExcerpt(t *testing.T) {
+	name := strings.Repeat("a", 1<<20)
+	expr := xpath1.MustCompile(name + "()")
+	_, err := xpath1.NewEvaluator().Evaluate(t.Context(), expr, nil)
+	require.ErrorIs(t, err, xpath1.ErrUnknownFunction)
+	requireBoundedXPathDiagnostic(t, err)
+}
+
+func TestMustCompileDiagnosticExcerpt(t *testing.T) {
+	defer func() {
+		value := recover()
+		require.NotNil(t, value)
+		message := fmt.Sprint(value)
+		require.LessOrEqual(t, len(message), maxXPathDiagnosticBytes)
+		require.True(t, utf8.ValidString(message))
+		require.Contains(t, message, "[truncated]")
+	}()
+
+	xpath1.MustCompile("1 " + strings.Repeat("a", 1<<20))
+}
+
+func requireBoundedXPathDiagnostic(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	require.LessOrEqual(t, len(err.Error()), maxXPathDiagnosticBytes)
+	require.True(t, utf8.ValidString(err.Error()))
+	require.Contains(t, err.Error(), "[truncated]")
+}

--- a/xpath1/diagnostic_test.go
+++ b/xpath1/diagnostic_test.go
@@ -2,6 +2,7 @@ package xpath1_test
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -11,6 +12,7 @@ import (
 )
 
 const maxXPathDiagnosticBytes = 768
+const maxXPathDiagnosticAllocBytes = 1 << 20
 
 func TestCompileDiagnosticExcerpt(t *testing.T) {
 	t.Run("short diagnostic is unchanged", func(t *testing.T) {
@@ -32,6 +34,33 @@ func TestCompileDiagnosticExcerpt(t *testing.T) {
 			requireBoundedXPathDiagnostic(t, err)
 		})
 	}
+}
+
+func TestCompileDiagnosticAllocation(t *testing.T) {
+	t.Run("invalid string token", func(t *testing.T) {
+		payload := strings.Repeat("\xffa", 2<<20)
+		input := "1 '" + payload + "'"
+		var err error
+		allocated := allocatedBytes(t, func() {
+			_, err = xpath1.NewCompiler().Compile(input)
+		})
+		require.ErrorIs(t, err, xpath1.ErrUnexpectedToken)
+		requireBoundedXPathDiagnostic(t, err)
+		require.Less(t, allocated, uint64(maxXPathDiagnosticAllocBytes))
+	})
+
+	t.Run("QName function", func(t *testing.T) {
+		prefix := strings.Repeat("p", 4<<20)
+		name := strings.Repeat("n", 4<<20)
+		input := prefix + ":" + name + "(1"
+		var err error
+		allocated := allocatedBytes(t, func() {
+			_, err = xpath1.NewCompiler().Compile(input)
+		})
+		require.ErrorIs(t, err, xpath1.ErrExpectedToken)
+		requireBoundedXPathDiagnostic(t, err)
+		require.Less(t, allocated, uint64(maxXPathDiagnosticAllocBytes))
+	})
 }
 
 func TestValidateDiagnosticExcerpt(t *testing.T) {
@@ -87,4 +116,15 @@ func requireBoundedXPathDiagnostic(t *testing.T, err error) {
 	require.LessOrEqual(t, len(err.Error()), maxXPathDiagnosticBytes)
 	require.True(t, utf8.ValidString(err.Error()))
 	require.Contains(t, err.Error(), "[truncated]")
+}
+
+func allocatedBytes(t *testing.T, fn func()) uint64 {
+	t.Helper()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
 }

--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -10,6 +10,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	ixpath "github.com/lestrrat-go/helium/internal/xpath"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 	"github.com/lestrrat-go/helium/internal/xpath1/number"
 )
 
@@ -743,11 +744,11 @@ func evalUnaryExpr(ctx context.Context, ec *evalContext, e UnaryExpr) (*Result, 
 
 func evalVariableExpr(ec *evalContext, e VariableExpr) (*Result, error) {
 	if ec.variables == nil {
-		return nil, fmt.Errorf("%w: $%s", ErrUndefinedVariable, e.Name)
+		return nil, fmt.Errorf("%w: $%s", ErrUndefinedVariable, lexer.DiagnosticExcerpt(e.Name))
 	}
 	v, ok := ec.variables[e.Name]
 	if !ok {
-		return nil, fmt.Errorf("%w: $%s", ErrUndefinedVariable, e.Name)
+		return nil, fmt.Errorf("%w: $%s", ErrUndefinedVariable, lexer.DiagnosticExcerpt(e.Name))
 	}
 	switch val := v.(type) {
 	case []helium.Node:
@@ -773,7 +774,8 @@ func evalVariableExpr(ec *evalContext, e VariableExpr) (*Result, error) {
 	case bool:
 		return &Result{Type: BooleanResult, Bool: val}, nil
 	default:
-		return nil, fmt.Errorf("%w: $%s is %T", ErrUnsupportedVariableType, e.Name, v)
+		return nil, fmt.Errorf("%w: $%s is %T", ErrUnsupportedVariableType,
+			lexer.DiagnosticExcerpt(e.Name), v)
 	}
 }
 

--- a/xpath1/functions.go
+++ b/xpath1/functions.go
@@ -9,6 +9,7 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/domutil"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 )
 
 // sentinel errors for XPath built-in function argument validation.
@@ -115,7 +116,7 @@ func evalFunctionCall(ctx context.Context, ec *evalContext, fc FunctionCall) (*R
 		fn = ec.functions[fc.Name]
 	}
 	if fn == nil {
-		return nil, fmt.Errorf("%w: %s", ErrUnknownFunction, fc.Name)
+		return nil, fmt.Errorf("%w: %s", ErrUnknownFunction, lexer.DiagnosticExcerpt(fc.Name))
 	}
 
 	return callResolvedFn(ctx, ec, fn, fc.Args)
@@ -143,18 +144,19 @@ func callResolvedFn(ctx context.Context, ec *evalContext, fn Function, exprs []E
 
 func evalNamespacedFunctionCall(ctx context.Context, ec *evalContext, fc FunctionCall) (*Result, error) {
 	if ec.namespaces == nil {
-		return nil, fmt.Errorf("%w: %s", ErrUnknownFunctionNamespace, fc.Prefix)
+		return nil, fmt.Errorf("%w: %s", ErrUnknownFunctionNamespace, lexer.DiagnosticExcerpt(fc.Prefix))
 	}
 	uri, ok := ec.namespaces[fc.Prefix]
 	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrUnknownFunctionNamespace, fc.Prefix)
+		return nil, fmt.Errorf("%w: %s", ErrUnknownFunctionNamespace, lexer.DiagnosticExcerpt(fc.Prefix))
 	}
 	var fn Function
 	if ec.functionsNS != nil {
 		fn = ec.functionsNS[QualifiedName{URI: uri, Name: fc.Name}]
 	}
 	if fn == nil {
-		return nil, fmt.Errorf("%w: {%s}%s", ErrUnknownFunction, uri, fc.Name)
+		return nil, fmt.Errorf("%w: {%s}%s", ErrUnknownFunction,
+			lexer.DiagnosticExcerpt(uri), lexer.DiagnosticExcerpt(fc.Name))
 	}
 
 	return callResolvedFn(ctx, ec, fn, fc.Args)

--- a/xpath1/parser.go
+++ b/xpath1/parser.go
@@ -371,11 +371,12 @@ func (p *parser) parseFunctionCall(prefix, name string) (Expr, error) {
 		}
 	}
 	if p.lexer.Peek().Type != TokenRParen {
+		name = lexer.DiagnosticExcerpt(name)
 		displayName := name
 		if prefix != "" {
-			displayName = prefix + ":" + name
+			prefix = lexer.DiagnosticExcerpt(prefix)
+			displayName = lexer.DiagnosticExcerpt(prefix + ":" + name)
 		}
-		displayName = lexer.DiagnosticExcerpt(displayName)
 		return nil, fmt.Errorf("%w: ')' in function call %s but got %s", ErrExpectedToken, displayName, p.lexer.Peek())
 	}
 	p.lexer.Next()

--- a/xpath1/parser.go
+++ b/xpath1/parser.go
@@ -341,7 +341,13 @@ func (p *parser) parseParenExpr() (Expr, error) {
 func parseNumberLiteral(s string) (NumberExpr, error) {
 	v, err := strconv.ParseFloat(s, 64)
 	if err != nil && !errors.Is(err, strconv.ErrRange) {
-		return NumberExpr{}, fmt.Errorf("invalid number %q: %w", s, err)
+		var numErr *strconv.NumError
+		if errors.As(err, &numErr) {
+			safeErr := *numErr
+			safeErr.Num = lexer.DiagnosticExcerpt(safeErr.Num)
+			err = &safeErr
+		}
+		return NumberExpr{}, fmt.Errorf("invalid number %q: %w", lexer.DiagnosticExcerpt(s), err)
 	}
 	return NumberExpr{Value: v}, nil
 }
@@ -369,6 +375,7 @@ func (p *parser) parseFunctionCall(prefix, name string) (Expr, error) {
 		if prefix != "" {
 			displayName = prefix + ":" + name
 		}
+		displayName = lexer.DiagnosticExcerpt(displayName)
 		return nil, fmt.Errorf("%w: ')' in function call %s but got %s", ErrExpectedToken, displayName, p.lexer.Peek())
 	}
 	p.lexer.Next()
@@ -495,7 +502,7 @@ func (p *parser) parseStep() (Step, error) {
 				axis = a
 				p.lexer.Next() // consume '::'
 			} else {
-				return Step{}, fmt.Errorf("%w: %q", ErrUnknownAxis, tok.Value)
+				return Step{}, fmt.Errorf("%w: %q", ErrUnknownAxis, lexer.DiagnosticExcerpt(tok.Value))
 			}
 		} else {
 			p.lexer.Backup() // not an axis, put name back
@@ -609,7 +616,7 @@ func (p *parser) parseQNameTest(prefix string) (NodeTest, error) {
 		p.lexer.Next()
 		return NameTest{Prefix: prefix, Local: next.Value}, nil
 	}
-	return nil, fmt.Errorf("%w: name or '*' after '%s:'", ErrExpectedToken, prefix)
+	return nil, fmt.Errorf("%w: name or '*' after '%s:'", ErrExpectedToken, lexer.DiagnosticExcerpt(prefix))
 }
 
 // parsePredicate parses → '[' Expr ']'.

--- a/xpath1/static_check.go
+++ b/xpath1/static_check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 )
 
 func validateStaticExpr(expr Expr, cfg *evalConfig, depth int) error {
@@ -30,7 +31,7 @@ func validateStaticExpr(expr Expr, cfg *evalConfig, depth int) error {
 				return nil
 			}
 		}
-		return fmt.Errorf("%w: $%s", ErrUndefinedVariable, e.Name)
+		return fmt.Errorf("%w: $%s", ErrUndefinedVariable, lexer.DiagnosticExcerpt(e.Name))
 	case FunctionCall:
 		if err := validateStaticFunction(e, cfg); err != nil {
 			return err
@@ -68,7 +69,7 @@ func validateStaticLocationPath(path *LocationPath, cfg *evalConfig, depth int) 
 	for _, step := range path.Steps {
 		if test, ok := step.NodeTest.(NameTest); ok && test.Prefix != "" {
 			if !staticNameTestPrefixDefined(test.Prefix, cfg) {
-				return fmt.Errorf("%w: %s", ErrUnknownNamespacePrefix, test.Prefix)
+				return fmt.Errorf("%w: %s", ErrUnknownNamespacePrefix, lexer.DiagnosticExcerpt(test.Prefix))
 			}
 		}
 		if err := validateStaticPredicates(step.Predicates, cfg, depth); err != nil {
@@ -104,18 +105,19 @@ func validateStaticFunction(call FunctionCall, cfg *evalConfig) error {
 		if cfg != nil && cfg.functions != nil && cfg.functions[call.Name] != nil {
 			return nil
 		}
-		return fmt.Errorf("%w: %s", ErrUnknownFunction, call.Name)
+		return fmt.Errorf("%w: %s", ErrUnknownFunction, lexer.DiagnosticExcerpt(call.Name))
 	}
 
 	if cfg == nil || cfg.namespaces == nil {
-		return fmt.Errorf("%w: %s", ErrUnknownFunctionNamespace, call.Prefix)
+		return fmt.Errorf("%w: %s", ErrUnknownFunctionNamespace, lexer.DiagnosticExcerpt(call.Prefix))
 	}
 	uri, ok := cfg.namespaces[call.Prefix]
 	if !ok {
-		return fmt.Errorf("%w: %s", ErrUnknownFunctionNamespace, call.Prefix)
+		return fmt.Errorf("%w: %s", ErrUnknownFunctionNamespace, lexer.DiagnosticExcerpt(call.Prefix))
 	}
 	if cfg.functionsNS != nil && cfg.functionsNS[QualifiedName{URI: uri, Name: call.Name}] != nil {
 		return nil
 	}
-	return fmt.Errorf("%w: {%s}%s", ErrUnknownFunction, uri, call.Name)
+	return fmt.Errorf("%w: {%s}%s", ErrUnknownFunction,
+		lexer.DiagnosticExcerpt(uri), lexer.DiagnosticExcerpt(call.Name))
 }

--- a/xpath1/xpath.go
+++ b/xpath1/xpath.go
@@ -337,7 +337,7 @@ func (Compiler) Compile(expr string) (*Expression, error) {
 func (c Compiler) MustCompile(expr string) *Expression {
 	e, err := c.Compile(expr)
 	if err != nil {
-		panic("xpath: Compile(" + expr + "): " + err.Error())
+		panic("xpath: Compile(" + lexer.DiagnosticExcerpt(expr) + "): " + err.Error())
 	}
 	return e
 }

--- a/xpointer/xpointer.go
+++ b/xpointer/xpointer.go
@@ -74,7 +74,7 @@ func Compile(expr string) (*Expression, error) {
 		case "xmlns":
 			prefix, _, ok := parseXmlnsBody(p.body)
 			if !ok {
-				return nil, fmt.Errorf("xpointer: invalid xmlns() body %q", p.body)
+				return nil, fmt.Errorf("xpointer: invalid xmlns() body %q", lexer.DiagnosticExcerpt(p.body))
 			}
 			if err := validateXmlnsPrefix(prefix); err != nil {
 				return nil, err
@@ -171,7 +171,8 @@ func (e *Expression) evaluatePart(ctx context.Context, doc *helium.Document, p x
 		// UTF-8) as syntax errors, resolving silently to no node,
 		// which would let XInclude unlink the include node.
 		if !xmlchar.IsValidNCName(p.body) {
-			return nil, fmt.Errorf("xpointer: invalid shorthand pointer %q (not an NCName)", p.body)
+			return nil, fmt.Errorf("xpointer: invalid shorthand pointer %q (not an NCName)",
+				lexer.DiagnosticExcerpt(p.body))
 		}
 		elem := doc.GetElementByID(p.body)
 		if elem == nil {
@@ -179,7 +180,7 @@ func (e *Expression) evaluatePart(ctx context.Context, doc *helium.Document, p x
 		}
 		return []helium.Node{elem}, nil
 	default:
-		return nil, fmt.Errorf("%w: %s", errUnknownScheme, p.scheme)
+		return nil, fmt.Errorf("%w: %s", errUnknownScheme, lexer.DiagnosticExcerpt(p.scheme))
 	}
 }
 
@@ -223,7 +224,7 @@ func Evaluate(ctx context.Context, doc *helium.Document, expr string) ([]helium.
 // during evaluation (see isXmlnsNoOp).
 func validateXmlnsPrefix(prefix string) error {
 	if !xmlchar.IsValidNCName(prefix) {
-		return fmt.Errorf("xpointer: invalid xmlns() prefix %q (not an NCName)", prefix)
+		return fmt.Errorf("xpointer: invalid xmlns() prefix %q (not an NCName)", lexer.DiagnosticExcerpt(prefix))
 	}
 	return nil
 }
@@ -326,7 +327,8 @@ func parseParts(expr string) ([]xptrPart, error) {
 		// scheme (e.g. "foo(...)") is still a valid QName and continues to
 		// cascade as an unknown scheme during evaluation.
 		if scheme != "" && !xmlchar.IsValidQName(scheme) {
-			return nil, fmt.Errorf("xpointer: invalid scheme name %q (not a QName)", scheme)
+			return nil, fmt.Errorf("xpointer: invalid scheme name %q (not a QName)",
+				lexer.DiagnosticExcerpt(scheme))
 		}
 
 		// A non-scheme trailing token is only valid as the entire pointer on
@@ -344,7 +346,8 @@ func parseParts(expr string) ([]xptrPart, error) {
 			if body == ")" {
 				break
 			}
-			return nil, fmt.Errorf("xpointer: trailing non-scheme text %q is not allowed after scheme-based parts", body)
+			return nil, fmt.Errorf("xpointer: trailing non-scheme text %q is not allowed after scheme-based parts",
+				lexer.DiagnosticExcerpt(body))
 		}
 
 		parts = append(parts, xptrPart{scheme: scheme, body: body})
@@ -397,7 +400,7 @@ func parseScheme(expr string) (scheme, body, remaining string, err error) {
 		}
 	}
 
-	return "", "", "", fmt.Errorf("xpointer: unbalanced parentheses in %q", expr)
+	return "", "", "", fmt.Errorf("xpointer: unbalanced parentheses in %q", lexer.DiagnosticExcerpt(expr))
 }
 
 // evaluateElement handles the element() scheme.
@@ -422,7 +425,8 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 	// zero). An empty segment anywhere else is a trailing/doubled slash and is a
 	// syntax error.
 	if parts[0] != "" && !xmlchar.IsValidNCName(parts[0]) {
-		return nil, fmt.Errorf("xpointer: invalid element() id %q (not an NCName)", parts[0])
+		return nil, fmt.Errorf("xpointer: invalid element() id %q (not an NCName)",
+			lexer.DiagnosticExcerpt(parts[0]))
 	}
 	childIndexes := make([]int, 0, len(parts)-1)
 	for _, part := range parts[1:] {
@@ -430,7 +434,8 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 			return nil, fmt.Errorf("xpointer: empty child-sequence segment in element() scheme (trailing or doubled %q)", "/")
 		}
 		if !isChildIndex(part) {
-			return nil, fmt.Errorf("xpointer: invalid child index %q in element() scheme (must match [1-9][0-9]*)", part)
+			return nil, fmt.Errorf("xpointer: invalid child index %q in element() scheme (must match [1-9][0-9]*)",
+				lexer.DiagnosticExcerpt(part))
 		}
 		idx, err := childIndexValue(part)
 		if err != nil {
@@ -491,7 +496,8 @@ func isChildIndex(s string) bool {
 func childIndexValue(s string) (int, error) {
 	idx, err := strconv.Atoi(s)
 	if err != nil {
-		return 0, fmt.Errorf("xpointer: child index %q in element() scheme is out of range", s)
+		return 0, fmt.Errorf("xpointer: child index %q in element() scheme is out of range",
+			lexer.DiagnosticExcerpt(s))
 	}
 	return idx, nil
 }

--- a/xpointer/xpointer.go
+++ b/xpointer/xpointer.go
@@ -11,6 +11,7 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 	"github.com/lestrrat-go/helium/xpath1"
 )
 
@@ -66,7 +67,8 @@ func Compile(expr string) (*Expression, error) {
 		case "xpointer", "xpath1":
 			c, cerr := xpath1.Compile(p.body)
 			if cerr != nil {
-				return nil, fmt.Errorf("xpointer: XPath compilation failed in %s(%s): %w", p.scheme, p.body, cerr)
+				return nil, fmt.Errorf("xpointer: XPath compilation failed in %s(%s): %w",
+					p.scheme, lexer.DiagnosticExcerpt(p.body), cerr)
 			}
 			compiled[i] = c
 		case "xmlns":

--- a/xpointer/xpointer_test.go
+++ b/xpointer/xpointer_test.go
@@ -67,6 +67,11 @@ func TestCompileDiagnosticExcerpt(t *testing.T) {
 		require.ErrorIs(t, err, xpath1.ErrUnexpectedToken)
 	})
 
+	t.Run("short unbalanced wording is unchanged", func(t *testing.T) {
+		_, err := xpointer.Compile("xpath1(/root")
+		require.EqualError(t, err, `xpointer: unbalanced parentheses in "xpath1(/root"`)
+	})
+
 	t.Run("long multibyte body is bounded", func(t *testing.T) {
 		body := "1 " + strings.Repeat("界", 1<<19)
 		input := "xpath1(" + body + ")"
@@ -81,6 +86,23 @@ func TestCompileDiagnosticExcerpt(t *testing.T) {
 		require.Contains(t, err.Error(), "[truncated]")
 		require.Less(t, allocated, uint64(1<<20))
 	})
+
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "long unbalanced ASCII body is bounded", body: strings.Repeat("a", 1<<20)},
+		{name: "long unbalanced multibyte body is bounded", body: strings.Repeat("界", 1<<19)},
+		{name: "long unbalanced invalid UTF-8 body is bounded", body: strings.Repeat("\xff", 1<<20)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := xpointer.Compile("xpath1(" + test.body)
+			require.Error(t, err)
+			require.LessOrEqual(t, len(err.Error()), 1024)
+			require.True(t, utf8.ValidString(err.Error()))
+			require.Contains(t, err.Error(), "[truncated]")
+		})
+	}
 }
 
 func xpointerCompileAllocatedBytes(t *testing.T, fn func()) uint64 {

--- a/xpointer/xpointer_test.go
+++ b/xpointer/xpointer_test.go
@@ -1,9 +1,13 @@
 package xpointer_test
 
 import (
+	"runtime"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath1"
 	"github.com/lestrrat-go/helium/xpointer"
 	"github.com/stretchr/testify/require"
 )
@@ -53,6 +57,41 @@ func TestCompile_ReportsXPathSyntaxErrorEarly(t *testing.T) {
 	t.Parallel()
 	_, err := xpointer.Compile("xpath1(///)")
 	require.Error(t, err, "compile should reject malformed xpath1 body")
+}
+
+func TestCompileDiagnosticExcerpt(t *testing.T) {
+	t.Run("short wording is unchanged", func(t *testing.T) {
+		_, err := xpointer.Compile("xpath1(1 foo)")
+		require.EqualError(t, err,
+			`xpointer: XPath compilation failed in xpath1(1 foo): xpath: unexpected token: Name("foo") after expression`)
+		require.ErrorIs(t, err, xpath1.ErrUnexpectedToken)
+	})
+
+	t.Run("long multibyte body is bounded", func(t *testing.T) {
+		body := "1 " + strings.Repeat("界", 1<<19)
+		input := "xpath1(" + body + ")"
+		var err error
+		allocated := xpointerCompileAllocatedBytes(t, func() {
+			_, err = xpointer.Compile(input)
+		})
+
+		require.ErrorIs(t, err, xpath1.ErrUnexpectedToken)
+		require.LessOrEqual(t, len(err.Error()), 1024)
+		require.True(t, utf8.ValidString(err.Error()))
+		require.Contains(t, err.Error(), "[truncated]")
+		require.Less(t, allocated, uint64(1<<20))
+	})
+}
+
+func xpointerCompileAllocatedBytes(t *testing.T, fn func()) uint64 {
+	t.Helper()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
 }
 
 func TestParseFragmentID(t *testing.T) {

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -11,6 +11,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 	"github.com/lestrrat-go/helium/xpath1"
 )
 
@@ -1654,7 +1655,8 @@ func (c *compiler) reportIDCXPathError(ctx context.Context, kind string, line in
 	if kind == elemField {
 		noun = "field"
 	}
-	msg := fmt.Sprintf("The %s XPath '%s' is not a valid %s expression: %s.", noun, xpath, noun, cause)
+	msg := fmt.Sprintf("The %s XPath '%s' is not a valid %s expression: %s.",
+		noun, lexer.DiagnosticExcerpt(xpath), noun, cause)
 	c.schemaError(ctx,
 		schemaParserErrorAttr(src, line, kind, kind, attrXPath, msg))
 }

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -1851,7 +1851,7 @@ func checkIDCNameTestPrefix(nt xpath1.NameTest, namespaces map[string]string) er
 		return nil
 	}
 	if _, ok := namespaces[nt.Prefix]; !ok {
-		return fmt.Errorf("the prefix '%s' is not bound to a namespace", nt.Prefix)
+		return fmt.Errorf("the prefix '%s' is not bound to a namespace", lexer.DiagnosticExcerpt(nt.Prefix))
 	}
 	return nil
 }

--- a/xsd/read_elements_test.go
+++ b/xsd/read_elements_test.go
@@ -41,6 +41,17 @@ func TestIDCXPathDiagnosticExcerpt(t *testing.T) {
 		require.GreaterOrEqual(t, large.allocated, small.allocated)
 		require.Less(t, large.allocated-small.allocated, uint64(5<<19))
 	})
+
+	t.Run("long unbound prefix is bounded", func(t *testing.T) {
+		prefix := strings.Repeat("界", (1<<20)/len("界"))
+		_, errs, err := compileWith(t, xsd.Version10, schema(prefix+":item"))
+
+		require.ErrorIs(t, err, xsd.ErrCompilationFailed)
+		require.LessOrEqual(t, len(errs), 2048)
+		require.True(t, utf8.ValidString(errs))
+		require.Contains(t, errs, "[truncated]")
+		require.Contains(t, errs, "is not bound to a namespace")
+	})
 }
 
 type xsdCompileMeasurement struct {

--- a/xsd/read_elements_test.go
+++ b/xsd/read_elements_test.go
@@ -28,24 +28,44 @@ func TestIDCXPathDiagnosticExcerpt(t *testing.T) {
 	})
 
 	t.Run("long multibyte selector is bounded", func(t *testing.T) {
-		doc, err := helium.NewParser().Parse(t.Context(), []byte(schema("1 "+strings.Repeat("界", (1<<20)/len("界")))))
-		require.NoError(t, err)
-		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
-		compiler := xsd.NewCompiler().Version(xsd.Version10).Label("test.xsd").ErrorHandler(collector)
+		small := measureXSDCompile(t, schema("1 "+strings.Repeat("界", (1<<19)/len("界"))))
+		large := measureXSDCompile(t, schema("1 "+strings.Repeat("界", (1<<20)/len("界"))))
 
-		var compileErr error
-		allocated := xsdCompileAllocatedBytes(t, func() {
-			_, compileErr = compiler.Compile(t.Context(), doc)
-		})
-		require.NoError(t, collector.Close())
-		errs := compileErrorsString(collector.Errors())
-
-		require.ErrorIs(t, compileErr, xsd.ErrCompilationFailed)
-		require.LessOrEqual(t, len(errs), 2048)
-		require.True(t, utf8.ValidString(errs))
-		require.Contains(t, errs, "[truncated]")
-		require.Less(t, allocated, uint64(4<<20))
+		require.ErrorIs(t, small.compileErr, xsd.ErrCompilationFailed)
+		require.ErrorIs(t, large.compileErr, xsd.ErrCompilationFailed)
+		require.LessOrEqual(t, len(large.diagnostic), 2048)
+		require.True(t, utf8.ValidString(large.diagnostic))
+		require.Contains(t, large.diagnostic, "[truncated]")
+		// The differential removes fixed compiler and race-runtime allocations.
+		// Reintroducing the source-sized diagnostic copies exceeds this bound.
+		require.GreaterOrEqual(t, large.allocated, small.allocated)
+		require.Less(t, large.allocated-small.allocated, uint64(5<<19))
 	})
+}
+
+type xsdCompileMeasurement struct {
+	allocated  uint64
+	compileErr error
+	diagnostic string
+}
+
+func measureXSDCompile(t *testing.T, schemaXML string) xsdCompileMeasurement {
+	t.Helper()
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	compiler := xsd.NewCompiler().Version(xsd.Version10).Label("test.xsd").ErrorHandler(collector)
+
+	var compileErr error
+	allocated := xsdCompileAllocatedBytes(t, func() {
+		_, compileErr = compiler.Compile(t.Context(), doc)
+	})
+	require.NoError(t, collector.Close())
+	return xsdCompileMeasurement{
+		allocated:  allocated,
+		compileErr: compileErr,
+		diagnostic: compileErrorsString(collector.Errors()),
+	}
 }
 
 func xsdCompileAllocatedBytes(t *testing.T, fn func()) uint64 {

--- a/xsd/read_elements_test.go
+++ b/xsd/read_elements_test.go
@@ -1,0 +1,60 @@
+package xsd_test
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIDCXPathDiagnosticExcerpt(t *testing.T) {
+	schema := func(xpath string) string {
+		return `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">` +
+			`<xs:element name="root"><xs:key name="k">` +
+			`<xs:selector xpath="` + xpath + `"/><xs:field xpath="@id"/>` +
+			`</xs:key></xs:element></xs:schema>`
+	}
+
+	t.Run("short wording is unchanged", func(t *testing.T) {
+		_, errs, err := compileWith(t, xsd.Version10, schema("1 foo"))
+		require.ErrorIs(t, err, xsd.ErrCompilationFailed)
+		require.Contains(t, errs,
+			`The selector XPath '1 foo' is not a valid selector expression: `+
+				`xpath: unexpected token: Name("foo") after expression.`)
+	})
+
+	t.Run("long multibyte selector is bounded", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schema("1 "+strings.Repeat("界", (1<<20)/len("界")))))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		compiler := xsd.NewCompiler().Version(xsd.Version10).Label("test.xsd").ErrorHandler(collector)
+
+		var compileErr error
+		allocated := xsdCompileAllocatedBytes(t, func() {
+			_, compileErr = compiler.Compile(t.Context(), doc)
+		})
+		require.NoError(t, collector.Close())
+		errs := compileErrorsString(collector.Errors())
+
+		require.ErrorIs(t, compileErr, xsd.ErrCompilationFailed)
+		require.LessOrEqual(t, len(errs), 2048)
+		require.True(t, utf8.ValidString(errs))
+		require.Contains(t, errs, "[truncated]")
+		require.Less(t, allocated, uint64(4<<20))
+	})
+}
+
+func xsdCompileAllocatedBytes(t *testing.T, fn func()) uint64 {
+	t.Helper()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
+}

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -10,6 +10,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	ixpath "github.com/lestrrat-go/helium/internal/xpath"
+	"github.com/lestrrat-go/helium/internal/xpath1/lexer"
 	"github.com/lestrrat-go/helium/internal/xsd/value"
 	"github.com/lestrrat-go/helium/xpath1"
 )
@@ -319,7 +320,8 @@ func (vc *validationContext) evaluateIDC(ctx context.Context, ev xpath1.Evaluato
 					// marking the field absent silently drops the selected node from
 					// the constraint, so a unique/keyref could miss a duplicate or a
 					// dangling reference. Surface it like the selector path.
-					return nil, fmt.Errorf("xsd: IDC field XPath %q failed to compile: %w", fieldXPath, compErr)
+					return nil, fmt.Errorf("xsd: IDC field XPath %q failed to compile: %w",
+						lexer.DiagnosticExcerpt(fieldXPath), compErr)
 				}
 				fieldResult, err = fieldEv.Evaluate(ctx, compiled, node)
 			}
@@ -327,7 +329,8 @@ func (vc *validationContext) evaluateIDC(ctx context.Context, ev xpath1.Evaluato
 				// A field XPath that compiles but fails at evaluation (e.g. an
 				// unknown function) must likewise surface as an error, and is never
 				// treated as an absent field.
-				return nil, fmt.Errorf("xsd: IDC field XPath %q failed to evaluate: %w", fieldXPath, err)
+				return nil, fmt.Errorf("xsd: IDC field XPath %q failed to evaluate: %w",
+					lexer.DiagnosticExcerpt(fieldXPath), err)
 			}
 
 			var value string
@@ -365,7 +368,7 @@ func (vc *validationContext) evaluateIDC(ctx context.Context, ev xpath1.Evaluato
 					if entry.elem != nil {
 						idcName := idcDisplayName(idc, vc.schema)
 						msg := fmt.Sprintf("The XPath '%s' of a field of %s identity-constraint '%s' evaluates to a node whose type is not simple.",
-							fieldXPath, idcKindName(idc.Kind), idcName)
+							lexer.DiagnosticExcerpt(fieldXPath), idcKindName(idc.Kind), idcName)
 						vc.reportValidityError(ctx, vc.filename, entry.elem.Line(), elemDisplayName(entry.elem), msg)
 					}
 					table.fieldType = true
@@ -381,7 +384,7 @@ func (vc *validationContext) evaluateIDC(ctx context.Context, ev xpath1.Evaluato
 					if entry.elem != nil {
 						idcName := idcDisplayName(idc, vc.schema)
 						msg := fmt.Sprintf("The XPath '%s' of a field of %s identity-constraint '%s' evaluates to a node-set with more than one member.",
-							fieldXPath, idcKindName(idc.Kind), idcName)
+							lexer.DiagnosticExcerpt(fieldXPath), idcKindName(idc.Kind), idcName)
 						vc.reportValidityError(ctx, vc.filename, entry.elem.Line(), elemDisplayName(entry.elem), msg)
 					}
 					table.fieldError = true

--- a/xsd/validate_idc_errors_test.go
+++ b/xsd/validate_idc_errors_test.go
@@ -1,12 +1,36 @@
 package xsd_test
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xsd"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIDCFieldValidationDiagnosticExcerpt(t *testing.T) {
+	field := "a|b|" + strings.Repeat("n", 1<<20)
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">` +
+		`<xs:element name="root"><xs:complexType><xs:sequence>` +
+		`<xs:element name="a" type="xs:string"/><xs:element name="b" type="xs:string"/>` +
+		`</xs:sequence></xs:complexType><xs:unique name="u">` +
+		`<xs:selector xpath="."/><xs:field xpath="` + field + `"/>` +
+		`</xs:unique></xs:element></xs:schema>`
+
+	schema, compileErrs, err := compileWith(t, xsd.Version10, schemaXML)
+	require.NoError(t, err, compileErrs)
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><a>x</a><b>y</b></root>`))
+	require.NoError(t, err)
+	var diagnostics string
+	err = validateWithOutput(t, xsd.NewValidator(schema), doc, &diagnostics)
+
+	require.ErrorIs(t, err, xsd.ErrValidationFailed)
+	require.LessOrEqual(t, len(diagnostics), 2048)
+	require.True(t, utf8.ValidString(diagnostics))
+	require.Contains(t, diagnostics, "[truncated]")
+}
 
 // TestIDCMalformedXPath covers the case where an identity constraint's selector
 // or field XPath is not a valid XPath expression. Previously the compile error


### PR DESCRIPTION
- Bound caller-controlled XPath 1.0 diagnostic excerpts while preserving short wording and sentinel identity.
- Keep excerpts valid UTF-8 across ASCII, multibyte, and malformed input.
