### PR TITLE
qualify xmlenc1 key-resolution outcomes

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -355,8 +355,10 @@ the empty-candidate branch of both decrypt terminals, and picks this sentinel ov
 `xenc11:DerivedKey` child and `parseRetrievalMethod` for a `ds:RetrievalMethod` whose `@Type` is
 `typeDerivedKey`; neither reads the construct any further. The split matters because the two errors ask
 different things of the caller: `ErrMissingKey` says supply a key, which no caller can act on here, while this
-names the facility the package lacks. A document ALSO carrying a usable `xenc:EncryptedKey` decrypts under it,
-and a pre-shared `Decryptor.SessionKey` returns before key resolution runs, so neither reaches the sentinel.
+names the facility the package lacks. Once block-algorithm resolution and any AES-CBC opt-in pass, a document
+ALSO carrying a usable `xenc:EncryptedKey` decrypts under it, and a pre-shared `Decryptor.SessionKey` returns
+before key resolution runs, so neither reaches the sentinel. Those earlier gates can instead return
+`ErrMalformedEncrypted` or `ErrCBCRequiresOptIn`.
 
 `ErrOpaquePayload` is `Decryptor.Decrypt`'s refusal of an `EncryptedData` whose `@Type` declares no XML
 content — absent, empty, or any URI other than `TypeElement`/`TypeContent`. `decryptElement`'s `@Type` switch

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1835,9 +1835,11 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
   `encryptedData.offersDerivedKey` is set — i.e. the `ds:KeyInfo` offered the session key only through an
   `xenc11:DerivedKey`, inline or named by a `ds:RetrievalMethod` `Type` of `#DerivedKey`. It is deliberately
   not `ErrMissingKey`: no key the caller supplies can decrypt such a document, so the error must name the
-  missing facility instead of sending the caller to audit its key configuration. A document that ALSO carries
-  a usable `xenc:EncryptedKey` decrypts under it (the flag is consulted only on an empty candidate list), and
-  a pre-shared `Decryptor.SessionKey` never reaches it at all
+  missing facility instead of sending the caller to audit its key configuration. Once block-algorithm
+  resolution and any AES-CBC opt-in pass, a document that ALSO carries a usable `xenc:EncryptedKey` decrypts
+  under it (the flag is consulted only on an empty candidate list), and a pre-shared `Decryptor.SessionKey`
+  never reaches the sentinel at all; those earlier gates can instead return `ErrMalformedEncrypted` or
+  `ErrCBCRequiresOptIn`
 - `UnsupportedAlgorithmError` and `KeySizeError` each carry a leading blank `_ struct{}` field, so an unkeyed
   composite literal cannot compile from another package (`implicit assignment to unexported field _`). That is
   what lets either field set GROW without breaking a caller: nobody can have written the positional form a new
@@ -1963,8 +1965,10 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
   (§3.5.2), which it records on `encryptedData.offersDerivedKey`, and an `xenc:AgreementMethod` in the
   `EncryptedData`-level `ds:KeyInfo` position §5.6 defines for it — §3.5 marks that OPTIONAL, the same grade
   as `ds:KeyValue`, so an `EncryptedData` offering its session key only that way carries no candidate and
-  fails with `ErrMissingKey`. The `EncryptedKey`-level position IS read, by `parseAgreementMethodForKeyInfo`,
-  which is how this package performs ECDH-ES key agreement
+  reaches `ErrMissingKey` only after block-algorithm resolution and any AES-CBC opt-in pass; a pre-shared
+  `Decryptor.SessionKey` then bypasses that key-resolution outcome. Those earlier gates can instead return
+  `ErrMalformedEncrypted` or `ErrCBCRequiresOptIn` regardless of that key. The `EncryptedKey`-level position
+  IS read, by `parseAgreementMethodForKeyInfo`, which is how this package performs ECDH-ES key agreement
 <!-- Refutation of a review finding that this bullet still lists only completion, over-budget and cancellation
 as the close paths, omitting the stream-plus-error case. Checked against this file's bytes at this commit: the
 bullet below reads "the stream is CLOSED on completion, over-budget, and cancellation alike, and equally when

--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -401,7 +401,11 @@ even when a pre-shared `SessionKey` is configured. A present empty value is the
 valid null same-document URI. After that presence check, a `Type` this package
 does not implement — a `#DerivedKey` (§3.5.2), or any type from another
 specification — is stepped over before its URI is resolved, so it costs nothing,
-cannot fail a decrypt, and a pre-shared `SessionKey` decrypts past it. A `Type` of
+cannot itself fail a decrypt. Once the block algorithm resolves and any AES-CBC
+opt-in passes, a pre-shared `SessionKey` decrypts past it. Without an
+`EncryptionMethod` or `Decryptor.BlockAlgorithm`, the document instead fails
+with `ErrMalformedEncrypted`; AES-CBC without `AllowUnauthenticatedCBC(true)`
+fails with `ErrCBCRequiresOptIn`, even with a `SessionKey`. A `Type` of
 `#EncryptedKey` naming something that is not an `xenc:EncryptedKey` is a
 contradiction inside the document and fails with `ErrMalformedEncrypted`; a
 reference with no `Type` at all is resolved, and its target used only if it is
@@ -418,10 +422,12 @@ that is where ECDH-ES carries the sender's ephemeral key, and so is an
 `xenc:AgreementMethod` inside an `xenc:EncryptedKey`'s own `ds:KeyInfo`,
 which this package DOES read — that is how it does ECDH-ES key agreement.
 An `EncryptedData` whose own `ds:KeyInfo` carries only the outer,
-`EncryptedData`-level form fails decryption with `ErrMissingKey`, and still
-decrypts under a pre-shared
-[`Decryptor.SessionKey`](#decrypting-with-a-pre-shared-session-key), the same
-as any other document with no readable key candidate.
+`EncryptedData`-level form reaches `ErrMissingKey` only after the block algorithm
+resolves and any AES-CBC opt-in passes. A pre-shared
+[`Decryptor.SessionKey`](#decrypting-with-a-pre-shared-session-key) then decrypts
+past it, as it does for any other document with no readable key candidate; the
+same earlier gates can instead return `ErrMalformedEncrypted` or
+`ErrCBCRequiresOptIn` regardless of that key.
 
 An `xenc:KeySize` child of `EncryptionMethod` is read and checked, but it is
 never used as a key length: every algorithm URI this package implements


### PR DESCRIPTION
- qualify key-info outcomes behind block-algorithm resolution and CBC opt-in
- keep README and agent cache sentinel guidance aligned
