### PR TITLE
deduplicate XMLDSig reference search roots

### DIFF
--- a/xmldsig1/issue1220_test.go
+++ b/xmldsig1/issue1220_test.go
@@ -106,6 +106,46 @@ func TestSignEnveloping_ReferenceIntoOwnObject(t *testing.T) {
 	require.NoError(t, err, "signature covering a reference into its own Object must verify")
 }
 
+func TestSignEnvelopingReferenceSearchDomains(t *testing.T) {
+	const key = "reference-search-domains"
+
+	t.Run("detached Object target resolves", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		payload, err := doc.CreateElement("Payload")
+		require.NoError(t, err)
+		require.NoError(t, payload.SetAttribute("Id", "inside"))
+
+		sig, err := xmldsig1.NewSigner().
+			SignatureAlgorithm(xmldsig1.AlgHMACSHA256).
+			Reference(xmldsig1.ReferenceConfig{
+				URI:             "#inside",
+				DigestAlgorithm: xmldsig1.DigestSHA256,
+				Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+			}).
+			SignEnveloping(t.Context(), doc, []helium.Node{payload}, []byte(key))
+		require.NoError(t, err)
+		require.NotNil(t, sig)
+	})
+
+	t.Run("distinct document and Object targets are ambiguous", func(t *testing.T) {
+		doc := mustParseXML(t, `<root><DocumentTarget Id="duplicate"/></root>`)
+		payload, err := doc.CreateElement("ObjectTarget")
+		require.NoError(t, err)
+		require.NoError(t, payload.SetAttribute("Id", "duplicate"))
+
+		sig, err := xmldsig1.NewSigner().
+			SignatureAlgorithm(xmldsig1.AlgHMACSHA256).
+			Reference(xmldsig1.ReferenceConfig{
+				URI:             "#duplicate",
+				DigestAlgorithm: xmldsig1.DigestSHA256,
+				Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+			}).
+			SignEnveloping(t.Context(), doc, []helium.Node{payload}, []byte(key))
+		require.ErrorIs(t, err, xmldsig1.ErrAmbiguousReference)
+		require.Nil(t, sig)
+	})
+}
+
 // Parity guard for #1220: an enveloping reference to the document element
 // (URI="#root", where root IS the document element) must be digested over
 // root's own subtree, unchanged — the Signature is never inserted into the

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -1583,15 +1583,17 @@ func effectiveC14NMethod(method string, includeComments bool) string {
 // For a whole-document form (URI="" or "#xpointer(/)"), returns the document
 // element. For an element form ("#id" or "#xpointer(id('id'))"), returns the
 // unique element with that id, searched across the document tree and any
-// extraRoots. An enveloping signature passes its own (detached) Signature
-// element as an extra root so a reference into its own <Object> content resolves
-// before the Signature is placed in a document. If more than one element matches
-// the id — in either tree, or one in each — returns ErrAmbiguousReference. This
-// is the primary defense against XML Signature Wrapping (XSW) attacks where an
-// attacker injects a duplicate-ID element containing malicious content, and it
-// also rejects an id that collides between the document and the Signature's own
-// Object content. Any unsupported URI (an external reference, or an unrecognized
-// #xpointer(...) scheme) stays fail-closed as ErrReferenceNotFound.
+// extraRoots. Overlapping search roots count each element once by pointer
+// identity. An enveloping signature passes its own (detached) Signature element
+// as an extra root so a reference into its own <Object> content resolves before
+// the Signature is placed in a document. If more than one distinct element
+// matches the id — in either tree, or one in each — returns
+// ErrAmbiguousReference. This is the primary defense against XML Signature
+// Wrapping (XSW) attacks where an attacker injects a duplicate-ID element
+// containing malicious content, and it also rejects an id that collides between
+// the document and the Signature's own Object content. Any unsupported URI (an
+// external reference, or an unrecognized #xpointer(...) scheme) stays
+// fail-closed as ErrReferenceNotFound.
 func resolveReference(doc *helium.Document, uri string, extraRoots ...helium.Node) (*helium.Element, error) {
 	id, wholeDoc, _, ok := referenceURIForm(uri)
 	if !ok {
@@ -1603,10 +1605,21 @@ func resolveReference(doc *helium.Document, uri string, extraRoots ...helium.Nod
 	// Walk each tree once and collect every candidate. We accept matches from
 	// any of: a DTD/schema-declared ID-typed attribute, xml:id, or the "id"
 	// attribute token in the casings "Id", "ID", or "id". We refuse to resolve
-	// the reference if more than one element matches.
-	matches := domutil.FindElementsByID(doc.DocumentElement(), id)
+	// the reference if more than one distinct element matches.
+	var matches []*helium.Element
+	seen := make(map[*helium.Element]struct{})
+	collect := func(root helium.Node) {
+		for _, match := range domutil.FindElementsByID(root, id) {
+			if _, ok := seen[match]; ok {
+				continue
+			}
+			seen[match] = struct{}{}
+			matches = append(matches, match)
+		}
+	}
+	collect(doc.DocumentElement())
 	for _, root := range extraRoots {
-		matches = append(matches, domutil.FindElementsByID(root, id)...)
+		collect(root)
 	}
 	switch len(matches) {
 	case 0:

--- a/xmldsig1/transforms_internal_test.go
+++ b/xmldsig1/transforms_internal_test.go
@@ -242,6 +242,53 @@ func TestExclusiveC14NEquivalentDocumentReferencesMatch(t *testing.T) {
 	require.Equal(t, selectedDigest, wholeDigest)
 }
 
+func TestResolveReferenceOverlappingRoots(t *testing.T) {
+	doc := mustParse(t, `<root><branch><target Id=" target "/></branch></root>`)
+	root := doc.DocumentElement()
+	branch := findLocal(root, "branch")
+	target := findLocal(root, "target")
+	require.NotNil(t, branch)
+	require.NotNil(t, target)
+
+	t.Run("document element repeated as extra root", func(t *testing.T) {
+		got, err := resolveReference(doc, "#target", root)
+		require.NoError(t, err)
+		require.Same(t, target, got)
+	})
+
+	t.Run("nested extra root overlaps document", func(t *testing.T) {
+		got, err := resolveReference(doc, "#target", branch)
+		require.NoError(t, err)
+		require.Same(t, target, got)
+	})
+
+	t.Run("repeated extra roots count once", func(t *testing.T) {
+		got, err := resolveReference(doc, "#target", branch, branch, target)
+		require.NoError(t, err)
+		require.Same(t, target, got)
+	})
+
+	t.Run("detached root remains searchable", func(t *testing.T) {
+		detached, err := doc.CreateElement("detached")
+		require.NoError(t, err)
+		require.NoError(t, detached.SetAttribute("Id", "detached"))
+
+		got, err := resolveReference(doc, "#detached", detached)
+		require.NoError(t, err)
+		require.Same(t, detached, got)
+	})
+
+	t.Run("distinct matches across domains remain ambiguous", func(t *testing.T) {
+		detached, err := doc.CreateElement("duplicate")
+		require.NoError(t, err)
+		require.NoError(t, detached.SetAttribute("Id", "target"))
+
+		_, err = resolveReference(doc, "#target", detached)
+		require.ErrorIs(t, err, ErrAmbiguousReference)
+		require.Contains(t, err.Error(), "matched 2 elements")
+	})
+}
+
 // dtdEntityDecl returns the DTD entity-declaration node named name, or nil.
 func dtdEntityDecl(doc *helium.Document, name string) helium.Node {
 	for c := range helium.Children(doc) {


### PR DESCRIPTION
- Count each matching XMLDSig element once across overlapping reference search roots.
- Keep distinct duplicate-ID elements ambiguous across document and detached Object domains.
- Cover equal, nested, repeated, detached, and distinct search-root cases.
