### PR TITLE
bound XMLDSig XPath filter inputs

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -28,7 +28,8 @@ sax            → helium, enum
 helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack, internal/uripath, internal/iofs, internal/writerctl, internal/nodelink, internal/nslookup
                   (helium installs hooks in internal/writerctl in init so xpath3 fn:serialize can enable declaration-only encoding and xslt3 can omit document-child terminators without public methods; the writerctl package imports nothing, so the edge is one-way)
                   (helium installs hooks in internal/nodelink in init so xslt3's strip-space copier can link a freshly built child without AddChild's preflight, and the xsd/xmldsig1 corrupt-tree cycle-guard tests can write a raw next-sibling pointer, all without public functions in helium; the nodelink package imports nothing, so the edge is one-way)
-                  (helium installs hooks in internal/nslookup in init so internal/domutil can search raw namespace declarations without cloning Element.Namespaces or exposing the mutable nsDefs slice; the nslookup package imports nothing, so the edge is one-way)
+                  (helium installs hooks in internal/nslookup in init so internal/domutil can search or read raw namespace declarations one at a time
+                  without cloning Element.Namespaces or exposing the mutable nsDefs slice; the nslookup package imports nothing, so the edge is one-way)
 sink           → (none)
 enum           → (none)
 internal/lexicon → (none)

--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -341,6 +341,9 @@ parser error. `errors.Is` therefore matches `context.Canceled` or `context.Deadl
 for context, while `errors.As` still recovers a non-context `helium.ErrParseError`; the malformed-resource
 wording is unchanged.
 
+An XPath filter node-set limit error names the caller-configured absolute `MaxXPathFilterNodes` cap, including
+whole-document collections that count leading comments or processing instructions before the document element.
+
 ### XML Encryption (`xmlenc1/errors.go`)
 
 `ErrCipherValueBytesExceeded` is returned when an EncryptedData payload exceeds

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -46,10 +46,12 @@ Element has THREE namespace-related fields:
 `Element.Namespaces()` returns a cloned slice, so callers cannot replace or
 append entries in the element's `nsDefs`. Namespace lookup does not clone that
 slice: `LookupNSByPrefix`/`LookupNSByHref` scan the raw declarations in-package,
-and sibling packages use the read-only `internal/nslookup` hooks through
-`internal/domutil`. Both lookup forms preserve nearest-ancestor shadowing and
-empty-URI undeclarations. The bare internal lookup does not synthesize the
-implicit `xml` binding; the public `LookupNSByPrefix`/`LookupNSByHref` APIs do.
+and sibling packages use the read-only lookup and indexed-declaration hooks
+through `internal/nslookup` and `internal/domutil`. The indexed accessor reads
+one declaration without cloning the complete slice, so capped consumers can
+stop early. Both lookup forms preserve nearest-ancestor shadowing and empty-URI
+undeclarations. The bare internal lookup does not synthesize the implicit `xml`
+binding; the public `LookupNSByPrefix`/`LookupNSByHref` APIs do.
 
 ## Attribute Storage
 

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1182,15 +1182,21 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
     to keep it. The `SignDetached`/`SignEnveloping` godoc states this, and `sign_lifetime_test.go` proves the
     node survives `doc.Free()` plus slab-pool churn intact.
 - **NewVerifier(KeySource) → Verifier** — create fluent builder for verification (clone-on-write value type)
-  - `AllowSHA1(bool)`, `AllowXPointer(bool)`, `LenientKeyInfo(bool)`, `ReferenceResolver(r)`, `ReferenceParser(p)`, `ValidateManifests(bool)`, `XSLTTransformer(t)`, `MaxReferences(n)`, `MaxKeyInfoEntries(n)`, `MaxDecodedBytes(n)` — builder methods
-  - **Parse-time resource caps** (`xmldsig1.go` `verifierConfig` + `verify.go` `verifyBudget`): bound the
-    decode/parse work an unsigned, attacker-controlled Signature can force BEFORE the SignatureValue is
-    checked (many/large `DigestValue`/`SignatureValue`/`X509Certificate` base64 decodes, one
-    `x509.ParseCertificate` per embedded cert). `MaxReferences` (default 1024) caps `ds:Reference` count,
+  - `AllowSHA1(bool)`, `AllowXPointer(bool)`, `LenientKeyInfo(bool)`, `ReferenceResolver(r)`,
+    `ReferenceParser(p)`, `ValidateManifests(bool)`, `XSLTTransformer(t)`, `MaxReferences(n)`,
+    `MaxKeyInfoEntries(n)`, `MaxDecodedBytes(n)`, `MaxXPathFilterNodes(n)` — builder methods
+  - **Verification resource caps** (`xmldsig1.go` `verifierConfig`, `verify.go` `verifyBudget`,
+    `transforms.go` `nodeSet`): bound the decode, parse, and transform work an unsigned,
+    attacker-controlled Signature can force before the SignatureValue is checked. `MaxReferences`
+    (default 1024) caps `ds:Reference` count,
     `MaxKeyInfoEntries` (default 256) caps `KeyInfo` children + `X509Data` children, `MaxDecodedBytes`
-    (default 10 MiB) caps the running certificate/signature octet total. Exceeding any →
-    `ErrResourceLimitExceeded` (before digesting/crypto). Per builder, `n==0` selects the default and `n<0`
-    disables the cap. The `verifyBudget` also polls `ctx.Err()` inside the KeyInfo/Reference parse loops (not
+    (default 10 MiB) caps the running certificate/signature octet total, and `MaxXPathFilterNodes`
+    (default 65,536) caps the complete node-set members collected and evaluated by one XPath filter,
+    including every element's full in-scope namespace axis. Exceeding any →
+    `ErrResourceLimitExceeded`. Per builder, `n==0` selects the default and `n<0` disables the cap. The
+    XPath limit is checked before the over-limit namespace wrapper is allocated and before evaluation;
+    `ctx.Err()` takes priority when cancellation and the boundary coincide. The `verifyBudget` also polls
+    `ctx.Err()` inside the KeyInfo/Reference parse loops (not
     just at their boundaries), so a cancelled ctx/passed deadline stops the parse promptly. `MaxDecodedBytes`
     has **five** charge sites, four of them DOM-decoded (`verify.go` SignatureValue + DigestValue,
     `keyinfo.go` X509Certificate, `retrieval_method.go:374` same-document rawX509Certificate) and one not
@@ -1227,7 +1233,8 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
     `ReferenceResolver` under the resolver's OWN 64 MiB cap and run through its transforms, and only then
     charged — so those octets are charged AFTER materialization and are not base64-decoded bytes. The KeyInfo
     values outside the budget (KeyName, X509SKI, X509SubjectName/IssuerName, the base64 KeyValue families) are
-    not charged at all. The XPath-transform expression is not charged against `MaxDecodedBytes` either; it has
+    not charged at all. The XPath-transform expression and node-set members are not charged against
+    `MaxDecodedBytes`; the expression has
     its own fixed `maxXPathFilterExpressionBytes` = 8 KiB length ceiling (`verify.go`, applied in
     `parseXPathTransform` → `ErrResourceLimitExceeded`), bounding the expression where it is read off the
     document because compiling one costs superlinearly in its LENGTH (a flat predicate chain allocates ~100x

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -420,9 +420,9 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   callers cannot replace or append entries in the element's private `nsDefs`.
   `LookupNSByPrefix` and `LookupNSByHref` scan the raw declarations without
   cloning while preserving nearest-ancestor shadowing and the public implicit
-  `xml` binding. Sibling-package bare lookups run through `internal/domutil` and
-  `internal/nslookup`; they preserve undeclarations and intentionally do not
-  synthesize `xml`.
+  `xml` binding. Sibling-package bare lookups and indexed declaration reads run
+  through `internal/domutil` and `internal/nslookup`; the lookups preserve
+  undeclarations and intentionally do not synthesize `xml`.
 - `UnlinkNode(n MutableNode)` — detaches `n` from its parent/sibling chain; a nil or typed-nil `n` is a no-op.
   `node.Replace(...Node) → error` (guarded) rejects an EMPTY replacement set with `ErrInvalidOperation`
   (matching `Document.Replace`; use `UnlinkNode` to delete), a nil/typed-nil operand with `ErrNilNode`, and a
@@ -1194,7 +1194,8 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
     (default 65,536) caps the complete node-set members collected and evaluated by one XPath filter,
     including every element's full in-scope namespace axis. Exceeding any →
     `ErrResourceLimitExceeded`. Per builder, `n==0` selects the default and `n<0` disables the cap. The
-    XPath limit is checked before the over-limit namespace wrapper is allocated and before evaluation;
+    XPath limit is checked before the over-limit member is added or evaluation begins; namespace declaration
+    and attribute iteration stop at the boundary without copying the complete over-limit collection.
     `ctx.Err()` takes priority when cancellation and the boundary coincide. The `verifyBudget` also polls
     `ctx.Err()` inside the KeyInfo/Reference parse loops (not
     just at their boundaries), so a cancelled ctx/passed deadline stops the parse promptly. `MaxDecodedBytes`
@@ -2207,11 +2208,12 @@ Generic bitset operations for bitmask types.
 
 ## internal/nslookup/
 
-Read-only bridge for namespace declaration lookup. Package helium installs the
-prefix and URI lookup hooks during init; sibling packages use them through
-`internal/domutil` to search the private `nsDefs` storage without cloning it or
-adding a public raw-slice accessor. The bridge imports nothing, so helium can
-register the hooks without an import cycle.
+Read-only bridge for namespace declaration access. Package helium installs the
+prefix and URI lookup hooks plus an indexed declaration hook during init;
+sibling packages use them through `internal/domutil` to read the private
+`nsDefs` storage without cloning it or adding a public raw-slice accessor. The
+bridge imports nothing, so helium can register the hooks without an import
+cycle.
 
 - Files: `nslookup.go`
 - Imports: none
@@ -2222,7 +2224,8 @@ Shared DOM/QName helpers used by processing packages. Namespace lookup uses
 `internal/nslookup` to scan private declaration storage without cloning it;
 `LookupNSPrefixURI` and `LookupNSURI` preserve nearest-ancestor shadowing and
 empty-URI undeclarations, and neither synthesizes the implicit `xml` binding.
-`Element.Namespaces()` remains the public defensive-copy accessor.
+`NamespaceDeclarationAt` reads one declaration without cloning the containing
+slice. `Element.Namespaces()` remains the public defensive-copy accessor.
 
 - Files: `domutil.go`, `id.go`
 - Imports: helium, enum, internal/lexicon, internal/nslookup, internal/xmlchar

--- a/README.md
+++ b/README.md
@@ -186,9 +186,12 @@ The `xmldsig1` package supports narrow, explicit same-document verification
 profiles when the application pins its trusted key or certificate source and
 checks `VerifyResult.Covers` before consuming a signed element. External
 references and XSLT remain opt-in advanced features with caller-owned resource
-and execution policy. The `xmlenc1` package uses authenticated AES-GCM by
-default and refuses retired Triple DES algorithms. Callers should still review
-their deployment's security and compliance requirements.
+and execution policy. XPath filter inputs retain the complete namespace axis
+required by XMLDSig and are capped at 65,536 members by default; callers can
+tune this with `Verifier.MaxXPathFilterNodes`. The `xmlenc1` package uses
+authenticated AES-GCM by default and refuses retired Triple DES algorithms.
+Callers should still review their deployment's security and compliance
+requirements.
 
 # `encoding/xml` compatibility
 

--- a/internal/domutil/domutil.go
+++ b/internal/domutil/domutil.go
@@ -117,6 +117,18 @@ func LookupNSURI(start helium.Node, uri string) (*helium.Namespace, bool) {
 	return ns, ok
 }
 
+// NamespaceDeclarationAt returns one namespace declaration from e by index.
+// It reads the element's private declaration storage without cloning the whole
+// slice, so callers with a resource cap can stop before visiting the remainder.
+func NamespaceDeclarationAt(e *helium.Element, index int) (*helium.Namespace, bool) {
+	raw, found := nslookup.DeclarationAt(e, index)
+	if !found {
+		return nil, false
+	}
+	ns, ok := raw.(*helium.Namespace)
+	return ns, ok
+}
+
 // SplitLexicalQName trims surrounding whitespace from s, splits it at the first
 // ':' into prefix and local, and validates each part as an NCName. It is
 // error-code free: callers map a failure to whatever XPath error code

--- a/internal/nslookup/nslookup.go
+++ b/internal/nslookup/nslookup.go
@@ -16,3 +16,8 @@ var PrefixURI func(start any, prefix string) (string, bool)
 // declaration matching uri. It returns a *helium.Namespace as any, plus whether
 // a declaration was found. It does not synthesize the implicit xml binding.
 var ByURI func(start any, uri string) (any, bool)
+
+// DeclarationAt returns one namespace declaration from a helium element by
+// index. It lets sibling packages stop before traversing or copying declarations
+// beyond their own resource limits.
+var DeclarationAt func(elem any, index int) (any, bool)

--- a/tree_namespaces.go
+++ b/tree_namespaces.go
@@ -8,6 +8,17 @@ import (
 func init() {
 	nslookup.PrefixURI = namespacePrefixURI
 	nslookup.ByURI = namespaceByURIHook
+	nslookup.DeclarationAt = namespaceDeclarationAt
+}
+
+// namespaceDeclarationAt exposes one raw declaration through the internal
+// bridge without copying the containing slice.
+func namespaceDeclarationAt(elem any, index int) (any, bool) {
+	el, ok := elem.(*Element)
+	if !ok || isNilNode(el) || index < 0 || index >= len(el.nsDefs) {
+		return nil, false
+	}
+	return el.nsDefs[index], true
 }
 
 // namespaceByPrefix walks raw namespace declarations without cloning each

--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -534,9 +534,11 @@ needs its own axis. The node set and its evaluations can therefore be quadratic
 in the document. `MaxXPathFilterNodes` bounds the members collected and
 evaluated by one filter while preserving the complete standards-required axis
 for every accepted input. The limit is checked before the over-limit namespace
-wrapper is allocated and before evaluation begins. It applies to same-document
-References, external or intermediate octets parsed for a later XPath transform,
-Manifest inner references, and `ds:RetrievalMethod` transforms.
+wrapper is allocated and before evaluation begins. Namespace declaration and
+attribute iteration stop at the boundary without copying the complete
+over-limit collection. The limit applies to same-document References, external
+or intermediate octets parsed for a later XPath transform, Manifest inner
+references, and `ds:RetrievalMethod` transforms.
 
 Both collection and per-node evaluation also poll `ctx`. A context error wins
 when cancellation coincides with the member boundary. Keep the default finite

--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -449,20 +449,20 @@ source: [examples/xmldsig1_sha1_optin_example_test.go](https://github.com/lestrr
 An attacker-controlled, unsigned document can force verification to do
 substantial decode/parse work *before* the `SignatureValue` is ever checked:
 many or large `DigestValue`/`SignatureValue`/`X509Certificate` values to
-base64-decode, and one `x509.ParseCertificate` per embedded certificate. To
-bound that work the `Verifier` enforces three parse-time caps, each with a
-conservative default that sits well above any legitimate signature so existing
-documents verify unchanged:
+base64-decode, one `x509.ParseCertificate` per embedded certificate, and a
+namespace-heavy XPath filter input to collect and evaluate. To bound that work
+the `Verifier` enforces four resource caps. Their defaults preserve the package's
+interop vectors while bounding hostile work:
 
 | Builder | Bounds | Default |
 |---------|--------|---------|
 | `Verifier.MaxReferences(n)` | number of `ds:Reference` elements | 1024 |
 | `Verifier.MaxKeyInfoEntries(n)` | `KeyInfo` children + `X509Data` children | 256 |
 | `Verifier.MaxDecodedBytes(n)` | running total of certificate and signature octets | 10 MiB |
+| `Verifier.MaxXPathFilterNodes(n)` | members in one XPath filter input node-set | 65,536 |
 
-Exceeding a cap fails with `ErrResourceLimitExceeded` before any Reference is
-digested or the signature is checked. For each builder, `n == 0` selects the
-default and a negative `n` disables that cap.
+Exceeding a cap fails with `ErrResourceLimitExceeded`. For each builder,
+`n == 0` selects the default and a negative `n` disables that cap.
 
 `MaxDecodedBytes` charges five sites. Four are base64 values decoded straight
 off the document — the Signature's own `DigestValue`, `SignatureValue`, and
@@ -530,21 +530,19 @@ canonical octets in every supported method, Exclusive C14N and its
 The one node set that does carry the complete axis is the input to an `XPath`
 filter transform. That transform is evaluated once per node — namespace nodes
 included — and may keep an element whose parent it drops, so every element there
-needs its own axis; the node set, and the one evaluation per member, are
-quadratic in the document. That is the transform's own data model, not a choice
-this package makes, and it is where a deadline earns its keep: nothing caps that
-node set's size, and both the walk that builds it and the per-node evaluation
-poll the context, so a `ctx` deadline bounds the work at roughly the rate times
-the deadline instead of running to completion. The walk charges its poll per
-collected node-set MEMBER — every element, attribute, and namespace node — and
-not per tree node walked, so an element that repeats the whole axis cannot carry
-a document's worth of members past a poll: what a passed deadline may still cost
-is one poll interval of members, whatever the document's shape.
+needs its own axis. The node set and its evaluations can therefore be quadratic
+in the document. `MaxXPathFilterNodes` bounds the members collected and
+evaluated by one filter while preserving the complete standards-required axis
+for every accepted input. The limit is checked before the over-limit namespace
+wrapper is allocated and before evaluation begins. It applies to same-document
+References, external or intermediate octets parsed for a later XPath transform,
+Manifest inner references, and `ds:RetrievalMethod` transforms.
 
-Pass one when verifying documents from untrusted sources. A Reference's
-transforms run only *after* the `SignatureValue` has verified, but a
-`ds:RetrievalMethod`'s transforms run before it, so a RetrievalMethod carrying
-an XPath filter transform reaches that quadratic node set without a key or a
+Both collection and per-node evaluation also poll `ctx`. A context error wins
+when cancellation coincides with the member boundary. Keep the default finite
+for untrusted documents: a Reference's transforms run only after the
+`SignatureValue` has verified, but a `ds:RetrievalMethod`'s transforms run
+before it, so a RetrievalMethod can reach the XPath node set without a key or a
 valid signature.
 
 RetrievalMethod transforms have a separate fixed `maxRetrievalTransformSteps`

--- a/xmldsig1/errors.go
+++ b/xmldsig1/errors.go
@@ -48,18 +48,20 @@ var (
 	// memory during verification.
 	ErrReferenceTooLarge = errors.New("xmldsig1: external reference exceeds size cap")
 
-	// ErrResourceLimitExceeded is returned when an attacker-controlled Signature
-	// element exceeds one of the Verifier's parse-time resource caps before the
-	// SignatureValue is checked: too many ds:Reference elements
+	// ErrResourceLimitExceeded is returned when attacker-controlled signature
+	// processing exceeds one of the Verifier's resource caps: too many
+	// ds:Reference elements
 	// ([Verifier.MaxReferences]), too many KeyInfo entries
 	// ([Verifier.MaxKeyInfoEntries]), or too many total certificate and signature
 	// octets — the DigestValue/SignatureValue/X509Certificate values plus
 	// whatever a ds:RetrievalMethod in KeyInfo pulls in
-	// ([Verifier.MaxDecodedBytes]). It also covers two fixed pre-verification
-	// caps: a ds:RetrievalMethod transform list past its step cap, and a
+	// ([Verifier.MaxDecodedBytes]), or an XPath filter input node-set past
+	// [Verifier.MaxXPathFilterNodes]. It also covers two fixed pre-verification
+	// caps: a ds:RetrievalMethod transform list past its step cap and a
 	// ds:Transform/XPath filter expression past its length ceiling. The caps have
-	// conservative defaults and bound the decode/parse/transform work an unsigned
-	// document can force before verification rejects it. A base64 value decoded
+	// conservative defaults and bound the decode, parse, and transform work an
+	// unsigned document can force before verification rejects it. A base64 value
+	// decoded
 	// off the document is charged against [Verifier.MaxDecodedBytes] before it is
 	// decoded, so a value that is both over the cap and invalid base64 reports
 	// this error, and never the base64 one.

--- a/xmldsig1/retrieval_method.go
+++ b/xmldsig1/retrieval_method.go
@@ -141,9 +141,10 @@ func prepareRetrievalMethod(ctx context.Context, cfg *verifierConfig, doc *heliu
 		}
 		_, _, _, sameDocument := referenceURIForm(uri)
 		runtime := transformRuntime{
-			parser:          cfg.parser(),
-			xsltTransformer: cfg.xsltTransformer,
-			external:        !sameDocument,
+			parser:              cfg.parser(),
+			xsltTransformer:     cfg.xsltTransformer,
+			external:            !sameDocument,
+			maxXPathFilterNodes: cfg.maxXPathFilterNodesLimit(),
 		}
 		initialKind := transformValueOctets
 		if sameDocument {
@@ -202,9 +203,10 @@ func processRetrievalMethod(ctx context.Context, budget *verifyBudget, cfg *veri
 	steps := state.steps
 	_, wholeDoc, includeComments, sameDocument := referenceURIForm(uri)
 	runtime := transformRuntime{
-		parser:          cfg.parser(),
-		xsltTransformer: cfg.xsltTransformer,
-		external:        !sameDocument,
+		parser:              cfg.parser(),
+		xsltTransformer:     cfg.xsltTransformer,
+		external:            !sameDocument,
+		maxXPathFilterNodes: cfg.maxXPathFilterNodesLimit(),
 	}
 
 	// An external URI (not one of the four same-document forms) is dereferenced

--- a/xmldsig1/transform_pipeline.go
+++ b/xmldsig1/transform_pipeline.go
@@ -68,9 +68,17 @@ type transformRuntime struct {
 	xsltTransformer XSLTTransformer
 	signature       *helium.Element
 
-	allowEnveloped bool
-	signing        bool
-	external       bool
+	allowEnveloped      bool
+	signing             bool
+	external            bool
+	maxXPathFilterNodes int
+}
+
+func (r transformRuntime) xpathFilterNodeLimit() int {
+	if r.maxXPathFilterNodes == 0 {
+		return defaultMaxXPathFilterNodes
+	}
+	return r.maxXPathFilterNodes
 }
 
 func newNodeSetTransformValue(nodes *nodeSetValue) transformValue {
@@ -317,7 +325,7 @@ func executeTransformPipeline(ctx context.Context, runtime transformRuntime, ini
 			}
 			value = newOctetTransformValue(octets)
 		case TransformXPath:
-			nodes, err := materializeNodeSet(ctx, value.nodes)
+			nodes, err := materializeNodeSet(ctx, value.nodes, runtime.xpathFilterNodeLimit())
 			if err != nil {
 				return nil, fmt.Errorf("transform %d (%s): %w", i, step.algorithm, err)
 			}
@@ -325,7 +333,7 @@ func executeTransformPipeline(ctx context.Context, runtime transformRuntime, ini
 			if hereNode != nil && hereNode.OwnerDocument() != nodes.doc {
 				hereNode = nil
 			}
-			filtered, err := applyXPathFilter(ctx, nodes.nodes, xpathFilter{expr: contract.xpath, ns: step.xpathNS, hereNode: hereNode})
+			filtered, err := applyXPathFilter(ctx, nodes.nodes, xpathFilter{expr: contract.xpath, ns: step.xpathNS, hereNode: hereNode}, runtime.xpathFilterNodeLimit())
 			if err != nil {
 				return nil, fmt.Errorf("transform %d (%s): %w", i, step.algorithm, err)
 			}
@@ -374,7 +382,7 @@ func convertTransformValue(ctx context.Context, runtime transformRuntime, value 
 			}
 			return transformValue{}, fmt.Errorf("%w: octet input cannot be parsed for transform %d (%s): %v", ErrUnsupportedTransform, consumerIndex, consumerAlgorithm, err)
 		}
-		docNodes, err := collectConvertedDocumentNodes(ctx, doc, consumerAlgorithm)
+		docNodes, err := collectConvertedDocumentNodes(ctx, doc, consumerAlgorithm, runtime.xpathFilterNodeLimit())
 		if err != nil {
 			return transformValue{}, err
 		}
@@ -391,17 +399,20 @@ func convertTransformValue(ctx context.Context, runtime transformRuntime, value 
 	}
 }
 
-func materializeNodeSet(ctx context.Context, value *nodeSetValue) (*nodeSetValue, error) {
+func materializeNodeSet(ctx context.Context, value *nodeSetValue, maxXPathFilterNodes int) (*nodeSetValue, error) {
 	if value == nil || value.doc == nil {
 		return nil, fmt.Errorf("%w: transform node-set has no owning document", ErrUnsupportedTransform)
 	}
 	if value.materialized {
+		if err := checkXPathFilterNodeLimit(ctx, len(value.nodes), maxXPathFilterNodes); err != nil {
+			return nil, err
+		}
 		return value, nil
 	}
 	if value.origin == nil || value.origin.target == nil {
 		return nil, fmt.Errorf("%w: transform node-set has no reference origin", ErrUnsupportedTransform)
 	}
-	nodes, err := originNodes(ctx, value.origin)
+	nodes, err := originNodes(ctx, value.origin, maxXPathFilterNodes)
 	if err != nil {
 		return nil, err
 	}
@@ -428,11 +439,11 @@ func materializeNodeSet(ctx context.Context, value *nodeSetValue) (*nodeSetValue
 // filter drops nodes one at a time and may keep an element whose parent it
 // dropped — so every element carries its complete namespace axis here
 // (collectSubtreeNodes), in place of the reduced canonicalization set.
-func originNodes(ctx context.Context, origin *referenceNodeSetOrigin) ([]helium.Node, error) {
+func originNodes(ctx context.Context, origin *referenceNodeSetOrigin, maxXPathFilterNodes int) ([]helium.Node, error) {
 	if origin.wholeDoc {
-		return collectDocumentNodes(ctx, origin.doc)
+		return collectDocumentNodesLimited(ctx, origin.doc, maxXPathFilterNodes)
 	}
-	return collectSubtreeNodes(ctx, origin.target)
+	return collectSubtreeNodesLimited(ctx, origin.target, maxXPathFilterNodes)
 }
 
 // removeCommentNodes drops every comment from a node-set, implementing the

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -217,14 +217,7 @@ func collectDocumentNodesLimited(ctx context.Context, doc *helium.Document, maxN
 	for c := range helium.Children(doc) {
 		switch c.Type() {
 		case helium.ElementNode:
-			remaining := maxNodes
-			if remaining > 0 {
-				remaining -= len(set.nodes)
-				if remaining == 0 {
-					return nil, checkXPathFilterNodeLimit(ctx, maxNodes+1, maxNodes)
-				}
-			}
-			sub, err := collectSubtreeNodesLimited(ctx, c, remaining)
+			sub, err := collectSubtreeNodesLimitedAtOffset(ctx, c, maxNodes, len(set.nodes))
 			if err != nil {
 				return nil, err
 			}
@@ -779,7 +772,13 @@ func collectSubtreeNodes(ctx context.Context, n helium.Node) ([]helium.Node, err
 // namespace-node wrapper. Rejecting a namespace-heavy input therefore does not
 // first materialize the work being bounded.
 func collectSubtreeNodesLimited(ctx context.Context, n helium.Node, maxNodes int) ([]helium.Node, error) {
-	c := &subtreeCollector{nodeSet: nodeSet{maxNodes: maxNodes}, fullAxis: true}
+	return collectSubtreeNodesLimitedAtOffset(ctx, n, maxNodes, 0)
+}
+
+// collectSubtreeNodesLimitedAtOffset applies the absolute maxNodes cap after
+// accounting for nodeOffset members already collected outside the subtree.
+func collectSubtreeNodesLimitedAtOffset(ctx context.Context, n helium.Node, maxNodes, nodeOffset int) ([]helium.Node, error) {
+	c := &subtreeCollector{nodeSet: nodeSet{maxNodes: maxNodes, nodeOffset: nodeOffset}, fullAxis: true}
 	if err := c.collect(ctx, n); err != nil {
 		return nil, err
 	}
@@ -891,8 +890,9 @@ func (p *ctxPoll) charge(ctx context.Context, n int) error {
 // element's or a whole subtree's worth of work inside one unpolled span.
 type nodeSet struct {
 	ctxPoll
-	nodes    []helium.Node
-	maxNodes int
+	nodes      []helium.Node
+	maxNodes   int // Absolute cap reported to the caller.
+	nodeOffset int // Members collected before this node set.
 }
 
 func (s *nodeSet) add(ctx context.Context, n helium.Node) error {
@@ -913,10 +913,14 @@ func (s *nodeSet) addNamespace(ctx context.Context, ns *helium.Namespace, elem *
 }
 
 func (s *nodeSet) beforeAdd(ctx context.Context, n int) error {
-	if s.maxNodes <= 0 || n <= s.maxNodes-len(s.nodes) {
+	if s.maxNodes <= 0 {
 		return nil
 	}
-	return checkXPathFilterNodeLimit(ctx, len(s.nodes)+n, s.maxNodes)
+	remaining := s.maxNodes - s.nodeOffset
+	if remaining >= len(s.nodes) && n <= remaining-len(s.nodes) {
+		return nil
+	}
+	return xpathFilterNodeLimitExceeded(ctx, s.maxNodes)
 }
 
 // addAll appends nodes a poll interval at a time, so the span between two polls
@@ -944,13 +948,17 @@ func (s *nodeSet) addAll(ctx context.Context, nodes []helium.Node) error {
 }
 
 func checkXPathFilterNodeLimit(ctx context.Context, members, maxNodes int) error {
+	if maxNodes > 0 && members > maxNodes {
+		return xpathFilterNodeLimitExceeded(ctx, maxNodes)
+	}
+	return ctx.Err()
+}
+
+func xpathFilterNodeLimitExceeded(ctx context.Context, maxNodes int) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if maxNodes > 0 && members > maxNodes {
-		return fmt.Errorf("%w: XPath filter input exceeds %d node-set members", ErrResourceLimitExceeded, maxNodes)
-	}
-	return nil
+	return fmt.Errorf("%w: XPath filter input exceeds %d node-set members", ErrResourceLimitExceeded, maxNodes)
 }
 
 func (c *subtreeCollector) collect(ctx context.Context, n helium.Node) error {
@@ -1007,7 +1015,7 @@ func (c *subtreeCollector) seedRootBinding(ctx context.Context, ns *helium.Names
 	if _, exists := c.scope[prefix]; !exists {
 		// The root itself is the one pending member not represented in scope.
 		if c.maxNodes > 0 {
-			if err := checkXPathFilterNodeLimit(ctx, len(c.nodes)+1+len(c.scope)+1, c.maxNodes); err != nil {
+			if err := c.beforeAdd(ctx, 1+len(c.scope)+1); err != nil {
 				return err
 			}
 		}
@@ -1030,7 +1038,7 @@ func (c *subtreeCollector) walk(ctx context.Context, n helium.Node, root bool) e
 		if !root {
 			remaining := -1
 			if c.maxNodes > 0 {
-				remaining = c.maxNodes - len(c.nodes)
+				remaining = c.maxNodes - c.nodeOffset - len(c.nodes)
 			}
 			var err error
 			changed, err = c.enter(ctx, elem, remaining)
@@ -1135,7 +1143,7 @@ func (c *subtreeCollector) enter(ctx context.Context, elem *helium.Element, rema
 		prefix := ns.Prefix()
 		if prefix != lexicon.PrefixXML && !seen.contains(prefix) {
 			if remaining >= 0 && pendingMembers >= remaining {
-				return checkXPathFilterNodeLimit(ctx, len(c.nodes)+pendingMembers+1, c.maxNodes)
+				return c.beforeAdd(ctx, pendingMembers+1)
 			}
 			if err := c.charge(ctx, 1); err != nil {
 				return err

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -990,7 +990,11 @@ func (c *subtreeCollector) seedRootScope(ctx context.Context, elem *helium.Eleme
 	}
 
 	for _, anc := range slices.Backward(chain) {
-		for _, ns := range anc.Namespaces() {
+		for i := 0; ; i++ {
+			ns, ok := domutil.NamespaceDeclarationAt(anc, i)
+			if !ok {
+				break
+			}
 			if err := c.seedRootBinding(ctx, ns); err != nil {
 				return err
 			}
@@ -1049,10 +1053,13 @@ func (c *subtreeCollector) walk(ctx context.Context, n helium.Node, root bool) e
 		if err := c.appendNamespaceNodes(ctx, elem, root, changed); err != nil {
 			return err
 		}
-		for _, attr := range elem.Attributes() {
-			if err := c.add(ctx, attr); err != nil {
-				return err
-			}
+		var attrErr error
+		elem.ForEachAttribute(func(attr *helium.Attribute) bool {
+			attrErr = c.add(ctx, attr)
+			return attrErr == nil
+		})
+		if attrErr != nil {
+			return attrErr
 		}
 	}
 
@@ -1153,7 +1160,11 @@ func (c *subtreeCollector) enter(ctx context.Context, elem *helium.Element, rema
 		changed = c.bind(ns, changed, &seen)
 		return nil
 	}
-	for _, ns := range elem.Namespaces() {
+	for i := 0; ; i++ {
+		ns, ok := domutil.NamespaceDeclarationAt(elem, i)
+		if !ok {
+			break
+		}
 		if err := bind(ns); err != nil {
 			return nil, err
 		}

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -209,11 +209,22 @@ func canonicalizeNodeSetMode(mode c14n.Mode, comments bool, nodes []helium.Node,
 // when a transform needs explicit node membership. The materializer removes
 // comments for a comment-excluding Reference form before applying that transform.
 func collectDocumentNodes(ctx context.Context, doc *helium.Document) ([]helium.Node, error) {
-	var set nodeSet
+	return collectDocumentNodesLimited(ctx, doc, -1)
+}
+
+func collectDocumentNodesLimited(ctx context.Context, doc *helium.Document, maxNodes int) ([]helium.Node, error) {
+	set := nodeSet{maxNodes: maxNodes}
 	for c := range helium.Children(doc) {
 		switch c.Type() {
 		case helium.ElementNode:
-			sub, err := collectSubtreeNodes(ctx, c)
+			remaining := maxNodes
+			if remaining > 0 {
+				remaining -= len(set.nodes)
+				if remaining == 0 {
+					return nil, checkXPathFilterNodeLimit(ctx, maxNodes+1, maxNodes)
+				}
+			}
+			sub, err := collectSubtreeNodesLimited(ctx, c, remaining)
 			if err != nil {
 				return nil, err
 			}
@@ -240,12 +251,12 @@ func collectDocumentNodes(ctx context.Context, doc *helium.Document) ([]helium.N
 // Those two are the only node-set consumers a parse can feed: validateTransformSteps
 // rejects an enveloped-signature transform after an octet boundary, and base64
 // consumes a node-set through its own text-only conversion.
-func collectConvertedDocumentNodes(ctx context.Context, doc *helium.Document, consumerAlgorithm string) ([]helium.Node, error) {
+func collectConvertedDocumentNodes(ctx context.Context, doc *helium.Document, consumerAlgorithm string, maxXPathFilterNodes int) ([]helium.Node, error) {
 	mode, _, err := resolveC14NMode(consumerAlgorithm)
 	if err != nil {
 		// Not one of the six canonicalization URIs, so the consumer is the XPath
 		// filter and the set it is evaluated over must carry every namespace node.
-		return collectDocumentNodes(ctx, doc)
+		return collectDocumentNodesLimited(ctx, doc, maxXPathFilterNodes)
 	}
 	return collectCanonicalizationDocumentNodes(ctx, doc, mode)
 }
@@ -288,6 +299,11 @@ func collectCanonicalizationDocumentNodes(ctx context.Context, doc *helium.Docum
 // same-document reference — while still finite, so a legitimate signature is
 // never rejected for exceeding it.
 const defaultXPathOpLimit = 100_000_000
+
+// defaultMaxXPathFilterNodes bounds the complete XPath namespace-axis node set
+// collected before one XMLDSig XPath filter is evaluated. Unlike the reduced
+// canonicalization set, this set can grow quadratically with a small document.
+const defaultMaxXPathFilterNodes = 65_536
 
 // hereFunction implements the XMLDSig here() function (core §6.6.3.1): it returns
 // a node-set containing the single element that bears the XPath expression — the
@@ -379,7 +395,12 @@ func compileXPathFilterExpression(expr string, eval xpath1.Evaluator) (*xpath1.E
 // execution starts. An evaluation error is fail-closed as
 // ErrUnsupportedTransform while retaining the evaluator error, so a reference
 // never digests an unfiltered node-set and callers can still detect cancellation.
-func applyXPathFilter(ctx context.Context, nodes []helium.Node, f xpathFilter) ([]helium.Node, error) {
+func applyXPathFilter(ctx context.Context, nodes []helium.Node, f xpathFilter, maxNodes int) ([]helium.Node, error) {
+	if maxNodes > 0 && len(nodes) > maxNodes {
+		if err := checkXPathFilterNodeLimit(ctx, len(nodes), maxNodes); err != nil {
+			return nil, err
+		}
+	}
 	eval := newDSigXPathEvaluator(f.ns, f.hereNode, defaultXPathOpLimit)
 	kept := make([]helium.Node, 0, len(nodes))
 	for _, n := range nodes {
@@ -749,7 +770,14 @@ func resolveC14NMode(method string) (c14n.Mode, bool, error) {
 // A node set that goes straight to c14n unfiltered is built by
 // collectCanonicalizationNodes, which is linear in the document.
 func collectSubtreeNodes(ctx context.Context, n helium.Node) ([]helium.Node, error) {
-	c := &subtreeCollector{fullAxis: true}
+	return collectSubtreeNodesLimited(ctx, n, -1)
+}
+
+// collectSubtreeNodesLimited is collectSubtreeNodes with a member cap. It
+// checks the cap before allocating each namespace-node wrapper, so rejecting a
+// namespace-heavy input does not first materialize the work being bounded.
+func collectSubtreeNodesLimited(ctx context.Context, n helium.Node, maxNodes int) ([]helium.Node, error) {
+	c := &subtreeCollector{nodeSet: nodeSet{maxNodes: maxNodes}, fullAxis: true}
 	if err := c.collect(ctx, n); err != nil {
 		return nil, err
 	}
@@ -861,12 +889,32 @@ func (p *ctxPoll) charge(ctx context.Context, n int) error {
 // element's or a whole subtree's worth of work inside one unpolled span.
 type nodeSet struct {
 	ctxPoll
-	nodes []helium.Node
+	nodes    []helium.Node
+	maxNodes int
 }
 
 func (s *nodeSet) add(ctx context.Context, n helium.Node) error {
+	if err := s.beforeAdd(ctx, 1); err != nil {
+		return err
+	}
 	s.nodes = append(s.nodes, n)
 	return s.charge(ctx, 1)
+}
+
+// addNamespace checks the member cap before allocating the wrapper it adds.
+func (s *nodeSet) addNamespace(ctx context.Context, ns *helium.Namespace, elem *helium.Element) error {
+	if err := s.beforeAdd(ctx, 1); err != nil {
+		return err
+	}
+	s.nodes = append(s.nodes, helium.NewNamespaceNodeWrapper(ns, elem))
+	return s.charge(ctx, 1)
+}
+
+func (s *nodeSet) beforeAdd(ctx context.Context, n int) error {
+	if s.maxNodes <= 0 || n <= s.maxNodes-len(s.nodes) {
+		return nil
+	}
+	return checkXPathFilterNodeLimit(ctx, len(s.nodes)+n, s.maxNodes)
 }
 
 // addAll appends nodes a poll interval at a time, so the span between two polls
@@ -878,6 +926,9 @@ func (s *nodeSet) add(ctx context.Context, n helium.Node) error {
 // members, while growing once leaves the copy within a percent of it at every
 // size.
 func (s *nodeSet) addAll(ctx context.Context, nodes []helium.Node) error {
+	if err := s.beforeAdd(ctx, len(nodes)); err != nil {
+		return err
+	}
 	s.nodes = slices.Grow(s.nodes, len(nodes))
 	for len(nodes) > 0 {
 		n := min(len(nodes), ctxPollInterval)
@@ -886,6 +937,16 @@ func (s *nodeSet) addAll(ctx context.Context, nodes []helium.Node) error {
 			return err
 		}
 		nodes = nodes[n:]
+	}
+	return nil
+}
+
+func checkXPathFilterNodeLimit(ctx context.Context, members, maxNodes int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if maxNodes > 0 && members > maxNodes {
+		return fmt.Errorf("%w: XPath filter input exceeds %d node-set members", ErrResourceLimitExceeded, maxNodes)
 	}
 	return nil
 }
@@ -1064,7 +1125,7 @@ func (c *subtreeCollector) appendNamespaceNodes(ctx context.Context, elem *heliu
 			if prefix == lexicon.PrefixXML {
 				continue
 			}
-			if err := c.add(ctx, helium.NewNamespaceNodeWrapper(ns, elem)); err != nil {
+			if err := c.addNamespace(ctx, ns, elem); err != nil {
 				return err
 			}
 		}
@@ -1134,7 +1195,7 @@ func (c *subtreeCollector) emitNamespace(ctx context.Context, elem *helium.Eleme
 		return nil
 	}
 	emitted.add(prefix)
-	return c.add(ctx, helium.NewNamespaceNodeWrapper(ns, elem))
+	return c.addNamespace(ctx, ns, elem)
 }
 
 // referenceURIForm classifies a same-document Reference URI into the node-set

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -774,8 +774,9 @@ func collectSubtreeNodes(ctx context.Context, n helium.Node) ([]helium.Node, err
 }
 
 // collectSubtreeNodesLimited is collectSubtreeNodes with a member cap. It
-// checks the cap before allocating each namespace-node wrapper, so rejecting a
-// namespace-heavy input does not first materialize the work being bounded.
+// checks the cap before recording inherited root bindings or allocating their
+// namespace-node wrappers, so rejecting a namespace-heavy input does not first
+// materialize the work being bounded.
 func collectSubtreeNodesLimited(ctx context.Context, n helium.Node, maxNodes int) ([]helium.Node, error) {
 	c := &subtreeCollector{nodeSet: nodeSet{maxNodes: maxNodes}, fullAxis: true}
 	if err := c.collect(ctx, n); err != nil {
@@ -959,19 +960,62 @@ func (c *subtreeCollector) collect(ctx context.Context, n helium.Node) error {
 	}
 	c.scope = make(map[string]*helium.Namespace)
 	if elem, ok := helium.AsNode[*helium.Element](n); ok {
-		// Seed the scope with the subtree root's own in-scope axis, so bindings
-		// declared ABOVE the root are carried in. Every deeper element updates
-		// this map incrementally instead of walking its ancestors again. The
-		// seeding is charged like an emission: the root goes on to emit one
-		// namespace node per binding seeded here, so the two are the same size.
-		for prefix, ns := range domutil.InScopeNamespaces(elem, true) {
-			c.scope[prefix] = ns
-			if err := c.charge(ctx, 1); err != nil {
-				return err
-			}
+		if err := c.seedRootScope(ctx, elem); err != nil {
+			return err
 		}
 	}
 	return c.walk(ctx, n, true)
+}
+
+// seedRootScope collects the subtree root's in-scope namespace axis. Bindings
+// declared above the root must be carried in, but each distinct binding will
+// become a namespace-node member after the root itself is added. Enforce that
+// future cost before growing scope, so a small member limit cannot first build
+// an arbitrarily large inherited-binding map.
+func (c *subtreeCollector) seedRootScope(ctx context.Context, elem *helium.Element) error {
+	var chain []*helium.Element
+	for n := helium.Node(elem); n != nil; n = n.Parent() {
+		if anc, ok := helium.AsNode[*helium.Element](n); ok {
+			chain = append(chain, anc)
+		}
+	}
+
+	for _, anc := range slices.Backward(chain) {
+		for _, ns := range anc.Namespaces() {
+			if err := c.seedRootBinding(ctx, ns); err != nil {
+				return err
+			}
+		}
+		if ns := anc.Namespace(); ns != nil {
+			prefix := ns.Prefix()
+			if _, ok := c.scope[prefix]; !ok {
+				if err := c.seedRootBinding(ctx, ns); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *subtreeCollector) seedRootBinding(ctx context.Context, ns *helium.Namespace) error {
+	prefix := ns.Prefix()
+	if prefix == lexicon.PrefixXML {
+		return nil
+	}
+	if _, exists := c.scope[prefix]; !exists {
+		// The root itself is the one pending member not represented in scope.
+		if c.maxNodes > 0 {
+			if err := checkXPathFilterNodeLimit(ctx, len(c.nodes)+1+len(c.scope)+1, c.maxNodes); err != nil {
+				return err
+			}
+		}
+		if err := c.charge(ctx, 1); err != nil {
+			return err
+		}
+	}
+	c.scope[prefix] = ns
+	return nil
 }
 
 func (c *subtreeCollector) walk(ctx context.Context, n helium.Node, root bool) error {

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -774,9 +774,10 @@ func collectSubtreeNodes(ctx context.Context, n helium.Node) ([]helium.Node, err
 }
 
 // collectSubtreeNodesLimited is collectSubtreeNodes with a member cap. It
-// checks the cap before recording inherited root bindings or allocating their
-// namespace-node wrappers, so rejecting a namespace-heavy input does not first
-// materialize the work being bounded.
+// checks the cap before recording inherited root bindings, before growing a
+// child's scope past its remaining member budget, or before allocating a
+// namespace-node wrapper. Rejecting a namespace-heavy input therefore does not
+// first materialize the work being bounded.
 func collectSubtreeNodesLimited(ctx context.Context, n helium.Node, maxNodes int) ([]helium.Node, error) {
 	c := &subtreeCollector{nodeSet: nodeSet{maxNodes: maxNodes}, fullAxis: true}
 	if err := c.collect(ctx, n); err != nil {
@@ -1027,7 +1028,15 @@ func (c *subtreeCollector) walk(ctx context.Context, n helium.Node, root bool) e
 	var changed []nsBinding
 	if isElem {
 		if !root {
-			changed = c.enter(elem)
+			remaining := -1
+			if c.maxNodes > 0 {
+				remaining = c.maxNodes - len(c.nodes)
+			}
+			var err error
+			changed, err = c.enter(ctx, elem, remaining)
+			if err != nil {
+				return err
+			}
 		}
 		if err := c.appendNamespaceNodes(ctx, elem, root, changed); err != nil {
 			return err
@@ -1109,22 +1118,46 @@ func (s *prefixSet) add(prefix string) {
 }
 
 // enter applies elem's namespace declarations to the running scope and returns
-// the bindings it replaced, one entry per prefix touched. The rule matches
-// domutil.InScopeNamespaces exactly — declarations first, then the element's own
-// active namespace when nothing already binds its prefix — so the incremental
-// scope equals the ancestor-chain walk that function performs.
-func (c *subtreeCollector) enter(elem *helium.Element) []nsBinding {
+// the bindings it replaced, one entry per prefix touched. It charges each new
+// non-xml prefix before growing the scope: that prefix can become a namespace
+// node, so remaining bounds the work even when the eventual node-set append
+// would reject it. A negative remaining value leaves the member count unlimited.
+//
+// The binding rule matches domutil.InScopeNamespaces exactly — declarations
+// first, then the element's own active namespace when nothing already binds its
+// prefix — so the incremental scope equals the ancestor-chain walk that function
+// performs.
+func (c *subtreeCollector) enter(ctx context.Context, elem *helium.Element, remaining int) ([]nsBinding, error) {
 	var seen prefixSet
 	var changed []nsBinding
-	for _, ns := range elem.Namespaces() {
+	pendingMembers := 0
+	bind := func(ns *helium.Namespace) error {
+		prefix := ns.Prefix()
+		if prefix != lexicon.PrefixXML && !seen.contains(prefix) {
+			if remaining >= 0 && pendingMembers >= remaining {
+				return checkXPathFilterNodeLimit(ctx, len(c.nodes)+pendingMembers+1, c.maxNodes)
+			}
+			if err := c.charge(ctx, 1); err != nil {
+				return err
+			}
+			pendingMembers++
+		}
 		changed = c.bind(ns, changed, &seen)
+		return nil
+	}
+	for _, ns := range elem.Namespaces() {
+		if err := bind(ns); err != nil {
+			return nil, err
+		}
 	}
 	if ns := elem.Namespace(); ns != nil {
 		if _, ok := c.scope[ns.Prefix()]; !ok {
-			changed = c.bind(ns, changed, &seen)
+			if err := bind(ns); err != nil {
+				return nil, err
+			}
 		}
 	}
-	return changed
+	return changed, nil
 }
 
 // bind records the binding prefix had before ns replaced it, unless this element

--- a/xmldsig1/transforms_nodeset_internal_test.go
+++ b/xmldsig1/transforms_nodeset_internal_test.go
@@ -310,6 +310,40 @@ func TestNodeSetCollectionCost(t *testing.T) {
 	}
 }
 
+// cancelOnErrContext cancels itself on a selected Err call. That makes a
+// cancellation at a collector poll deterministic without coupling the test to
+// scheduler timing.
+type cancelOnErrContext struct {
+	context.Context
+	cancel   context.CancelFunc
+	cancelAt int
+	calls    int
+}
+
+func (c *cancelOnErrContext) Err() error {
+	c.calls++
+	if c.calls == c.cancelAt {
+		c.cancel()
+	}
+	return c.Context.Err()
+}
+
+// TestNodeSetCollectionCancellationDuringChildScope pins that namespace scope
+// entry polls while it binds a child's declarations. The first Err call starts
+// collection; the second comes from the periodic poll inside the dense child.
+func TestNodeSetCollectionCancellationDuringChildScope(t *testing.T) {
+	root := costDocument(t, declDenseDoc(costDeclarations))
+	base, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	ctx := &cancelOnErrContext{Context: base, cancel: cancel, cancelAt: 2}
+	c := &subtreeCollector{fullAxis: true}
+
+	err := c.collect(ctx, root)
+	require.ErrorIs(t, err, context.Canceled)
+	require.LessOrEqual(t, len(c.scope), ctxPollInterval,
+		"collector bound %d child declarations before observing cancellation", len(c.scope))
+}
+
 // emissionPrefixes is how many prefixes the emission-cost documents put in scope
 // and carry on attributes, and emissionOwnDeclarations is how many declarations
 // of its own the CONTROL document's element adds on top.

--- a/xmldsig1/transforms_nodeset_internal_test.go
+++ b/xmldsig1/transforms_nodeset_internal_test.go
@@ -314,18 +314,34 @@ func TestNodeSetCollectionCost(t *testing.T) {
 // cancellation at a collector poll deterministic without coupling the test to
 // scheduler timing.
 type cancelOnErrContext struct {
-	context.Context
-	cancel   context.CancelFunc
+	done     chan struct{}
 	cancelAt int
 	calls    int
+}
+
+func (*cancelOnErrContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c *cancelOnErrContext) Done() <-chan struct{} {
+	return c.done
 }
 
 func (c *cancelOnErrContext) Err() error {
 	c.calls++
 	if c.calls == c.cancelAt {
-		c.cancel()
+		close(c.done)
 	}
-	return c.Context.Err()
+	select {
+	case <-c.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (*cancelOnErrContext) Value(any) any {
+	return nil
 }
 
 // TestNodeSetCollectionCancellationDuringChildScope pins that namespace scope
@@ -333,9 +349,7 @@ func (c *cancelOnErrContext) Err() error {
 // collection; the second comes from the periodic poll inside the dense child.
 func TestNodeSetCollectionCancellationDuringChildScope(t *testing.T) {
 	root := costDocument(t, declDenseDoc(costDeclarations))
-	base, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	ctx := &cancelOnErrContext{Context: base, cancel: cancel, cancelAt: 2}
+	ctx := &cancelOnErrContext{done: make(chan struct{}), cancelAt: 2}
 	c := &subtreeCollector{fullAxis: true}
 
 	err := c.collect(ctx, root)

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -351,10 +351,11 @@ func prepareReferenceForVerification(cfg *verifierConfig, doc *helium.Document, 
 	}
 
 	runtime := transformRuntime{
-		parser:          cfg.parser(),
-		xsltTransformer: cfg.xsltTransformer,
-		allowEnveloped:  allowEnveloped,
-		external:        initialKind == transformValueOctets,
+		parser:              cfg.parser(),
+		xsltTransformer:     cfg.xsltTransformer,
+		allowEnveloped:      allowEnveloped,
+		external:            initialKind == transformValueOctets,
+		maxXPathFilterNodes: cfg.maxXPathFilterNodesLimit(),
 	}
 	if _, err := validateTransformSteps(runtime, initialKind, steps); err != nil {
 		return nil, err
@@ -429,10 +430,11 @@ func canonicalizeReference(ctx context.Context, cfg *verifierConfig, doc *helium
 // URI forms and the general XPointer resolver.
 func applyReferenceTransforms(ctx context.Context, cfg *verifierConfig, doc *helium.Document, sigElem, target *helium.Element, wholeDoc, includeComments bool, steps []transformStep) ([]byte, error) {
 	runtime := transformRuntime{
-		parser:          cfg.parser(),
-		xsltTransformer: cfg.xsltTransformer,
-		signature:       sigElem,
-		allowEnveloped:  true,
+		parser:              cfg.parser(),
+		xsltTransformer:     cfg.xsltTransformer,
+		signature:           sigElem,
+		allowEnveloped:      true,
+		maxXPathFilterNodes: cfg.maxXPathFilterNodesLimit(),
 	}
 	initial := newReferenceNodeSetValue(doc, target, sigElem, wholeDoc, includeComments, nil)
 	return executeTransformPipeline(ctx, runtime, initial, steps)
@@ -488,9 +490,10 @@ func resolveExternalReference(ctx context.Context, cfg *verifierConfig, doc *hel
 		}
 	}
 	runtime := transformRuntime{
-		parser:          cfg.parser(),
-		xsltTransformer: cfg.xsltTransformer,
-		external:        true,
+		parser:              cfg.parser(),
+		xsltTransformer:     cfg.xsltTransformer,
+		external:            true,
+		maxXPathFilterNodes: cfg.maxXPathFilterNodesLimit(),
 	}
 
 	joined, err := joinReferenceURI(doc.URL(), ref.uri)

--- a/xmldsig1/verify_nodeset_limits_test.go
+++ b/xmldsig1/verify_nodeset_limits_test.go
@@ -266,6 +266,77 @@ func xpathFilterRetrievalDoc(decls, pad int) string {
 		1)
 }
 
+// xpathFilterRetrievalMembers is the exact number of members in the <bulk>
+// subtree's XPath input node-set: the bulk element, its Id attribute and
+// inherited namespace axis, then each child element, attribute, and complete
+// namespace axis.
+func xpathFilterRetrievalMembers(decls, pad int) int {
+	return 2 + decls + pad*(decls+2)
+}
+
+func TestVerifyXPathFilterNodeLimit(t *testing.T) {
+	const (
+		decls = 3
+		pad   = 4
+	)
+	key := generateRSAKey(t)
+	src := xpathFilterRetrievalDoc(decls, pad)
+	limit := xpathFilterRetrievalMembers(decls, pad)
+
+	t.Run("exact boundary", func(t *testing.T) {
+		doc := mustParseXML(t, src)
+		_, err := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+			MaxXPathFilterNodes(limit).
+			Verify(t.Context(), doc)
+		require.ErrorIs(t, err, xmldsig1.ErrInvalidKeyInfo)
+		require.NotErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+	})
+
+	t.Run("one member over", func(t *testing.T) {
+		doc := mustParseXML(t, src)
+		ks := &recordingKeySource{key: &key.PublicKey}
+		_, err := xmldsig1.NewVerifier(ks).
+			MaxXPathFilterNodes(limit-1).
+			Verify(t.Context(), doc)
+		require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+		require.Contains(t, err.Error(), fmt.Sprintf("exceeds %d node-set members", limit-1))
+		require.False(t, ks.called, "the XPath input limit must fire before key resolution")
+	})
+
+	t.Run("cancelled context wins", func(t *testing.T) {
+		doc := mustParseXML(t, src)
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+			MaxXPathFilterNodes(limit-1).
+			Verify(ctx, doc)
+		require.ErrorIs(t, err, context.Canceled)
+		require.NotErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+	})
+}
+
+// TestVerifyXPathFilterNodeLimitAllocation keeps the default bound tied to its
+// purpose: this compact namespace-heavy document would otherwise materialize
+// over 1.6 million namespace-axis members before authentication. The default
+// refuses it after 65,536 members without allocating the rejected wrapper.
+func TestVerifyXPathFilterNodeLimitAllocation(t *testing.T) {
+	const maxVerifyAllocation = 32 << 20
+
+	key := generateRSAKey(t)
+	src := xpathFilterRetrievalDoc(800, 2000)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	for _, candidate := range []xmldsig1.Verifier{verifier, verifier.MaxXPathFilterNodes(0)} {
+		doc := mustParseXML(t, src)
+		_, err := candidate.Verify(t.Context(), doc)
+		require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+	}
+
+	allocated := verifyAllocatedBytes(t, verifier, src)
+	t.Logf("default XPath input limit allocated %d bytes for a %d-byte fixture", allocated, len(src))
+	require.Less(t, allocated, uint64(maxVerifyAllocation),
+		"verifying a %d-byte namespace-heavy document allocated %d bytes", len(src), allocated)
+}
+
 // TestVerifyDeadlineDuringNodeSetConstruction pins that a deadline stops node-set
 // construction while it runs, well before the whole set is built. The
 // document costs seconds of work to canonicalize, so a deadline an order of
@@ -277,7 +348,9 @@ func TestVerifyDeadlineDuringNodeSetConstruction(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 
-	_, err := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).Verify(ctx, doc)
+	_, err := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+		MaxXPathFilterNodes(-1).
+		Verify(ctx, doc)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 

--- a/xmldsig1/verify_nodeset_limits_test.go
+++ b/xmldsig1/verify_nodeset_limits_test.go
@@ -341,6 +341,20 @@ func TestVerifyXPathFilterNodeLimit(t *testing.T) {
 		require.False(t, ks.called, "the XPath input limit must fire before key resolution")
 	})
 
+	t.Run("whole document reports absolute limit after leading comment", func(t *testing.T) {
+		const absoluteLimit = 2
+		src := strings.Replace(xpathFilterRetrievalDoc(0, 0),
+			`<ds:RetrievalMethod URI="#bulk"`, `<ds:RetrievalMethod URI=""`, 1)
+		doc := mustParseXML(t, `<!--leading-->`+src)
+		ks := &recordingKeySource{key: &key.PublicKey}
+		_, err := xmldsig1.NewVerifier(ks).
+			MaxXPathFilterNodes(absoluteLimit).
+			Verify(t.Context(), doc)
+		require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+		require.Contains(t, err.Error(), fmt.Sprintf("exceeds %d node-set members", absoluteLimit))
+		require.False(t, ks.called, "the XPath input limit must fire before key resolution")
+	})
+
 	t.Run("cancelled context wins", func(t *testing.T) {
 		doc := mustParseXML(t, src)
 		ctx, cancel := context.WithCancel(t.Context())

--- a/xmldsig1/verify_nodeset_limits_test.go
+++ b/xmldsig1/verify_nodeset_limits_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xmldsig1"
 	"github.com/stretchr/testify/require"
 )
@@ -64,13 +65,23 @@ func namespaceHeavyDoc(decls, pad int, signedInfoPad bool) string {
 func verifyAllocatedBytes(t *testing.T, verifier xmldsig1.Verifier, src string) uint64 {
 	t.Helper()
 	doc := mustParseXML(t, src)
+	allocated, err := verifyDocumentAllocatedBytes(t, verifier, doc)
+	require.Error(t, err)
+	return allocated
+}
+
+func verifyDocumentAllocatedBytes(
+	t *testing.T,
+	verifier xmldsig1.Verifier,
+	doc *helium.Document,
+) (uint64, error) {
+	t.Helper()
 	var before, after runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&before)
 	_, err := verifier.Verify(t.Context(), doc)
 	runtime.ReadMemStats(&after)
-	require.Error(t, err)
-	return after.TotalAlloc - before.TotalAlloc
+	return after.TotalAlloc - before.TotalAlloc, err
 }
 
 // TestVerifyNamespaceHeavyDocument bounds the memory an unsigned,
@@ -304,6 +315,22 @@ func xpathFilterChildDeclarationDoc(decls int) string {
 		`<bulk Id="bulk"></bulk>`, `<bulk Id="bulk">`+child.String()+`</bulk>`, 1)
 }
 
+// xpathFilterWholeDocumentAttributeDoc puts the attribute-heavy input on the
+// document element and makes the RetrievalMethod select the whole document.
+// The document element consumes the one-member budget before its attributes
+// are visited, while the empty URI avoids an unrelated ID-attribute scan.
+func xpathFilterWholeDocumentAttributeDoc(attrs int) string {
+	var root strings.Builder
+	root.WriteString(`<root`)
+	for i := range attrs {
+		fmt.Fprintf(&root, ` a%d="%d"`, i, i)
+	}
+	root.WriteString(`>`)
+
+	src := strings.Replace(xpathFilterRetrievalDoc(0, 0), `<root>`, root.String(), 1)
+	return strings.Replace(src, `<ds:RetrievalMethod URI="#bulk"`, `<ds:RetrievalMethod URI=""`, 1)
+}
+
 // xpathFilterRetrievalMembers is the exact number of members in the <bulk>
 // subtree's XPath input node-set: the bulk element, its Id attribute and
 // inherited namespace axis, then each child element, attribute, and complete
@@ -395,22 +422,27 @@ func TestVerifyXPathFilterNodeLimitAllocation(t *testing.T) {
 // reject the first namespace without building a map of every declaration.
 func TestVerifyXPathFilterNodeLimitBoundsInheritedScope(t *testing.T) {
 	const (
-		decls               = 20_000
-		maxVerifyAllocation = 2 << 20
+		smallDecls       = 8
+		largeDecls       = 200_000
+		maxScalingGrowth = 256 << 10
 	)
 
 	key := generateRSAKey(t)
-	src := xpathFilterInheritedTargetDoc(decls)
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
 		MaxXPathFilterNodes(1)
-	doc := mustParseXML(t, src)
-	_, err := verifier.Verify(t.Context(), doc)
-	require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+	measure := func(decls int) uint64 {
+		doc := mustParseXML(t, xpathFilterInheritedTargetDoc(decls))
+		allocated, err := verifyDocumentAllocatedBytes(t, verifier, doc)
+		require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+		return allocated
+	}
 
-	allocated := verifyAllocatedBytes(t, verifier, src)
-	t.Logf("limited inherited namespace scope allocated %d bytes for %d declarations", allocated, decls)
-	require.Less(t, allocated, uint64(maxVerifyAllocation),
-		"verifying a document with %d inherited declarations allocated %d bytes", decls, allocated)
+	small := measure(smallDecls)
+	large := measure(largeDecls)
+	t.Logf("limited inherited namespace scope allocated %d bytes for %d declarations and %d bytes for %d",
+		small, smallDecls, large, largeDecls)
+	require.LessOrEqual(t, large, small+uint64(maxScalingGrowth),
+		"declarations beyond the member cap must not add allocation proportional to their count")
 }
 
 // TestVerifyXPathFilterNodeLimitBoundsChildDeclarations pins that a child
@@ -419,22 +451,56 @@ func TestVerifyXPathFilterNodeLimitBoundsInheritedScope(t *testing.T) {
 // bound covers verification and not storage already owned by the input tree.
 func TestVerifyXPathFilterNodeLimitBoundsChildDeclarations(t *testing.T) {
 	const (
-		decls               = 20_000
-		maxVerifyAllocation = 1 << 20
+		smallDecls       = 8
+		largeDecls       = 200_000
+		maxScalingGrowth = 256 << 10
 	)
 
 	key := generateRSAKey(t)
-	src := xpathFilterChildDeclarationDoc(decls)
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
 		MaxXPathFilterNodes(3)
-	doc := mustParseXML(t, src)
-	_, err := verifier.Verify(t.Context(), doc)
-	require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+	measure := func(decls int) uint64 {
+		doc := mustParseXML(t, xpathFilterChildDeclarationDoc(decls))
+		allocated, err := verifyDocumentAllocatedBytes(t, verifier, doc)
+		require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+		return allocated
+	}
 
-	allocated := verifyAllocatedBytes(t, verifier, src)
-	t.Logf("limited child namespace scope allocated %d bytes for %d declarations", allocated, decls)
-	require.Less(t, allocated, uint64(maxVerifyAllocation),
-		"verifying a child with %d declarations allocated %d bytes", decls, allocated)
+	small := measure(smallDecls)
+	large := measure(largeDecls)
+	t.Logf("limited child namespace scope allocated %d bytes for %d declarations and %d bytes for %d",
+		small, smallDecls, large, largeDecls)
+	require.LessOrEqual(t, large, small+uint64(maxScalingGrowth),
+		"declarations beyond the member cap must not add allocation proportional to their count")
+}
+
+// TestVerifyXPathFilterNodeLimitBoundsWholeDocumentAttributes pins that the member
+// cap stops attribute iteration before the complete property list is traversed
+// or copied. The larger fixture exceeds the one-member limit by five orders of
+// magnitude, but verification allocation remains close to the small fixture.
+func TestVerifyXPathFilterNodeLimitBoundsWholeDocumentAttributes(t *testing.T) {
+	const (
+		smallAttrs       = 8
+		largeAttrs       = 200_000
+		maxScalingGrowth = 256 << 10
+	)
+
+	key := generateRSAKey(t)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+		MaxXPathFilterNodes(1)
+	measure := func(attrs int) uint64 {
+		doc := mustParseXML(t, xpathFilterWholeDocumentAttributeDoc(attrs))
+		allocated, err := verifyDocumentAllocatedBytes(t, verifier, doc)
+		require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+		return allocated
+	}
+
+	small := measure(smallAttrs)
+	large := measure(largeAttrs)
+	t.Logf("limited document-element attributes allocated %d bytes for %d attributes and %d bytes for %d",
+		small, smallAttrs, large, largeAttrs)
+	require.LessOrEqual(t, large, small+uint64(maxScalingGrowth),
+		"attributes beyond the member cap must not add allocation proportional to their count")
 }
 
 // TestVerifyDeadlineDuringNodeSetConstruction pins that a deadline stops node-set

--- a/xmldsig1/verify_nodeset_limits_test.go
+++ b/xmldsig1/verify_nodeset_limits_test.go
@@ -266,6 +266,29 @@ func xpathFilterRetrievalDoc(decls, pad int) string {
 		1)
 }
 
+// xpathFilterInheritedTargetDoc keeps the large namespace axis on the selected
+// target's ancestor, outside ds:Signature. This isolates the allocation needed
+// to seed the RetrievalMethod selection from unrelated signature namespace
+// processing.
+func xpathFilterInheritedTargetDoc(decls int) string {
+	var b strings.Builder
+	b.WriteString(`<root><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo>`)
+	b.WriteString(`<ds:CanonicalizationMethod Algorithm="` + xmldsig1.C14N10 + `"/>`)
+	b.WriteString(`<ds:SignatureMethod Algorithm="` + xmldsig1.AlgRSASHA256 + `"/>`)
+	b.WriteString(`<ds:Reference URI=""><ds:DigestMethod Algorithm="` + xmldsig1.DigestSHA256 + `"/>`)
+	b.WriteString(`<ds:DigestValue>AAAA</ds:DigestValue></ds:Reference></ds:SignedInfo>`)
+	b.WriteString(`<ds:SignatureValue>AAAA</ds:SignatureValue><ds:KeyInfo>`)
+	b.WriteString(`<ds:RetrievalMethod URI="#bulk" Type="` + xmldsig1.TypeRawX509Certificate + `">`)
+	b.WriteString(`<ds:Transforms><ds:Transform Algorithm="` + xmldsig1.TransformXPath + `">`)
+	b.WriteString(`<ds:XPath>true()</ds:XPath></ds:Transform></ds:Transforms>`)
+	b.WriteString(`</ds:RetrievalMethod></ds:KeyInfo></ds:Signature><scope`)
+	for i := range decls {
+		fmt.Fprintf(&b, ` xmlns:p%d="urn:example:ns:%d"`, i, i)
+	}
+	b.WriteString(`><bulk Id="bulk"/></scope></root>`)
+	return b.String()
+}
+
 // xpathFilterRetrievalMembers is the exact number of members in the <bulk>
 // subtree's XPath input node-set: the bulk element, its Id attribute and
 // inherited namespace axis, then each child element, attribute, and complete
@@ -335,6 +358,30 @@ func TestVerifyXPathFilterNodeLimitAllocation(t *testing.T) {
 	t.Logf("default XPath input limit allocated %d bytes for a %d-byte fixture", allocated, len(src))
 	require.Less(t, allocated, uint64(maxVerifyAllocation),
 		"verifying a %d-byte namespace-heavy document allocated %d bytes", len(src), allocated)
+}
+
+// TestVerifyXPathFilterNodeLimitBoundsInheritedScope pins that the member cap
+// applies while the subtree root's inherited namespace scope is seeded. With a
+// one-member limit, the root consumes the entire budget, so verification must
+// reject the first namespace without building a map of every declaration.
+func TestVerifyXPathFilterNodeLimitBoundsInheritedScope(t *testing.T) {
+	const (
+		decls               = 20_000
+		maxVerifyAllocation = 2 << 20
+	)
+
+	key := generateRSAKey(t)
+	src := xpathFilterInheritedTargetDoc(decls)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+		MaxXPathFilterNodes(1)
+	doc := mustParseXML(t, src)
+	_, err := verifier.Verify(t.Context(), doc)
+	require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+
+	allocated := verifyAllocatedBytes(t, verifier, src)
+	t.Logf("limited inherited namespace scope allocated %d bytes for %d declarations", allocated, decls)
+	require.Less(t, allocated, uint64(maxVerifyAllocation),
+		"verifying a document with %d inherited declarations allocated %d bytes", decls, allocated)
 }
 
 // TestVerifyDeadlineDuringNodeSetConstruction pins that a deadline stops node-set

--- a/xmldsig1/verify_nodeset_limits_test.go
+++ b/xmldsig1/verify_nodeset_limits_test.go
@@ -289,6 +289,21 @@ func xpathFilterInheritedTargetDoc(decls int) string {
 	return b.String()
 }
 
+// xpathFilterChildDeclarationDoc puts the namespace-heavy input on a child of
+// the selected subtree. The target element and its Id attribute consume two
+// members; the child consumes the third, leaving no budget for its declarations.
+func xpathFilterChildDeclarationDoc(decls int) string {
+	var child strings.Builder
+	child.WriteString(`<wide`)
+	for i := range decls {
+		fmt.Fprintf(&child, ` xmlns:p%d="urn:example:ns:%d"`, i, i)
+	}
+	child.WriteString(`/>`)
+
+	return strings.Replace(xpathFilterRetrievalDoc(0, 0),
+		`<bulk Id="bulk"></bulk>`, `<bulk Id="bulk">`+child.String()+`</bulk>`, 1)
+}
+
 // xpathFilterRetrievalMembers is the exact number of members in the <bulk>
 // subtree's XPath input node-set: the bulk element, its Id attribute and
 // inherited namespace axis, then each child element, attribute, and complete
@@ -382,6 +397,30 @@ func TestVerifyXPathFilterNodeLimitBoundsInheritedScope(t *testing.T) {
 	t.Logf("limited inherited namespace scope allocated %d bytes for %d declarations", allocated, decls)
 	require.Less(t, allocated, uint64(maxVerifyAllocation),
 		"verifying a document with %d inherited declarations allocated %d bytes", decls, allocated)
+}
+
+// TestVerifyXPathFilterNodeLimitBoundsChildDeclarations pins that a child
+// cannot allocate scope bookkeeping for declarations that exceed the remaining
+// member budget. The DOM is parsed before the allocation measurement, so the
+// bound covers verification and not storage already owned by the input tree.
+func TestVerifyXPathFilterNodeLimitBoundsChildDeclarations(t *testing.T) {
+	const (
+		decls               = 20_000
+		maxVerifyAllocation = 1 << 20
+	)
+
+	key := generateRSAKey(t)
+	src := xpathFilterChildDeclarationDoc(decls)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+		MaxXPathFilterNodes(3)
+	doc := mustParseXML(t, src)
+	_, err := verifier.Verify(t.Context(), doc)
+	require.ErrorIs(t, err, xmldsig1.ErrResourceLimitExceeded)
+
+	allocated := verifyAllocatedBytes(t, verifier, src)
+	t.Logf("limited child namespace scope allocated %d bytes for %d declarations", allocated, decls)
+	require.Less(t, allocated, uint64(maxVerifyAllocation),
+		"verifying a child with %d declarations allocated %d bytes", decls, allocated)
 }
 
 // TestVerifyDeadlineDuringNodeSetConstruction pins that a deadline stops node-set

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -305,11 +305,12 @@ type verifierConfig struct {
 	// xsltTransformer applies the XSLT transform. nil (the default) keeps the XSLT
 	// transform fail-closed with ErrUnsupportedTransform.
 	xsltTransformer XSLTTransformer
-	// Parse-time resource caps (see the default* constants). Zero selects the
+	// Resource caps (see the default* constants). Zero selects the
 	// default; negative disables the cap.
-	maxReferences     int
-	maxKeyInfoEntries int
-	maxDecodedBytes   int
+	maxReferences       int
+	maxKeyInfoEntries   int
+	maxDecodedBytes     int
+	maxXPathFilterNodes int
 	// allowXPointer opts into resolving a general XPointer Reference URI (an
 	// xmlns()*xpointer(expr) framework form) beyond the four safe same-document
 	// forms. Default false keeps a general XPointer fail-closed as an external
@@ -352,6 +353,15 @@ func (cfg *verifierConfig) maxDecodedBytesLimit() int {
 		return defaultMaxDecodedBytes
 	}
 	return cfg.maxDecodedBytes
+}
+
+// maxXPathFilterNodesLimit returns the effective cap on the number of members
+// in one XPath filter transform's input node-set, defaulting when unset.
+func (cfg *verifierConfig) maxXPathFilterNodesLimit() int {
+	if cfg.maxXPathFilterNodes == 0 {
+		return defaultMaxXPathFilterNodes
+	}
+	return cfg.maxXPathFilterNodes
 }
 
 // parser returns the parser used for every octets-to-node-set transform
@@ -537,6 +547,24 @@ func (v Verifier) MaxKeyInfoEntries(n int) Verifier {
 func (v Verifier) MaxDecodedBytes(n int) Verifier {
 	v = v.clone()
 	v.cfg.maxDecodedBytes = n
+	return v
+}
+
+// MaxXPathFilterNodes caps the number of members in one XPath filter
+// transform's input node-set. The count includes elements, attributes, text,
+// comments, processing instructions, and each element's complete in-scope
+// namespace axis. Exceeding the cap returns [ErrResourceLimitExceeded] before
+// the over-limit member is collected or any member is evaluated.
+//
+// This limit applies to XPath transforms on ordinary References, Manifest
+// references, external content parsed after an octet transform, and
+// ds:RetrievalMethod. RetrievalMethod processing can run before the
+// SignatureValue is authenticated, so callers should keep a finite limit for
+// untrusted documents. Zero (the default) selects the built-in cap of 65,536
+// members; a negative value disables the cap.
+func (v Verifier) MaxXPathFilterNodes(n int) Verifier {
+	v = v.clone()
+	v.cfg.maxXPathFilterNodes = n
 	return v
 }
 

--- a/xmldsig1/xpath_transform_internal_test.go
+++ b/xmldsig1/xpath_transform_internal_test.go
@@ -43,6 +43,12 @@ func TestXPathTransformDefCanDigest(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, digestEqual(computed, ref.digestValue),
 		"defCan-1 XPath+c14n11 digest must match the signed DigestValue")
+
+	limited := *cfg
+	limited.maxXPathFilterNodes = 1
+	_, err = resolveExternalReference(t.Context(), &limited, doc, ref)
+	require.ErrorIs(t, err, ErrResourceLimitExceeded,
+		"the configured XPath member cap must reach an external document parsed after an octet boundary")
 }
 
 // TestXPathTransformThroughPipeline drives a same-document Reference carrying an
@@ -75,6 +81,10 @@ func TestXPathTransformThroughPipeline(t *testing.T) {
 	require.Contains(t, string(canonical), "KEEPVAL", "kept subtree must survive the XPath filter")
 	require.NotContains(t, string(canonical), "DROPVAL", "dropped subtree must be filtered out")
 	require.NotContains(t, string(canonical), "t:drop", "dropped element must be filtered out")
+
+	_, _, _, err = canonicalizeReference(t.Context(), &verifierConfig{maxXPathFilterNodes: 1}, doc, nil, ref)
+	require.ErrorIs(t, err, ErrResourceLimitExceeded,
+		"the configured XPath member cap must reach an ordinary same-document Reference")
 }
 
 func TestApplyXPathFilterEvaluationError(t *testing.T) {
@@ -126,6 +136,7 @@ func TestApplyXPathFilterEvaluationError(t *testing.T) {
 				ctx,
 				[]helium.Node{doc.DocumentElement()},
 				xpathFilter{expr: test.expr},
+				defaultMaxXPathFilterNodes,
 			)
 			require.Nil(t, kept)
 			require.EqualError(t, err, test.wantErr)

--- a/xmldsig1/xpath_transform_internal_test.go
+++ b/xmldsig1/xpath_transform_internal_test.go
@@ -82,7 +82,8 @@ func TestXPathTransformThroughPipeline(t *testing.T) {
 	require.NotContains(t, string(canonical), "DROPVAL", "dropped subtree must be filtered out")
 	require.NotContains(t, string(canonical), "t:drop", "dropped element must be filtered out")
 
-	_, _, _, err = canonicalizeReference(t.Context(), &verifierConfig{maxXPathFilterNodes: 1}, doc, nil, ref)
+	limitedTarget, _, _, err := canonicalizeReference(t.Context(), &verifierConfig{maxXPathFilterNodes: 1}, doc, nil, ref)
+	require.Nil(t, limitedTarget)
 	require.ErrorIs(t, err, ErrResourceLimitExceeded,
 		"the configured XPath member cap must reach an ordinary same-document Reference")
 }


### PR DESCRIPTION
- Bound pre-authentication XPath-filter work with a configurable 65,536-member default.
- Preserve the complete XMLDSig namespace axis below the cap and keep context cancellation authoritative.
- Prove the default on a 46,161-byte fixture: 15,482,400 allocated bytes versus 1.6 million uncapped members.
