### PR TITLE
fix fu116 namespace lookup allocations

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -13,7 +13,7 @@ xinclude       → helium, xpointer, internal/encoding, internal/iofs, internal/
 xpath1         → helium, internal/lexicon, internal/domutil
 xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex, internal/xmlchar, internal/domutil, internal/writerctl
 xslt3          → helium, xpath3, xsd, html, internal/iofs, internal/lexicon, internal/nodelink, internal/sequence, internal/uripath, internal/xpathstream, internal/domutil, internal/writerctl, xslt3/internal/elements
-xsd            → helium, xpath1, xpath3, internal/lexicon, internal/xsd/value, internal/xsdregex, internal/uripath, internal/iofs
+xsd            → helium, xpath1, xpath3, internal/domutil, internal/lexicon, internal/xsd/value, internal/xsdregex, internal/uripath, internal/iofs
 relaxng        → helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xsdregex, internal/xmlchar, internal/uripath
 schematron     → helium, xpath1, xpath3, internal/xpath, internal/xpath1/number
 xpointer       → helium, xpath1, internal/xmlchar
@@ -25,9 +25,10 @@ html           → helium, sax, push, internal/xmlchar
 catalog        → helium, internal/catalog, internal/iofs, internal/lexicon, internal/xmlchar
 stream         → internal/encoding, internal/xmlchar
 sax            → helium, enum
-helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack, internal/uripath, internal/iofs, internal/writerctl, internal/nodelink
+helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack, internal/uripath, internal/iofs, internal/writerctl, internal/nodelink, internal/nslookup
                   (helium installs hooks in internal/writerctl in init so xpath3 fn:serialize can enable declaration-only encoding and xslt3 can omit document-child terminators without public methods; the writerctl package imports nothing, so the edge is one-way)
                   (helium installs hooks in internal/nodelink in init so xslt3's strip-space copier can link a freshly built child without AddChild's preflight, and the xsd/xmldsig1 corrupt-tree cycle-guard tests can write a raw next-sibling pointer, all without public functions in helium; the nodelink package imports nothing, so the edge is one-way)
+                  (helium installs hooks in internal/nslookup in init so internal/domutil can search raw namespace declarations without cloning Element.Namespaces or exposing the mutable nsDefs slice; the nslookup package imports nothing, so the edge is one-way)
 sink           → (none)
 enum           → (none)
 internal/lexicon → (none)
@@ -43,14 +44,15 @@ internal/xsdregex → (none)
 internal/xmlbase64 → helium (DecodeElement counts/charges/decodes a base64 value straight off its DOM children; the root never imports it back)
 internal/writerctl → (none)
 internal/nodelink → (none)
+internal/nslookup → (none)
 internal/xsd/value → internal/lexicon
-internal/domutil → helium, enum, internal/lexicon, internal/xmlchar
+internal/domutil → helium, enum, internal/lexicon, internal/nslookup, internal/xmlchar
 internal/xpathstream → xpath3, internal/lexicon
 test           → helium
 ```
 
 ## Leaf packages (no helium deps)
-sink, enum, internal/bitset, internal/heliumtest, internal/parser, push, internal/stack, internal/cliutil, internal/encoding, internal/lexicon, internal/icu, internal/nodelink, internal/sequence, internal/strcursor, internal/writerctl, internal/xsdregex, internal/uripath
+sink, enum, internal/bitset, internal/heliumtest, internal/parser, push, internal/stack, internal/cliutil, internal/encoding, internal/lexicon, internal/icu, internal/nodelink, internal/nslookup, internal/sequence, internal/strcursor, internal/writerctl, internal/xsdregex, internal/uripath
 
 ## Core layer
 helium (root) → sax, enum, internal/*

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -43,6 +43,14 @@ Element has THREE namespace-related fields:
 
 `NamespaceNodeWrapper` wraps Namespace for XPath: adds docnode linkage. `Name()` = prefix, `Content()` = URI. Read-only (AddChild/AddSibling are no-ops).
 
+`Element.Namespaces()` returns a cloned slice, so callers cannot replace or
+append entries in the element's `nsDefs`. Namespace lookup does not clone that
+slice: `LookupNSByPrefix`/`LookupNSByHref` scan the raw declarations in-package,
+and sibling packages use the read-only `internal/nslookup` hooks through
+`internal/domutil`. Both lookup forms preserve nearest-ancestor shadowing and
+empty-URI undeclarations. The bare internal lookup does not synthesize the
+implicit `xml` binding; the public `LookupNSByPrefix`/`LookupNSByHref` APIs do.
+
 ## Attribute Storage
 
 Attributes are a **linked list via next/prev** on the Element, NOT children:

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -2203,7 +2203,7 @@ register the hooks without an import cycle.
 ## internal/domutil/
 
 Shared DOM/QName helpers used by processing packages. Namespace lookup uses
-`internal/nslookup` to scan private declaration storage without allocating;
+`internal/nslookup` to scan private declaration storage without cloning it;
 `LookupNSPrefixURI` and `LookupNSURI` preserve nearest-ancestor shadowing and
 empty-URI undeclarations, and neither synthesizes the implicit `xml` binding.
 `Element.Namespaces()` remains the public defensive-copy accessor.

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -416,6 +416,13 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   `RemoveNamespaceByPrefix` alone drops only the nsDefs entry, not the `n.ns`/attribute use, so a rebind still
   rejects while that use remains. Caller owns any ns passed to `AddNamespaceDecl` and must not share it across
   independently-mutated nodes
+- `Element.Namespaces() → []*Namespace` returns a fresh slice on every call, so
+  callers cannot replace or append entries in the element's private `nsDefs`.
+  `LookupNSByPrefix` and `LookupNSByHref` scan the raw declarations without
+  cloning while preserving nearest-ancestor shadowing and the public implicit
+  `xml` binding. Sibling-package bare lookups run through `internal/domutil` and
+  `internal/nslookup`; they preserve undeclarations and intentionally do not
+  synthesize `xml`.
 - `UnlinkNode(n MutableNode)` — detaches `n` from its parent/sibling chain; a nil or typed-nil `n` is a no-op.
   `node.Replace(...Node) → error` (guarded) rejects an EMPTY replacement set with `ErrInvalidOperation`
   (matching `Document.Replace`; use `UnlinkNode` to delete), a nil/typed-nil operand with `ErrNilNode`, and a
@@ -875,7 +882,8 @@ Toggle" section in CLAUDE.md for what is implemented in 1.1.
   (conditional type assignment), `conditional_inclusion.go` (XSD 1.1 conditional inclusion), `opencontent.go`
   (open content), `override.go` (xs:override), `inherited_attrs.go` (XSD 1.1 inherited attributes),
   `schema_decls.go` (schema-aware XPath adapter), `errors.go`
-- Imports: helium, xpath1/, xpath3/ (XSD 1.1 assertions + conditional type assignment), internal/lexicon
+- Imports: helium, xpath1/, xpath3/ (XSD 1.1 assertions + conditional type assignment), internal/domutil,
+  internal/lexicon
 - Status: see `.claude/docs/libxml2-parity.md` for libxml2 golden counts and W3C XSD 1.1 conformance run policy; do not cache branch-specific counts here
 
 ## relaxng/
@@ -2180,6 +2188,28 @@ Generic bitset operations for bitmask types.
 
 - **Set[T](*T, T)** / **IsSet[T](T, T) → bool**
 - Files: `bitset.go`
+
+## internal/nslookup/
+
+Read-only bridge for namespace declaration lookup. Package helium installs the
+prefix and URI lookup hooks during init; sibling packages use them through
+`internal/domutil` to search the private `nsDefs` storage without cloning it or
+adding a public raw-slice accessor. The bridge imports nothing, so helium can
+register the hooks without an import cycle.
+
+- Files: `nslookup.go`
+- Imports: none
+
+## internal/domutil/
+
+Shared DOM/QName helpers used by processing packages. Namespace lookup uses
+`internal/nslookup` to scan private declaration storage without allocating;
+`LookupNSPrefixURI` and `LookupNSURI` preserve nearest-ancestor shadowing and
+empty-URI undeclarations, and neither synthesizes the implicit `xml` binding.
+`Element.Namespaces()` remains the public defensive-copy accessor.
+
+- Files: `domutil.go`, `id.go`
+- Imports: helium, enum, internal/lexicon, internal/nslookup, internal/xmlchar
 
 ## internal/parser/
 

--- a/internal/domutil/domutil.go
+++ b/internal/domutil/domutil.go
@@ -1,5 +1,5 @@
 // Package domutil hosts small DOM/QName helpers shared by several helium
-// processing packages (c14n, xmldsig1, xmlenc1, xpath1, xpath3, xslt3). It may
+// processing packages (c14n, xmldsig1, xmlenc1, xpath1, xpath3, xsd, xslt3). It may
 // import the helium root package; the root never imports it back, so there is
 // no import cycle.
 package domutil
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/nslookup"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
@@ -99,18 +100,21 @@ func InScopeNamespaces(e *helium.Element, dropXML bool) map[string]*helium.Names
 // bool reports whether a binding was found. start may be any node (or nil);
 // non-element nodes in the chain are skipped.
 func LookupNSPrefixURI(start helium.Node, prefix string) (string, bool) {
-	for n := start; n != nil; n = n.Parent() {
-		el, ok := n.(*helium.Element)
-		if !ok {
-			continue
-		}
-		for _, ns := range el.Namespaces() {
-			if ns.Prefix() == prefix {
-				return ns.URI(), true
-			}
-		}
+	return nslookup.PrefixURI(start, prefix)
+}
+
+// LookupNSURI walks start and its ancestors for the nearest namespace
+// declaration matching uri. Unlike helium.LookupNSByHref it does not
+// synthesize the implicit XML namespace declaration. The bool reports whether
+// a declaration was found. start may be any node (or nil); non-element nodes
+// in the chain are skipped.
+func LookupNSURI(start helium.Node, uri string) (*helium.Namespace, bool) {
+	raw, found := nslookup.ByURI(start, uri)
+	if !found {
+		return nil, false
 	}
-	return "", false
+	ns, ok := raw.(*helium.Namespace)
+	return ns, ok
 }
 
 // SplitLexicalQName trims surrounding whitespace from s, splits it at the first

--- a/internal/domutil/domutil_test.go
+++ b/internal/domutil/domutil_test.go
@@ -21,8 +21,8 @@ func TestLookupNSPrefixURI(t *testing.T) {
 		))
 		require.NoError(t, err)
 
-		child := doc.DocumentElement().FirstChild().(*helium.Element) //nolint:forcetypeassert
-		leaf := child.FirstChild().(*helium.Element)                  //nolint:forcetypeassert
+		child := doc.DocumentElement().FirstChild().(*helium.Element)
+		leaf := child.FirstChild().(*helium.Element)
 
 		uri, found := domutil.LookupNSPrefixURI(leaf, "")
 		require.True(t, found)
@@ -39,8 +39,8 @@ func TestLookupNSPrefixURI(t *testing.T) {
 		))
 		require.NoError(t, err)
 
-		child := doc.DocumentElement().FirstChild().(*helium.Element) //nolint:forcetypeassert
-		leaf := child.FirstChild().(*helium.Element)                  //nolint:forcetypeassert
+		child := doc.DocumentElement().FirstChild().(*helium.Element)
+		leaf := child.FirstChild().(*helium.Element)
 
 		for _, prefix := range []string{"", "p"} {
 			uri, found := domutil.LookupNSPrefixURI(leaf, prefix)
@@ -70,8 +70,8 @@ func TestLookupNSPrefixURI(t *testing.T) {
 			require.NoError(t, err)
 
 			root := doc.DocumentElement()
-			child := root.FirstChild().(*helium.Element) //nolint:forcetypeassert
-			leaf := child.FirstChild().(*helium.Element) //nolint:forcetypeassert
+			child := root.FirstChild().(*helium.Element)
+			leaf := child.FirstChild().(*helium.Element)
 			require.True(t, root.RemoveNamespaceByPrefix("p"))
 
 			uri, found := domutil.LookupNSPrefixURI(leaf, "p")
@@ -138,8 +138,8 @@ func TestLookupNSURI(t *testing.T) {
 		`<root xmlns:q="urn:shared"><child xmlns:p="urn:shared"><leaf/></child></root>`,
 	))
 	require.NoError(t, err)
-	child := doc.DocumentElement().FirstChild().(*helium.Element) //nolint:forcetypeassert
-	leaf := child.FirstChild().(*helium.Element)                  //nolint:forcetypeassert
+	child := doc.DocumentElement().FirstChild().(*helium.Element)
+	leaf := child.FirstChild().(*helium.Element)
 
 	ns, found := domutil.LookupNSURI(leaf, "urn:shared")
 	require.True(t, found)

--- a/internal/domutil/domutil_test.go
+++ b/internal/domutil/domutil_test.go
@@ -2,12 +2,152 @@ package domutil_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/domutil"
 	"github.com/stretchr/testify/require"
 )
+
+var namespaceLookupSink string
+
+func TestLookupNSPrefixURI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nearest declarations shadow ancestors", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(
+			`<root xmlns="urn:outer" xmlns:p="urn:p-outer"><child xmlns="urn:inner" xmlns:p="urn:p-inner"><leaf/></child></root>`,
+		))
+		require.NoError(t, err)
+
+		child := doc.DocumentElement().FirstChild().(*helium.Element) //nolint:forcetypeassert
+		leaf := child.FirstChild().(*helium.Element)                  //nolint:forcetypeassert
+
+		uri, found := domutil.LookupNSPrefixURI(leaf, "")
+		require.True(t, found)
+		require.Equal(t, "urn:inner", uri)
+
+		uri, found = domutil.LookupNSPrefixURI(leaf, "p")
+		require.True(t, found)
+		require.Equal(t, "urn:p-inner", uri)
+	})
+
+	t.Run("undeclarations stop the ancestor walk", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(
+			`<?xml version="1.1"?><root xmlns="urn:outer" xmlns:p="urn:p"><child xmlns="" xmlns:p=""><leaf/></child></root>`,
+		))
+		require.NoError(t, err)
+
+		child := doc.DocumentElement().FirstChild().(*helium.Element) //nolint:forcetypeassert
+		leaf := child.FirstChild().(*helium.Element)                  //nolint:forcetypeassert
+
+		for _, prefix := range []string{"", "p"} {
+			uri, found := domutil.LookupNSPrefixURI(leaf, prefix)
+			require.True(t, found, "prefix %q", prefix)
+			require.Empty(t, uri, "prefix %q", prefix)
+		}
+	})
+
+	t.Run("xml is not implicitly declared", func(t *testing.T) {
+		doc := helium.NewDefaultDocument()
+		root, err := doc.CreateElement("root")
+		require.NoError(t, err)
+
+		_, found := domutil.LookupNSPrefixURI(root, "xml")
+		require.False(t, found)
+
+		require.NoError(t, root.DeclareNamespace("xml", "http://www.w3.org/XML/1998/namespace"))
+		uri, found := domutil.LookupNSPrefixURI(root, "xml")
+		require.True(t, found)
+		require.Equal(t, "http://www.w3.org/XML/1998/namespace", uri)
+	})
+
+	t.Run("CleanNamespaces controls retained declarations", func(t *testing.T) {
+		const input = `<root xmlns:p="urn:p"><child xmlns:p="urn:p"><leaf/></child></root>`
+		for _, clean := range []bool{false, true} {
+			doc, err := helium.NewParser().CleanNamespaces(clean).Parse(t.Context(), []byte(input))
+			require.NoError(t, err)
+
+			root := doc.DocumentElement()
+			child := root.FirstChild().(*helium.Element) //nolint:forcetypeassert
+			leaf := child.FirstChild().(*helium.Element) //nolint:forcetypeassert
+			require.True(t, root.RemoveNamespaceByPrefix("p"))
+
+			uri, found := domutil.LookupNSPrefixURI(leaf, "p")
+			if clean {
+				require.False(t, found)
+				continue
+			}
+			require.True(t, found)
+			require.Equal(t, "urn:p", uri)
+		}
+	})
+
+	t.Run("non-element start uses its element ancestor", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root xmlns:p="urn:p">text</root>`))
+		require.NoError(t, err)
+
+		uri, found := domutil.LookupNSPrefixURI(doc.DocumentElement().FirstChild(), "p")
+		require.True(t, found)
+		require.Equal(t, "urn:p", uri)
+	})
+}
+
+func TestLookupNSPrefixURIAllocationScaling(t *testing.T) {
+	measure := func(width int) float64 {
+		doc := helium.NewDefaultDocument()
+		root, err := doc.CreateElement("root")
+		require.NoError(t, err)
+		require.NoError(t, doc.AddChild(root))
+
+		for i := range width {
+			require.NoError(t, root.DeclareNamespace(fmt.Sprintf("p%d", i), fmt.Sprintf("urn:%d", i)))
+		}
+		children := make([]*helium.Element, 0, width)
+		for i := range width {
+			child, err := doc.CreateElement(fmt.Sprintf("child%d", i))
+			require.NoError(t, err)
+			require.NoError(t, root.AddChild(child))
+			children = append(children, child)
+		}
+		prefix := fmt.Sprintf("p%d", width-1)
+
+		return testing.AllocsPerRun(20, func() {
+			for _, child := range children {
+				uri, found := domutil.LookupNSPrefixURI(child, prefix)
+				if !found {
+					panic("namespace not found")
+				}
+				namespaceLookupSink = uri
+			}
+		})
+	}
+
+	small := measure(64)
+	large := measure(512)
+	t.Logf("namespace lookup allocations: width=64 %.0f, width=512 %.0f", small, large)
+	require.LessOrEqual(t, large, small*2+1,
+		"an eightfold wider namespace table and child list must keep lookup allocations constant")
+}
+
+func TestLookupNSURI(t *testing.T) {
+	t.Parallel()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(
+		`<root xmlns:q="urn:shared"><child xmlns:p="urn:shared"><leaf/></child></root>`,
+	))
+	require.NoError(t, err)
+	child := doc.DocumentElement().FirstChild().(*helium.Element) //nolint:forcetypeassert
+	leaf := child.FirstChild().(*helium.Element)                  //nolint:forcetypeassert
+
+	ns, found := domutil.LookupNSURI(leaf, "urn:shared")
+	require.True(t, found)
+	require.Equal(t, "p", ns.Prefix(), "the nearest declaration must win")
+
+	_, found = domutil.LookupNSURI(leaf, "http://www.w3.org/XML/1998/namespace")
+	require.False(t, found, "the bare declaration lookup must not synthesize xml")
+}
 
 // TestFindElementsByID pins the FROZEN ID-name rule FindElementsByID and
 // BuildIDIndex share: a DTD/schema-declared ID-typed attribute, xml:id, and

--- a/internal/domutil/domutil_test.go
+++ b/internal/domutil/domutil_test.go
@@ -134,19 +134,57 @@ func TestLookupNSPrefixURIAllocationScaling(t *testing.T) {
 func TestLookupNSURI(t *testing.T) {
 	t.Parallel()
 
-	doc, err := helium.NewParser().Parse(t.Context(), []byte(
-		`<root xmlns:q="urn:shared"><child xmlns:p="urn:shared"><leaf/></child></root>`,
-	))
-	require.NoError(t, err)
-	child := doc.DocumentElement().FirstChild().(*helium.Element)
-	leaf := child.FirstChild().(*helium.Element)
+	t.Run("nearest declaration wins", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(
+			`<root xmlns:q="urn:shared"><child xmlns:p="urn:shared"><leaf/></child></root>`,
+		))
+		require.NoError(t, err)
+		child := doc.DocumentElement().FirstChild().(*helium.Element)
+		leaf := child.FirstChild().(*helium.Element)
 
-	ns, found := domutil.LookupNSURI(leaf, "urn:shared")
-	require.True(t, found)
-	require.Equal(t, "p", ns.Prefix(), "the nearest declaration must win")
+		ns, found := domutil.LookupNSURI(leaf, "urn:shared")
+		require.True(t, found)
+		require.Equal(t, "p", ns.Prefix(), "the nearest declaration must win")
 
-	_, found = domutil.LookupNSURI(leaf, "http://www.w3.org/XML/1998/namespace")
-	require.False(t, found, "the bare declaration lookup must not synthesize xml")
+		_, found = domutil.LookupNSURI(leaf, "http://www.w3.org/XML/1998/namespace")
+		require.False(t, found, "the bare declaration lookup must not synthesize xml")
+	})
+
+	t.Run("nearer prefix rebind hides ancestor URI", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(
+			`<root xmlns:p="urn:target"><child xmlns:p="urn:other"><leaf/></child></root>`,
+		))
+		require.NoError(t, err)
+		child := doc.DocumentElement().FirstChild().(*helium.Element)
+		leaf := child.FirstChild().(*helium.Element)
+
+		uri, found := domutil.LookupNSPrefixURI(leaf, "p")
+		require.True(t, found)
+		require.Equal(t, "urn:other", uri)
+
+		ns, found := domutil.LookupNSURI(leaf, "urn:target")
+		require.False(t, found)
+		require.Nil(t, ns)
+		require.Nil(t, helium.LookupNSByHref(leaf, "urn:target"))
+	})
+
+	t.Run("nearer prefix undeclaration hides ancestor URI", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(
+			`<?xml version="1.1"?><root xmlns:p="urn:target"><child xmlns:p=""><leaf/></child></root>`,
+		))
+		require.NoError(t, err)
+		child := doc.DocumentElement().FirstChild().(*helium.Element)
+		leaf := child.FirstChild().(*helium.Element)
+
+		uri, found := domutil.LookupNSPrefixURI(leaf, "p")
+		require.True(t, found)
+		require.Empty(t, uri)
+
+		ns, found := domutil.LookupNSURI(leaf, "urn:target")
+		require.False(t, found)
+		require.Nil(t, ns)
+		require.Nil(t, helium.LookupNSByHref(leaf, "urn:target"))
+	})
 }
 
 // TestFindElementsByID pins the FROZEN ID-name rule FindElementsByID and

--- a/internal/domutil/domutil_test.go
+++ b/internal/domutil/domutil_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 var namespaceLookupSink string
+var namespaceLookupNSSink *helium.Namespace
 
 func TestLookupNSPrefixURI(t *testing.T) {
 	t.Parallel()
@@ -185,6 +186,43 @@ func TestLookupNSURI(t *testing.T) {
 		require.Nil(t, ns)
 		require.Nil(t, helium.LookupNSByHref(leaf, "urn:target"))
 	})
+}
+
+func TestLookupNSURIAllocations(t *testing.T) {
+	for _, width := range []int{64, 512} {
+		t.Run(fmt.Sprintf("width %d", width), func(t *testing.T) {
+			doc := helium.NewDefaultDocument()
+			root, err := doc.CreateElement("root")
+			require.NoError(t, err)
+			require.NoError(t, doc.AddChild(root))
+
+			for i := range width {
+				require.NoError(t, root.DeclareNamespace(fmt.Sprintf("p%d", i), fmt.Sprintf("urn:%d", i)))
+			}
+			leaf, err := doc.CreateElement("leaf")
+			require.NoError(t, err)
+			require.NoError(t, root.AddChild(leaf))
+			target := fmt.Sprintf("urn:%d", width-1)
+
+			internalAllocs := testing.AllocsPerRun(20, func() {
+				ns, found := domutil.LookupNSURI(leaf, target)
+				if !found {
+					panic("namespace not found")
+				}
+				namespaceLookupNSSink = ns
+			})
+			publicAllocs := testing.AllocsPerRun(20, func() {
+				ns := helium.LookupNSByHref(leaf, target)
+				if ns == nil {
+					panic("namespace not found")
+				}
+				namespaceLookupNSSink = ns
+			})
+
+			require.Zero(t, internalAllocs, "internal URI lookup must not allocate")
+			require.Zero(t, publicAllocs, "public URI lookup must not allocate")
+		})
+	}
 }
 
 // TestFindElementsByID pins the FROZEN ID-name rule FindElementsByID and

--- a/internal/nslookup/nslookup.go
+++ b/internal/nslookup/nslookup.go
@@ -1,0 +1,18 @@
+// Package nslookup is an internal bridge that lets sibling packages in this
+// module search helium namespace declarations without exposing the DOM's
+// mutable namespace slice through the public API.
+//
+// Package helium installs both hooks in init. The hooks use any to avoid an
+// import cycle: helium imports this package to register them, so this package
+// must not import helium.
+package nslookup
+
+// PrefixURI walks a helium node and its ancestors for the nearest namespace
+// declaration matching prefix. It returns the declaration's URI and whether a
+// declaration was found. It does not synthesize the implicit xml binding.
+var PrefixURI func(start any, prefix string) (string, bool)
+
+// ByURI walks a helium node and its ancestors for the nearest namespace
+// declaration matching uri. It returns a *helium.Namespace as any, plus whether
+// a declaration was found. It does not synthesize the implicit xml binding.
+var ByURI func(start any, uri string) (any, bool)

--- a/tree_namespaces.go
+++ b/tree_namespaces.go
@@ -32,7 +32,6 @@ func namespaceByPrefix(start Node, prefix string) (*Namespace, bool) {
 // declaration or undeclaration hides every ancestor binding for the same
 // prefix, even when the nearer URI does not match.
 func namespaceByURI(start Node, uri string) (*Namespace, bool) {
-	seenPrefixes := make(map[string]struct{})
 	for node := start; !isNilNode(node); node = node.Parent() {
 		el, ok := node.(*Element)
 		if !ok {
@@ -42,12 +41,11 @@ func namespaceByURI(start Node, uri string) (*Namespace, bool) {
 			if ns == nil {
 				continue
 			}
-			prefix := ns.Prefix()
-			if _, seen := seenPrefixes[prefix]; seen {
+			if ns.URI() != uri {
 				continue
 			}
-			seenPrefixes[prefix] = struct{}{}
-			if ns.URI() == uri {
+			active, found := namespaceByPrefix(start, ns.Prefix())
+			if found && active == ns {
 				return ns, true
 			}
 		}

--- a/tree_namespaces.go
+++ b/tree_namespaces.go
@@ -28,15 +28,26 @@ func namespaceByPrefix(start Node, prefix string) (*Namespace, bool) {
 	return nil, false
 }
 
-// namespaceByURI is the URI counterpart to namespaceByPrefix.
+// namespaceByURI is the URI counterpart to namespaceByPrefix. A nearer
+// declaration or undeclaration hides every ancestor binding for the same
+// prefix, even when the nearer URI does not match.
 func namespaceByURI(start Node, uri string) (*Namespace, bool) {
+	seenPrefixes := make(map[string]struct{})
 	for node := start; !isNilNode(node); node = node.Parent() {
 		el, ok := node.(*Element)
 		if !ok {
 			continue
 		}
 		for _, ns := range el.nsDefs {
-			if ns != nil && ns.URI() == uri {
+			if ns == nil {
+				continue
+			}
+			prefix := ns.Prefix()
+			if _, seen := seenPrefixes[prefix]; seen {
+				continue
+			}
+			seenPrefixes[prefix] = struct{}{}
+			if ns.URI() == uri {
 				return ns, true
 			}
 		}

--- a/tree_namespaces.go
+++ b/tree_namespaces.go
@@ -1,21 +1,82 @@
 package helium
 
-import "github.com/lestrrat-go/helium/internal/lexicon"
+import (
+	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/nslookup"
+)
+
+func init() {
+	nslookup.PrefixURI = namespacePrefixURI
+	nslookup.ByURI = namespaceByURIHook
+}
+
+// namespaceByPrefix walks raw namespace declarations without cloning each
+// element's declaration slice. The returned Namespace remains read-only to
+// sibling packages because its fields are unexported.
+func namespaceByPrefix(start Node, prefix string) (*Namespace, bool) {
+	for node := start; !isNilNode(node); node = node.Parent() {
+		el, ok := node.(*Element)
+		if !ok {
+			continue
+		}
+		for _, ns := range el.nsDefs {
+			if ns != nil && ns.Prefix() == prefix {
+				return ns, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// namespaceByURI is the URI counterpart to namespaceByPrefix.
+func namespaceByURI(start Node, uri string) (*Namespace, bool) {
+	for node := start; !isNilNode(node); node = node.Parent() {
+		el, ok := node.(*Element)
+		if !ok {
+			continue
+		}
+		for _, ns := range el.nsDefs {
+			if ns != nil && ns.URI() == uri {
+				return ns, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// namespacePrefixURI adapts namespaceByPrefix to the internal hook without
+// exposing the Namespace object or its containing slice.
+func namespacePrefixURI(start any, prefix string) (string, bool) {
+	node, ok := start.(Node)
+	if !ok {
+		return "", false
+	}
+	ns, found := namespaceByPrefix(node, prefix)
+	if !found {
+		return "", false
+	}
+	return ns.URI(), true
+}
+
+// namespaceByURIHook adapts namespaceByURI to the untyped internal hook.
+func namespaceByURIHook(start any, uri string) (any, bool) {
+	node, ok := start.(Node)
+	if !ok {
+		return nil, false
+	}
+	ns, found := namespaceByURI(node, uri)
+	if !found {
+		return nil, false
+	}
+	return ns, true
+}
 
 // LookupNSByPrefix walks the element and its ancestors to find a namespace
 // declaration matching the given prefix. The "xml" prefix is always
 // implicitly bound to the XML namespace.
 func LookupNSByPrefix(e *Element, prefix string) *Namespace {
-	var node Node = e
-	for node != nil {
-		if el, ok := node.(*Element); ok {
-			for _, ns := range el.Namespaces() {
-				if ns.Prefix() == prefix {
-					return ns
-				}
-			}
-		}
-		node = node.Parent()
+	if ns, found := namespaceByPrefix(e, prefix); found {
+		return ns
 	}
 	if prefix == "xml" {
 		return NewNamespace("xml", lexicon.NamespaceXML)
@@ -34,16 +95,8 @@ func LookupNSByHref(e *Element, href string) *Namespace {
 	if href == lexicon.NamespaceXML {
 		return NewNamespace("xml", lexicon.NamespaceXML)
 	}
-	var node Node = e
-	for node != nil {
-		if el, ok := node.(*Element); ok {
-			for _, ns := range el.Namespaces() {
-				if ns.URI() == href {
-					return ns
-				}
-			}
-		}
-		node = node.Parent()
+	if ns, found := namespaceByURI(e, href); found {
+		return ns
 	}
 	return nil
 }

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/domutil"
 	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
@@ -1465,18 +1466,8 @@ func findDocumentElement(doc *helium.Document) *helium.Element {
 // returned declaration's prefix is reused when inserting a qualified default
 // attribute so the inserted node mirrors the document's own prefix binding.
 func inScopeNamespace(elem *helium.Element, href string) *helium.Namespace {
-	var node helium.Node = elem
-	for node != nil {
-		if e, ok := node.(*helium.Element); ok {
-			for _, ns := range e.Namespaces() {
-				if ns.URI() == href {
-					return ns
-				}
-			}
-		}
-		node = node.Parent()
-	}
-	return nil
+	ns, _ := domutil.LookupNSURI(elem, href)
+	return ns
 }
 
 func collectNSContext(elem *helium.Element) map[string]string {

--- a/xsd/validate_default_attr_namespace_test.go
+++ b/xsd/validate_default_attr_namespace_test.go
@@ -1,0 +1,45 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDefaultAttributeNamespaceShadowing(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:p="urn:target" xmlns:q="urn:target" targetNamespace="urn:target"
+    elementFormDefault="qualified">
+  <xs:attribute name="a" type="xs:string" default="v"/>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence><xs:element ref="q:child"/></xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="child">
+    <xs:complexType><xs:attribute ref="p:a"/></xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	schema, errs := compileWithErrors(t, schemaXML)
+	require.Empty(t, errs)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(
+		`<q:root xmlns:p="urn:target" xmlns:q="urn:target"><q:child xmlns:p="urn:other"/></q:root>`,
+	))
+	require.NoError(t, err)
+	require.NoError(t, xsd.NewValidator(schema).Validate(t.Context(), doc))
+
+	serialized, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	roundTrip, err := helium.NewParser().Parse(t.Context(), []byte(serialized))
+	require.NoError(t, err)
+	child := roundTrip.DocumentElement().FirstChild().(*helium.Element)
+	value, found := child.GetAttributeNS("a", "urn:target")
+	require.True(t, found, "serialized default attribute must retain its declared namespace: %s", serialized)
+	require.Equal(t, "v", value)
+}


### PR DESCRIPTION
- keep namespace resolution allocation-free without exposing mutable DOM namespace storage
- preserve shadowing, undeclarations, implicit xml behavior, and defensive namespace copies
