### PR TITLE
fix XPath filter context error chains

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -307,7 +307,10 @@ Ordered-transform diagnostics (`transform_pipeline.go` `executeTransformPipeline
 transform index + algorithm. Static algorithm/parameter/capability failures wrap `ErrUnsupportedTransform`
 before execution. A first required parse of resolver-supplied octets wraps `ErrReferenceNotFound`; a parse of
 intermediate transform output wraps `ErrUnsupportedTransform` and names both producer + consumer steps.
-Invalid Base64 wraps `ErrInvalidSignature`. Context and injected-XSLT errors return unchanged.
+Invalid Base64 wraps `ErrInvalidSignature`. `ErrHereUnavailable` returns unchanged from XPath evaluation;
+every other XPath evaluation failure wraps both `ErrUnsupportedTransform` and the evaluator error, so
+`context.Canceled`, `context.DeadlineExceeded`, and XPath sentinels remain matchable through the outer
+`VerificationError`. Other context and injected-XSLT errors return unchanged.
 
 A RetrievalMethod transform list exceeding `maxRetrievalTransformSteps` wraps `ErrResourceLimitExceeded` before URI dereference, transform execution, or key resolution.
 

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1433,8 +1433,11 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   `validateTransformSteps` scans the complete list and statically validates every XPath expression before
   execution, so unknown algorithms, missing or malformed parameters, unavailable XSLT, unknown XPath
   functions, unbound XPath QName prefixes, unavailable `here()`, and invalid enveloped placement fail before
-  an injected transform runs. XPath uses `newDSigXPathEvaluator` with namespaces, `hereFunction`, and
-  `defaultXPathOpLimit`=100M. Base64 signing works through the exported `Transform` interface; XPath/XSLT
+  an injected transform runs. A runtime XPath evaluation failure wraps both `ErrUnsupportedTransform` and the
+  evaluator error, so cancellation, deadline, and XPath sentinels remain matchable through the outer
+  `VerificationError`; `ErrHereUnavailable` remains direct. XPath uses `newDSigXPathEvaluator` with
+  namespaces, `hereFunction`, and `defaultXPathOpLimit`=100M. Base64 signing works through the exported
+  `Transform` interface; XPath/XSLT
   signing stays rejected because `ReferenceConfig` cannot carry or emit their required child content.
   `ec:InclusiveNamespaces` is threaded through explicit exclusive-C14N steps; unknown C14N/SignatureMethod
   parameters fail closed.

--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -152,7 +152,10 @@ XPath → C14N 1.1 → XSLT → XPath → C14N 1.1, multiple XSLT steps, and a s
 canonicalization. Base64's node-set text conversion is its one algorithm-specific
 exception to the generic C14N conversion. Unknown algorithms and unusable
 parameters fail with `ErrUnsupportedTransform` before any injected transformer
-runs. An enveloped transform is limited to the original same-document node-set;
+runs. A runtime XPath evaluation failure wraps both `ErrUnsupportedTransform`
+and the evaluator error, so cancellation and deadline errors remain matchable
+through the reference wrapper. `ErrHereUnavailable` remains direct. An
+enveloped transform is limited to the original same-document node-set;
 it fails after an octet boundary because the containing Signature's node identity
 cannot be reconstructed from serialized markup. XPath and XSLT remain
 verify-only because the signing API cannot emit their required child content.

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -374,7 +374,8 @@ func compileXPathFilterExpression(expr string, eval xpath1.Evaluator) (*xpath1.E
 // evaluator (namespaces, here(), and the OpLimit security bound). Expressions are
 // compiled and statically validated during complete-list validation, before
 // execution starts. An evaluation error is fail-closed as
-// ErrUnsupportedTransform so a reference never digests an unfiltered node-set.
+// ErrUnsupportedTransform while retaining the evaluator error, so a reference
+// never digests an unfiltered node-set and callers can still detect cancellation.
 func applyXPathFilter(ctx context.Context, nodes []helium.Node, f xpathFilter) ([]helium.Node, error) {
 	eval := newDSigXPathEvaluator(f.ns, f.hereNode, defaultXPathOpLimit)
 	kept := make([]helium.Node, 0, len(nodes))
@@ -388,7 +389,7 @@ func applyXPathFilter(ctx context.Context, nodes []helium.Node, f xpathFilter) (
 			if errors.Is(err, ErrHereUnavailable) {
 				return nil, err
 			}
-			return nil, fmt.Errorf("%w: XPath transform evaluation failed: %v", ErrUnsupportedTransform, err)
+			return nil, fmt.Errorf("%w: XPath transform evaluation failed: %w", ErrUnsupportedTransform, err)
 		}
 		if r.Bool {
 			kept = append(kept, n)

--- a/xmldsig1/xpath_transform_internal_test.go
+++ b/xmldsig1/xpath_transform_internal_test.go
@@ -81,35 +81,29 @@ func TestApplyXPathFilterEvaluationError(t *testing.T) {
 	doc := mustParse(t, `<root/>`)
 	compiled := xpath1.MustCompile("boolean(true())")
 
-	canceledCtx, cancel := context.WithCancel(t.Context())
-	cancel()
-	deadlineCtx, deadlineCancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
-	t.Cleanup(deadlineCancel)
-
 	tests := []struct {
-		name    string
-		ctx     context.Context
-		expr    *xpath1.Expression
-		cause   error
-		wantErr string
+		name       string
+		contextErr error
+		expr       *xpath1.Expression
+		cause      error
+		wantErr    string
 	}{
 		{
-			name:    "canceled context",
-			ctx:     canceledCtx,
-			expr:    compiled,
-			cause:   context.Canceled,
-			wantErr: "xmldsig1: unsupported transform: XPath transform evaluation failed: context canceled",
+			name:       "canceled context",
+			contextErr: context.Canceled,
+			expr:       compiled,
+			cause:      context.Canceled,
+			wantErr:    "xmldsig1: unsupported transform: XPath transform evaluation failed: context canceled",
 		},
 		{
-			name:    "expired deadline",
-			ctx:     deadlineCtx,
-			expr:    compiled,
-			cause:   context.DeadlineExceeded,
-			wantErr: "xmldsig1: unsupported transform: XPath transform evaluation failed: context deadline exceeded",
+			name:       "expired deadline",
+			contextErr: context.DeadlineExceeded,
+			expr:       compiled,
+			cause:      context.DeadlineExceeded,
+			wantErr:    "xmldsig1: unsupported transform: XPath transform evaluation failed: context deadline exceeded",
 		},
 		{
 			name:    "ordinary evaluator error",
-			ctx:     t.Context(),
 			cause:   xpath1.ErrNilExpression,
 			wantErr: "xmldsig1: unsupported transform: XPath transform evaluation failed: xpath: nil or uncompiled expression",
 		},
@@ -117,8 +111,19 @@ func TestApplyXPathFilterEvaluationError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+			switch test.contextErr {
+			case context.Canceled:
+				canceledCtx, cancel := context.WithCancel(t.Context())
+				cancel()
+				ctx = canceledCtx
+			case context.DeadlineExceeded:
+				deadlineCtx, deadlineCancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+				t.Cleanup(deadlineCancel)
+				ctx = deadlineCtx
+			}
 			kept, err := applyXPathFilter(
-				test.ctx,
+				ctx,
 				[]helium.Node{doc.DocumentElement()},
 				xpathFilter{expr: test.expr},
 			)
@@ -135,8 +140,19 @@ func TestApplyXPathFilterEvaluationError(t *testing.T) {
 }
 
 type xpathEvaluationErrorContext struct {
-	context.Context
 	err error
+}
+
+func (xpathEvaluationErrorContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (xpathEvaluationErrorContext) Done() <-chan struct{} {
+	return nil
+}
+
+func (xpathEvaluationErrorContext) Value(any) any {
+	return nil
 }
 
 func (c xpathEvaluationErrorContext) Err() error {
@@ -144,7 +160,7 @@ func (c xpathEvaluationErrorContext) Err() error {
 	if ok && strings.HasSuffix(filepath.ToSlash(file), "/xpath1/eval.go") {
 		return c.err
 	}
-	return c.Context.Err()
+	return nil
 }
 
 func TestVerifyXPathFilterCancellationErrorChain(t *testing.T) {
@@ -174,7 +190,7 @@ func TestVerifyXPathFilterCancellationErrorChain(t *testing.T) {
 	require.NoError(t, transform.AddChild(xpathElem))
 	reSignSignedInfo(t, doc, sigElem, signedInfo, nil, key)
 
-	ctx := xpathEvaluationErrorContext{Context: t.Context(), err: context.Canceled}
+	ctx := xpathEvaluationErrorContext{err: context.Canceled}
 	_, err = NewVerifier(StaticKey(&key.PublicKey)).Verify(ctx, doc)
 	require.ErrorIs(t, err, ErrUnsupportedTransform)
 	require.ErrorIs(t, err, context.Canceled)

--- a/xmldsig1/xpath_transform_internal_test.go
+++ b/xmldsig1/xpath_transform_internal_test.go
@@ -5,11 +5,16 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"os"
+	"path/filepath"
+	"runtime"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,6 +75,116 @@ func TestXPathTransformThroughPipeline(t *testing.T) {
 	require.Contains(t, string(canonical), "KEEPVAL", "kept subtree must survive the XPath filter")
 	require.NotContains(t, string(canonical), "DROPVAL", "dropped subtree must be filtered out")
 	require.NotContains(t, string(canonical), "t:drop", "dropped element must be filtered out")
+}
+
+func TestApplyXPathFilterEvaluationError(t *testing.T) {
+	doc := mustParse(t, `<root/>`)
+	compiled := xpath1.MustCompile("boolean(true())")
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	deadlineCtx, deadlineCancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	t.Cleanup(deadlineCancel)
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		expr    *xpath1.Expression
+		cause   error
+		wantErr string
+	}{
+		{
+			name:    "canceled context",
+			ctx:     canceledCtx,
+			expr:    compiled,
+			cause:   context.Canceled,
+			wantErr: "xmldsig1: unsupported transform: XPath transform evaluation failed: context canceled",
+		},
+		{
+			name:    "expired deadline",
+			ctx:     deadlineCtx,
+			expr:    compiled,
+			cause:   context.DeadlineExceeded,
+			wantErr: "xmldsig1: unsupported transform: XPath transform evaluation failed: context deadline exceeded",
+		},
+		{
+			name:    "ordinary evaluator error",
+			ctx:     t.Context(),
+			cause:   xpath1.ErrNilExpression,
+			wantErr: "xmldsig1: unsupported transform: XPath transform evaluation failed: xpath: nil or uncompiled expression",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kept, err := applyXPathFilter(
+				test.ctx,
+				[]helium.Node{doc.DocumentElement()},
+				xpathFilter{expr: test.expr},
+			)
+			require.Nil(t, kept)
+			require.EqualError(t, err, test.wantErr)
+			require.ErrorIs(t, err, ErrUnsupportedTransform)
+			require.ErrorIs(t, err, test.cause)
+
+			var multiUnwrapper interface{ Unwrap() []error }
+			require.ErrorAs(t, err, &multiUnwrapper)
+			require.Len(t, multiUnwrapper.Unwrap(), 2)
+		})
+	}
+}
+
+type xpathEvaluationErrorContext struct {
+	context.Context
+	err error
+}
+
+func (c xpathEvaluationErrorContext) Err() error {
+	_, file, _, ok := runtime.Caller(1)
+	if ok && strings.HasSuffix(filepath.ToSlash(file), "/xpath1/eval.go") {
+		return c.err
+	}
+	return c.Context.Err()
+}
+
+func TestVerifyXPathFilterCancellationErrorChain(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	doc := mustParse(t, `<root><data Id="target">content</data></root>`)
+
+	sigElem, err := NewSigner().
+		SignatureAlgorithm(AlgRSASHA256).
+		Reference(ReferenceConfig{
+			URI:             "#target",
+			DigestAlgorithm: DigestSHA256,
+			Transforms:      []Transform{C14NTransform(C14N10)},
+		}).
+		SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	signedInfo := findChild(t, sigElem, "SignedInfo")
+	reference := findChild(t, signedInfo, "Reference")
+	transform := findChild(t, findChild(t, reference, "Transforms"), "Transform")
+	require.NoError(t, transform.SetAttribute("Algorithm", TransformXPath))
+	xpathElem, err := doc.CreateElement("XPath")
+	require.NoError(t, err)
+	require.NoError(t, xpathElem.SetActiveNamespace(nsPrefix, NamespaceDSig))
+	require.NoError(t, xpathElem.AddChild(doc.CreateText([]byte("true()"))))
+	require.NoError(t, transform.AddChild(xpathElem))
+	reSignSignedInfo(t, doc, sigElem, signedInfo, nil, key)
+
+	ctx := xpathEvaluationErrorContext{Context: t.Context(), err: context.Canceled}
+	_, err = NewVerifier(StaticKey(&key.PublicKey)).Verify(ctx, doc)
+	require.ErrorIs(t, err, ErrUnsupportedTransform)
+	require.ErrorIs(t, err, context.Canceled)
+	var referenceErr *VerificationError
+	require.ErrorAs(t, err, &referenceErr)
+	require.Equal(t, 0, referenceErr.Reference)
+	require.Equal(t, "#target", referenceErr.URI)
+
+	var multiUnwrapper interface{ Unwrap() []error }
+	require.ErrorAs(t, err, &multiUnwrapper)
 }
 
 func TestVerifyPreflightsAllReferencesBeforeXSLT(t *testing.T) {


### PR DESCRIPTION
- Preserve XPath filter transform and context error identities.
- Cover cancellation, deadlines, and reference wrapping.
