### PR TITLE
remove singular encrypted key fallback

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1860,9 +1860,7 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
   attacker cannot influence, so a mismatch is reported as a bare `KeySizeError` instead
 - Multi-recipient: `EncryptedData.EncryptedKeys []*EncryptedKey` holds one EncryptedKey per recipient; absent
   a session key, decrypt tries each candidate through full block decryption + plaintext validation (a bogus
-  prepended key cannot mask the real one). `EncryptedData.EncryptedKey` is the **deprecated** single-key field
-  — `EncryptedKeys` wins when non-empty, else the single field is treated as a one-element list; parse
-  populates both
+  prepended key cannot mask the real one)
 - An ECDH-ES originator key's `dsig11:PublicKey` is bounded by `maxECPublicKeyBytes` (133, `parse.go`), which
   owns the rationale; over-limit fails with an error wrapping `ErrMalformedEncrypted`. `decodeBoundedBase64`
   (`parse.go`, the same bounded walk the OAEPparams label goes through) reads it, called from

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -130,12 +130,6 @@ func parseEncryptedData(ctx context.Context, elem *helium.Element, ps *parseStat
 		return nil, abort(ctx, fmt.Errorf("%w: missing CipherData/CipherValue", ErrMalformedEncrypted))
 	}
 
-	// Populate the deprecated single EncryptedKey field with the first
-	// candidate so callers reading it keep working.
-	if len(ed.EncryptedKeys) > 0 {
-		ed.EncryptedKey = ed.EncryptedKeys[0]
-	}
-
 	return ed, nil
 }
 

--- a/xmlenc1/robustness_test.go
+++ b/xmlenc1/robustness_test.go
@@ -455,66 +455,6 @@ func TestDecryptType(t *testing.T) {
 	})
 }
 
-// TestDeprecatedEncryptedKeyField exercises the backward-compatible single
-// EncryptedKey field: a caller that sets only the deprecated field (with
-// EncryptedKeys left nil) must still marshal and decrypt, and parsing a
-// single-EncryptedKey document must populate BOTH EncryptedKey and
-// EncryptedKeys[0] so old and new readers agree.
-func TestDeprecatedEncryptedKeyField(t *testing.T) {
-	const algorithm = xmlenc1.AES256GCM
-
-	t.Run("marshal and decrypt via deprecated field only", func(t *testing.T) {
-		sessionKey := randKey(t, 32)
-		cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, []byte("<x>secret</x>"))
-		require.NoError(t, err)
-
-		kek := randKey(t, 32)
-		wrapped, err := xmlenc1.AESKeyWrapForTest(kek, sessionKey)
-		require.NoError(t, err)
-
-		doc := mustParseXML(t, `<root/>`)
-		ed := &xmlenc1.EncryptedData{
-			Type:             xmlenc1.TypeElement,
-			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
-			// Only the deprecated single field is set; EncryptedKeys is nil.
-			EncryptedKey: &xmlenc1.EncryptedKey{
-				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
-				CipherValue:      wrapped,
-			},
-			CipherValue: cipher,
-		}
-		elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
-		require.NoError(t, err)
-
-		nodes, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), elem)
-		require.NoError(t, err)
-		require.Len(t, nodes, 1)
-		s, err := helium.WriteString(nodes[0])
-		require.NoError(t, err)
-		require.Contains(t, s, "secret")
-	})
-
-	t.Run("parse populates both deprecated and slice fields", func(t *testing.T) {
-		const xenc = `xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"`
-		const ds = `xmlns:ds="http://www.w3.org/2000/09/xmldsig#"`
-		xml := `<xenc:EncryptedData ` + xenc + ` ` + ds + `>` +
-			`<xenc:EncryptionMethod Algorithm="` + algorithm + `"/>` +
-			`<ds:KeyInfo><xenc:EncryptedKey>` +
-			`<xenc:EncryptionMethod Algorithm="` + xmlenc1.RSAOAEP + `"/>` +
-			`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
-			`</xenc:EncryptedKey></ds:KeyInfo>` +
-			`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
-			`</xenc:EncryptedData>`
-
-		doc := mustParseXML(t, xml)
-		ed, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
-		require.NoError(t, err)
-		require.NotNil(t, ed.EncryptedKey)
-		require.Len(t, ed.EncryptedKeys, 1)
-		require.Same(t, ed.EncryptedKeys[0], ed.EncryptedKey)
-	})
-}
-
 // encryptedDataWithRawEncryptedKey builds an EncryptedData carrying real
 // AES-256-GCM ciphertext plus one EncryptedKey spliced in verbatim, so a test
 // can present an EncryptedKey the public marshaler would never emit.

--- a/xmlenc1/serialize.go
+++ b/xmlenc1/serialize.go
@@ -41,10 +41,8 @@ func marshalEncryptedData(doc *helium.Document, ed *encryptedData) (*helium.Elem
 		}
 	}
 
-	// KeyInfo with one EncryptedKey per recipient. EncryptedKeys takes
-	// precedence over the deprecated single EncryptedKey field.
-	encKeys := ed.effectiveEncryptedKeys()
-	if len(encKeys) > 0 {
+	// KeyInfo with one EncryptedKey per recipient.
+	if len(ed.EncryptedKeys) > 0 {
 		keyInfo, err := doc.CreateElement("KeyInfo")
 		if err != nil {
 			return nil, err
@@ -56,7 +54,7 @@ func marshalEncryptedData(doc *helium.Document, ed *encryptedData) (*helium.Elem
 			return nil, err
 		}
 
-		for _, k := range encKeys {
+		for _, k := range ed.EncryptedKeys {
 			ek, err := marshalEncryptedKey(doc, k)
 			if err != nil {
 				return nil, err

--- a/xmlenc1/types.go
+++ b/xmlenc1/types.go
@@ -55,13 +55,6 @@ type encryptedData struct {
 	// block encryption URI (AES-CBC or AES-GCM). Decryption needs it, so
 	// an EncryptedData without one fails with [ErrMalformedEncrypted].
 	EncryptionMethod *encryptionMethod
-	// EncryptedKey is the first EncryptedKey candidate, kept for backward
-	// compatibility with callers written against the old single-key field.
-	//
-	// Deprecated: use EncryptedKeys. When both are set, EncryptedKeys takes
-	// precedence and this field is ignored; when only this field is set it
-	// is treated as a single-element EncryptedKeys.
-	EncryptedKey *encryptedKey
 	// EncryptedKeys holds every EncryptedKey candidate found in KeyInfo
 	// (one per recipient). Decryption tries each in turn, so a
 	// multi-recipient document, or one with a bogus EncryptedKey
@@ -86,20 +79,6 @@ type encryptedData struct {
 	// carries a usable EncryptedKey decrypts under it, so this is consulted
 	// only when the candidate list came out empty.
 	offersDerivedKey bool
-}
-
-// effectiveEncryptedKeys returns the EncryptedKey candidates to use,
-// reconciling the EncryptedKeys slice with the deprecated single
-// EncryptedKey field: EncryptedKeys wins when non-empty; otherwise the
-// deprecated field, if set, is treated as a single-element list.
-func (ed *encryptedData) effectiveEncryptedKeys() []*encryptedKey {
-	if len(ed.EncryptedKeys) > 0 {
-		return ed.EncryptedKeys
-	}
-	if ed.EncryptedKey != nil {
-		return []*encryptedKey{ed.EncryptedKey}
-	}
-	return nil
 }
 
 // encryptedKey represents the <EncryptedKey> element: the session key of an

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -1194,7 +1194,7 @@ func decryptBytes(ctx context.Context, cfg *decryptConfig, elem *helium.Element)
 		}
 	}
 
-	keys := ed.effectiveEncryptedKeys()
+	keys := ed.EncryptedKeys
 
 	if len(cfg.sessionKey) > 0 {
 		// The caller supplied the session key directly, so its length is
@@ -1339,7 +1339,7 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 		}
 	}
 
-	keys := ed.effectiveEncryptedKeys()
+	keys := ed.EncryptedKeys
 
 	// A pre-shared session key, when configured, returns here — before
 	// candidate selection, per-candidate validation, and per-candidate key


### PR DESCRIPTION
- Remove the dead internal singular EncryptedKey compatibility path.
- Keep parsing, ordering, serialization, and decryption on EncryptedKeys.
