### PR TITLE
fix XPointer context error identity

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -303,6 +303,11 @@ external resource exceeds the resolver's 64 MiB cap. Both wrap via `%w` and are 
 per-reference external failure still surfaces through `VerificationError` (verify) / `ReferenceError` (sign)
 with the sentinel reachable via `Unwrap`.
 
+General-XPointer evaluation failures (`transforms.go` `resolvePreparedGeneralXPointerTarget`) wrap both
+`ErrReferenceNotFound` and the XPath evaluator error with `%w`. Cancellation and deadline errors therefore
+remain matchable through the public `VerificationError` wrapper while keeping the reference-resolution
+classification and wording. The URI-borne `here()` case returns `ErrHereUnavailable` unchanged.
+
 Ordered-transform diagnostics (`transform_pipeline.go` `executeTransformPipeline`) identify the zero-based
 transform index + algorithm. Static algorithm/parameter/capability failures wrap `ErrUnsupportedTransform`
 before execution. A first required parse of resolver-supplied octets wraps `ErrReferenceNotFound`; a parse of

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1389,8 +1389,10 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   the shared bounded evaluator with the document element's in-scope namespaces overlaid by the `xmlns()`
   overrides (`xpointerNamespaces`), so an unresolved variable/function/prefix fails as `ErrReferenceNotFound`
   before evaluation. `resolvePreparedGeneralXPointerTarget` then evaluates the expression and enforces a
-  SINGLE element apex (`singleElementApex`, the XSW defense): empty → `ErrReferenceNotFound`, a multi-element
-  or non-element node-set → `ErrAmbiguousReference`. An id() selector NEVER reaches xpath1's built-in id()
+  SINGLE element apex (`singleElementApex`, the XSW defense): an evaluation failure wraps both
+  `ErrReferenceNotFound` and the evaluator cause, so context cancellation/deadline identity remains matchable
+  through `VerificationError`; empty → `ErrReferenceNotFound`, and a multi-element or non-element node-set →
+  `ErrAmbiguousReference`. An id() selector NEVER reaches xpath1's built-in id()
   (`Document.GetElementByID`, which resolves a duplicate id to the last-registered element — an XSW bypass): a
   whole-expression `id('X')` selector in any whitespace spelling (`id('X')`, `id ('X')`, `id( "X" )`;
   `parseXPointerIDSelector`) resolves through the duplicate-detecting `domutil.FindElementsByID`

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -1459,7 +1459,7 @@ func resolvePreparedGeneralXPointerTarget(ctx context.Context, doc *helium.Docum
 		if errors.Is(err, ErrHereUnavailable) {
 			return nil, err
 		}
-		return nil, fmt.Errorf("%w: XPointer evaluation failed: %v", ErrReferenceNotFound, err)
+		return nil, fmt.Errorf("%w: XPointer evaluation failed: %w", ErrReferenceNotFound, err)
 	}
 	return singleElementApex(nodes)
 }

--- a/xmldsig1/xpath_features_internal_test.go
+++ b/xmldsig1/xpath_features_internal_test.go
@@ -1,15 +1,42 @@
 package xmldsig1
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xpath1"
 	"github.com/stretchr/testify/require"
 )
+
+// xpointerEvalErrorContext stays live until xpath1 begins evaluating an
+// expression, then reports err for that call and every later poll. This lets the
+// public verification tests reach the general-XPointer evaluator instead of
+// stopping at an earlier context check.
+type xpointerEvalErrorContext struct {
+	context.Context
+	err   error
+	armed bool
+}
+
+func (c *xpointerEvalErrorContext) Err() error {
+	if c.armed {
+		return c.err
+	}
+	_, file, _, ok := runtime.Caller(1)
+	if !ok || !strings.HasSuffix(filepath.ToSlash(file), "/xpath1/eval.go") {
+		return nil
+	}
+	c.armed = true
+	return c.err
+}
 
 // setElementText replaces elem's children with a single text node holding s.
 func setElementText(t *testing.T, doc *helium.Document, elem *helium.Element, s string) {
@@ -93,6 +120,51 @@ func TestGeneralXPointerVerifyRoundTrip(t *testing.T) {
 	t.Run("rejected without AllowXPointer", func(t *testing.T) {
 		_, err := NewVerifier(StaticKey(&key.PublicKey)).Verify(t.Context(), doc)
 		require.ErrorIs(t, err, ErrReferenceNotFound)
+	})
+
+	t.Run("context errors survive public wrappers", func(t *testing.T) {
+		verifier := NewVerifier(StaticKey(&key.PublicKey)).AllowXPointer(true)
+		entries := []struct {
+			name   string
+			verify func(context.Context) error
+		}{
+			{
+				name: "Verify",
+				verify: func(ctx context.Context) error {
+					_, err := verifier.Verify(ctx, doc)
+					return err
+				},
+			},
+			{
+				name: "VerifyElement",
+				verify: func(ctx context.Context) error {
+					_, err := verifier.VerifyElement(ctx, doc, sig)
+					return err
+				},
+			},
+		}
+		contextErrors := []struct {
+			name string
+			err  error
+		}{
+			{name: "canceled", err: context.Canceled},
+			{name: "deadline", err: context.DeadlineExceeded},
+		}
+		for _, entry := range entries {
+			for _, contextError := range contextErrors {
+				t.Run(entry.name+"/"+contextError.name, func(t *testing.T) {
+					ctx := &xpointerEvalErrorContext{Context: t.Context(), err: contextError.err}
+					err := entry.verify(ctx)
+					require.ErrorIs(t, err, ErrReferenceNotFound)
+					require.ErrorIs(t, err, contextError.err)
+					var verifyErr *VerificationError
+					require.ErrorAs(t, err, &verifyErr)
+					require.Equal(t, 0, verifyErr.Reference)
+					require.Equal(t, xpointerURI, verifyErr.URI)
+					require.True(t, ctx.armed)
+				})
+			}
+		}
 	})
 }
 
@@ -295,6 +367,51 @@ func TestGeneralXPointerResolution(t *testing.T) {
 		// external reference and, with no resolver, fails closed.
 		_, _, _, err := canonicalizeReference(t.Context(), &verifierConfig{}, doc, nil, ref)
 		require.ErrorIs(t, err, ErrReferenceNotFound)
+	})
+}
+
+func TestGeneralXPointerEvaluationErrorIdentity(t *testing.T) {
+	doc := mustParse(t, `<root><target/></root>`)
+	prepare := func(t *testing.T, expr string) *preparedGeneralXPointer {
+		t.Helper()
+		prepared, err := prepareGeneralXPointer(doc, nil, expr)
+		require.NoError(t, err)
+		return prepared
+	}
+
+	t.Run("canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := resolvePreparedGeneralXPointerTarget(ctx, doc, prepare(t, "//target"))
+		require.EqualError(t, err,
+			"xmldsig1: reference URI not resolved: XPointer evaluation failed: context canceled")
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+		defer cancel()
+		_, err := resolvePreparedGeneralXPointerTarget(ctx, doc, prepare(t, "//target"))
+		require.EqualError(t, err,
+			"xmldsig1: reference URI not resolved: XPointer evaluation failed: context deadline exceeded")
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("ordinary no-match", func(t *testing.T) {
+		_, err := resolvePreparedGeneralXPointerTarget(t.Context(), doc, prepare(t, "//missing"))
+		require.EqualError(t, err,
+			"xmldsig1: reference URI not resolved: XPointer selected an empty node-set")
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+	})
+
+	t.Run("ordinary XPath error", func(t *testing.T) {
+		_, err := resolvePreparedGeneralXPointerTarget(t.Context(), doc, prepare(t, "true()"))
+		require.EqualError(t, err,
+			"xmldsig1: reference URI not resolved: XPointer evaluation failed: xpath: result is not a node-set")
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+		require.ErrorIs(t, err, xpath1.ErrNotNodeSet)
 	})
 }
 

--- a/xmldsig1/xpath_features_internal_test.go
+++ b/xmldsig1/xpath_features_internal_test.go
@@ -21,9 +21,35 @@ import (
 // public verification tests reach the general-XPointer evaluator instead of
 // stopping at an earlier context check.
 type xpointerEvalErrorContext struct {
-	context.Context
-	err   error
-	armed bool
+	deadline    time.Time
+	hasDeadline bool
+	done        <-chan struct{}
+	value       func(any) any
+	err         error
+	armed       bool
+}
+
+func newXPointerEvalErrorContext(parent context.Context, err error) *xpointerEvalErrorContext {
+	deadline, hasDeadline := parent.Deadline()
+	return &xpointerEvalErrorContext{
+		deadline:    deadline,
+		hasDeadline: hasDeadline,
+		done:        parent.Done(),
+		value:       parent.Value,
+		err:         err,
+	}
+}
+
+func (c *xpointerEvalErrorContext) Deadline() (time.Time, bool) {
+	return c.deadline, c.hasDeadline
+}
+
+func (c *xpointerEvalErrorContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *xpointerEvalErrorContext) Value(key any) any {
+	return c.value(key)
 }
 
 func (c *xpointerEvalErrorContext) Err() error {
@@ -153,7 +179,7 @@ func TestGeneralXPointerVerifyRoundTrip(t *testing.T) {
 		for _, entry := range entries {
 			for _, contextError := range contextErrors {
 				t.Run(entry.name+"/"+contextError.name, func(t *testing.T) {
-					ctx := &xpointerEvalErrorContext{Context: t.Context(), err: contextError.err}
+					ctx := newXPointerEvalErrorContext(t.Context(), contextError.err)
 					err := entry.verify(ctx)
 					require.ErrorIs(t, err, ErrReferenceNotFound)
 					require.ErrorIs(t, err, contextError.err)


### PR DESCRIPTION
- Preserve cancellation and deadline matching when general XPointer evaluation fails.
- Keep `ErrReferenceNotFound` classification and existing diagnostics.
