### PR TITLE
preserve retrieval parse context errors

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -321,7 +321,7 @@ A RetrievalMethod transform list exceeding `maxRetrievalTransformSteps` wraps `E
 
 An external RetrievalMethod X509Data resource that fails XML parsing wraps both `ErrInvalidKeyInfo` and the
 parser error. `errors.Is` therefore matches `context.Canceled` or `context.DeadlineExceeded` when parsing stops
-for context, while `errors.As` still recovers a non-context `*helium.ErrParseError`; the malformed-resource
+for context, while `errors.As` still recovers a non-context `helium.ErrParseError`; the malformed-resource
 wording is unchanged.
 
 ### XML Encryption (`xmlenc1/errors.go`)

--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -319,6 +319,11 @@ every other XPath evaluation failure wraps both `ErrUnsupportedTransform` and th
 
 A RetrievalMethod transform list exceeding `maxRetrievalTransformSteps` wraps `ErrResourceLimitExceeded` before URI dereference, transform execution, or key resolution.
 
+An external RetrievalMethod X509Data resource that fails XML parsing wraps both `ErrInvalidKeyInfo` and the
+parser error. `errors.Is` therefore matches `context.Canceled` or `context.DeadlineExceeded` when parsing stops
+for context, while `errors.As` still recovers a non-context `*helium.ErrParseError`; the malformed-resource
+wording is unchanged.
+
 ### XML Encryption (`xmlenc1/errors.go`)
 
 `ErrCipherValueBytesExceeded` is returned when an EncryptedData payload exceeds

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1334,6 +1334,8 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   recursive RetrievalMethod links. `TypeRawX509Certificate` → `x509.ParseCertificate`; `TypeX509Data` →
   locked-down reparse + `parseX509Data`; any other/absent Type → `ErrInvalidKeyInfo`. A resolved-but-invalid
   resource is `ErrInvalidKeyInfo`, while a resource that cannot be dereferenced is `ErrReferenceNotFound`.
+  A failed external X509Data reparse also preserves the parser error in the chain, so context cancellation or
+  deadline expiry and a structured `*helium.ErrParseError` remain matchable alongside `ErrInvalidKeyInfo`.
   Recursive links use `maxRetrievalMethodDepth`=5 plus a visited-URI set. Retrieved material consumes the
   normal `verifyBudget`, and parsing never establishes trust. `Verifier.LenientKeyInfo(true)` skips only an
   unresolvable RetrievalMethod; resolved-but-invalid material remains fatal.

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -1335,7 +1335,7 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   locked-down reparse + `parseX509Data`; any other/absent Type → `ErrInvalidKeyInfo`. A resolved-but-invalid
   resource is `ErrInvalidKeyInfo`, while a resource that cannot be dereferenced is `ErrReferenceNotFound`.
   A failed external X509Data reparse also preserves the parser error in the chain, so context cancellation or
-  deadline expiry and a structured `*helium.ErrParseError` remain matchable alongside `ErrInvalidKeyInfo`.
+  deadline expiry and a structured `helium.ErrParseError` remain matchable alongside `ErrInvalidKeyInfo`.
   Recursive links use `maxRetrievalMethodDepth`=5 plus a visited-URI set. Retrieved material consumes the
   normal `verifyBudget`, and parsing never establishes trust. `Verifier.LenientKeyInfo(true)` skips only an
   unresolvable RetrievalMethod; resolved-but-invalid material remains fatal.

--- a/xmldsig1/retrieval_method.go
+++ b/xmldsig1/retrieval_method.go
@@ -363,7 +363,7 @@ func parseRetrievalDoc(ctx context.Context, cfg *verifierConfig, octets []byte) 
 	parser := cfg.parser()
 	extDoc, err := parser.Parse(ctx, octets)
 	if err != nil {
-		return nil, fmt.Errorf("%w: cannot parse RetrievalMethod resource as XML: %v", ErrInvalidKeyInfo, err)
+		return nil, fmt.Errorf("%w: cannot parse RetrievalMethod resource as XML: %w", ErrInvalidKeyInfo, err)
 	}
 	return extDoc, nil
 }

--- a/xmldsig1/retrieval_method.go
+++ b/xmldsig1/retrieval_method.go
@@ -63,7 +63,7 @@ func resolveRetrievalMethods(ctx context.Context, budget *verifyBudget, cfg *ver
 		visited := make(map[string]struct{})
 		err := prepareRetrievalMethod(ctx, cfg, doc, elem, prepared, visited, 0)
 		if err != nil {
-			if cfg.lenientKeyInfo && errors.Is(err, ErrReferenceNotFound) {
+			if shouldSkipRetrievalMethod(cfg, err) {
 				continue
 			}
 			return err
@@ -93,12 +93,22 @@ func resolveRetrievalMethods(ctx context.Context, budget *verifyBudget, cfg *ver
 		// ErrUnsupportedTransform, ErrRetrievalMethodLoop, ErrReferenceTooLarge,
 		// ErrAmbiguousReference) and still fails closed here even under leniency —
 		// a corrupt hint is an error, not a missing one.
-		if cfg.lenientKeyInfo && errors.Is(err, ErrReferenceNotFound) {
+		if shouldSkipRetrievalMethod(cfg, err) {
 			continue
 		}
 		return err
 	}
 	return nil
+}
+
+// shouldSkipRetrievalMethod reports whether lenient KeyInfo handling may ignore
+// an unavailable RetrievalMethod. A resolved parse failure may preserve a
+// nested ErrReferenceNotFound from a caller-supplied parser while also wrapping
+// ErrInvalidKeyInfo; resolved-but-invalid material must remain fatal.
+func shouldSkipRetrievalMethod(cfg *verifierConfig, err error) bool {
+	return cfg.lenientKeyInfo &&
+		errors.Is(err, ErrReferenceNotFound) &&
+		!errors.Is(err, ErrInvalidKeyInfo)
 }
 
 // prepareRetrievalMethod parses and statically validates one RetrievalMethod

--- a/xmldsig1/retrieval_method_internal_test.go
+++ b/xmldsig1/retrieval_method_internal_test.go
@@ -57,6 +57,11 @@ type abortingRetrievalParserSAX struct {
 	starts int
 }
 
+type unavailableRetrievalParserSAX struct {
+	*helium.TreeBuilder
+	starts int
+}
+
 func (s *abortingRetrievalParserSAX) StartElementNS(
 	ctx context.Context,
 	localname, prefix, uri string,
@@ -69,6 +74,22 @@ func (s *abortingRetrievalParserSAX) StartElementNS(
 		s.abort()
 	}
 	return err
+}
+
+func (s *unavailableRetrievalParserSAX) StartElementNS(
+	ctx context.Context,
+	localname, prefix, uri string,
+	namespaces []sax.Namespace,
+	attrs []sax.Attribute,
+) error {
+	s.starts++
+	if err := s.TreeBuilder.StartElementNS(ctx, localname, prefix, uri, namespaces, attrs); err != nil {
+		return err
+	}
+	if s.starts == 2 {
+		return ErrReferenceNotFound
+	}
+	return nil
 }
 
 type retrievalParseDeadlineContext struct {
@@ -765,6 +786,28 @@ func TestRetrievalMethodLenientKeyInfo(t *testing.T) {
 
 		err := resolveRetrievalMethods(t.Context(), newVerifyBudget(cfg), cfg, doc, doc.DocumentElement(), data)
 		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	})
+
+	t.Run("resolved parser error sharing unavailable sentinel still fails hard when lenient", func(t *testing.T) {
+		const resource = `<ds:X509Data xmlns:ds="` + NamespaceDSig + `"><child/></ds:X509Data>`
+		doc := mustParse(t, `<ds:KeyInfo xmlns:ds="`+NamespaceDSig+`"><ds:RetrievalMethod URI="keyinfo/data.xml" Type="`+
+			TypeX509Data+`"/></ds:KeyInfo>`)
+		handler := &unavailableRetrievalParserSAX{TreeBuilder: helium.NewTreeBuilder()}
+		parser := helium.NewParser().SAXHandler(handler)
+		resolver := &countingReferenceResolver{octets: []byte(resource)}
+		cfg := &verifierConfig{
+			lenientKeyInfo:    true,
+			referenceParser:   &parser,
+			referenceResolver: resolver,
+		}
+		inlineCert := &x509.Certificate{Raw: []byte("inline certificate")}
+		data := &KeyInfoData{X509Certificates: []*x509.Certificate{inlineCert}}
+
+		err := resolveRetrievalMethods(t.Context(), newVerifyBudget(cfg), cfg, doc, doc.DocumentElement(), data)
+		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+		require.ErrorIs(t, err, ErrReferenceNotFound)
+		require.EqualValues(t, 1, resolver.calls.Load())
+		require.Equal(t, []*x509.Certificate{inlineCert}, data.X509Certificates)
 	})
 
 	t.Run("unsupported Type still fails hard when lenient", func(t *testing.T) {

--- a/xmldsig1/retrieval_method_internal_test.go
+++ b/xmldsig1/retrieval_method_internal_test.go
@@ -18,6 +18,7 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/domutil"
+	"github.com/lestrrat-go/helium/sax"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,6 +49,60 @@ type capturingReferenceResolver struct {
 	calls  atomic.Int32
 	octets []byte
 	uri    string
+}
+
+type abortingRetrievalParserSAX struct {
+	*helium.TreeBuilder
+	abort  func()
+	starts int
+}
+
+func (s *abortingRetrievalParserSAX) StartElementNS(
+	ctx context.Context,
+	localname, prefix, uri string,
+	namespaces []sax.Namespace,
+	attrs []sax.Attribute,
+) error {
+	s.starts++
+	err := s.TreeBuilder.StartElementNS(ctx, localname, prefix, uri, namespaces, attrs)
+	if s.starts == 2 {
+		s.abort()
+	}
+	return err
+}
+
+type retrievalParseDeadlineContext struct {
+	context.Context
+	done    chan struct{}
+	expired atomic.Bool
+}
+
+func newRetrievalParseDeadlineContext(parent context.Context) *retrievalParseDeadlineContext {
+	return &retrievalParseDeadlineContext{Context: parent, done: make(chan struct{})}
+}
+
+func (c *retrievalParseDeadlineContext) Deadline() (time.Time, bool) {
+	if c.expired.Load() {
+		return time.Unix(0, 0), true
+	}
+	return c.Context.Deadline()
+}
+
+func (c *retrievalParseDeadlineContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *retrievalParseDeadlineContext) Err() error {
+	if c.expired.Load() {
+		return context.DeadlineExceeded
+	}
+	return c.Context.Err()
+}
+
+func (c *retrievalParseDeadlineContext) expire() {
+	if c.expired.CompareAndSwap(false, true) {
+		close(c.done)
+	}
 }
 
 func (r *capturingReferenceResolver) ResolveReference(_ context.Context, uri string) ([]byte, error) {
@@ -721,12 +776,76 @@ func TestRetrievalMethodLenientKeyInfo(t *testing.T) {
 // Verifier.LenientKeyInfo, non-skippable — leniency only skips the genuinely
 // unavailable case.
 func TestResolveRetrievalMethodResolvedButNotXML(t *testing.T) {
-	fsys := fstest.MapFS{"keyinfo/data.xml": {Data: []byte("this is not <well-formed> xml")}}
+	const malformedResource = "this is not <well-formed> xml"
+	fsys := fstest.MapFS{"keyinfo/data.xml": {Data: []byte(malformedResource)}}
 	doc := mustParse(t, `<ds:KeyInfo xmlns:ds="`+NamespaceDSig+`"><ds:RetrievalMethod URI="keyinfo/data.xml" Type="`+TypeX509Data+`"/></ds:KeyInfo>`)
 	cfg := &verifierConfig{referenceResolver: FSReferenceResolver(fsys)}
 	data := &KeyInfoData{}
 
 	err := resolveRetrievalMethods(t.Context(), newVerifyBudget(cfg), cfg, doc, doc.DocumentElement(), data)
 	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	var parseErr helium.ErrParseError
+	require.ErrorAs(t, err, &parseErr)
+	_, directParseErr := cfg.parser().Parse(t.Context(), []byte(malformedResource))
+	require.Equal(t,
+		fmt.Sprintf("%v: cannot parse RetrievalMethod resource as XML: %v", ErrInvalidKeyInfo, directParseErr),
+		err.Error(),
+	)
+	require.NotErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, context.DeadlineExceeded)
 	require.Empty(t, data.X509Certificates)
+}
+
+func TestParseRetrievalDocPreservesContextError(t *testing.T) {
+	const resource = `<ds:X509Data xmlns:ds="` + NamespaceDSig + `"><first/><second/></ds:X509Data>`
+
+	t.Run("canceled mid-parse", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		handler := &abortingRetrievalParserSAX{TreeBuilder: helium.NewTreeBuilder(), abort: cancel}
+		parser := helium.NewParser().SAXHandler(handler)
+
+		doc, err := parseRetrievalDoc(ctx, &verifierConfig{referenceParser: &parser}, []byte(resource))
+		require.Nil(t, doc)
+		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Contains(t, err.Error(), "cannot parse RetrievalMethod resource as XML: context canceled")
+	})
+
+	t.Run("deadline expires mid-parse", func(t *testing.T) {
+		ctx := newRetrievalParseDeadlineContext(t.Context())
+		handler := &abortingRetrievalParserSAX{TreeBuilder: helium.NewTreeBuilder(), abort: ctx.expire}
+		parser := helium.NewParser().SAXHandler(handler)
+
+		doc, err := parseRetrievalDoc(ctx, &verifierConfig{referenceParser: &parser}, []byte(resource))
+		require.Nil(t, doc)
+		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Contains(t, err.Error(), "cannot parse RetrievalMethod resource as XML: context deadline exceeded")
+	})
+}
+
+func TestVerifyPreservesRetrievalMethodParseCancellation(t *testing.T) {
+	const resource = `<ds:X509Data xmlns:ds="` + NamespaceDSig + `"><first/><second/></ds:X509Data>`
+	doc := mustParse(t, `<root><ds:Signature xmlns:ds="`+NamespaceDSig+`">`+
+		`<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="`+ExcC14N10+`"/>`+
+		`<ds:SignatureMethod Algorithm="`+AlgRSASHA256+`"/>`+
+		`<ds:Reference URI=""><ds:DigestMethod Algorithm="`+DigestSHA256+`"/>`+
+		`<ds:DigestValue>AA==</ds:DigestValue></ds:Reference></ds:SignedInfo>`+
+		`<ds:SignatureValue>AA==</ds:SignatureValue><ds:KeyInfo>`+
+		`<ds:RetrievalMethod URI="keyinfo/data.xml" Type="`+TypeX509Data+`"/>`+
+		`</ds:KeyInfo></ds:Signature></root>`)
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	handler := &abortingRetrievalParserSAX{TreeBuilder: helium.NewTreeBuilder(), abort: cancel}
+	parser := helium.NewParser().SAXHandler(handler)
+	resolver := &countingReferenceResolver{octets: []byte(resource)}
+
+	_, err = NewVerifier(StaticKey(&key.PublicKey)).
+		ReferenceResolver(resolver).
+		ReferenceParser(parser).
+		Verify(ctx, doc)
+	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	require.ErrorIs(t, err, context.Canceled)
+	require.EqualValues(t, 1, resolver.calls.Load())
 }

--- a/xmldsig1/retrieval_method_internal_test.go
+++ b/xmldsig1/retrieval_method_internal_test.go
@@ -72,20 +72,27 @@ func (s *abortingRetrievalParserSAX) StartElementNS(
 }
 
 type retrievalParseDeadlineContext struct {
-	context.Context
-	done    chan struct{}
-	expired atomic.Bool
+	parentDeadline func() (time.Time, bool)
+	parentErr      func() error
+	parentValue    func(any) any
+	done           chan struct{}
+	expired        atomic.Bool
 }
 
 func newRetrievalParseDeadlineContext(parent context.Context) *retrievalParseDeadlineContext {
-	return &retrievalParseDeadlineContext{Context: parent, done: make(chan struct{})}
+	return &retrievalParseDeadlineContext{
+		parentDeadline: parent.Deadline,
+		parentErr:      parent.Err,
+		parentValue:    parent.Value,
+		done:           make(chan struct{}),
+	}
 }
 
 func (c *retrievalParseDeadlineContext) Deadline() (time.Time, bool) {
 	if c.expired.Load() {
 		return time.Unix(0, 0), true
 	}
-	return c.Context.Deadline()
+	return c.parentDeadline()
 }
 
 func (c *retrievalParseDeadlineContext) Done() <-chan struct{} {
@@ -96,7 +103,11 @@ func (c *retrievalParseDeadlineContext) Err() error {
 	if c.expired.Load() {
 		return context.DeadlineExceeded
 	}
-	return c.Context.Err()
+	return c.parentErr()
+}
+
+func (c *retrievalParseDeadlineContext) Value(key any) any {
+	return c.parentValue(key)
 }
 
 func (c *retrievalParseDeadlineContext) expire() {


### PR DESCRIPTION
- preserve cancellation and deadline identity when RetrievalMethod XML parsing fails
- retain invalid-KeyInfo classification and malformed-document diagnostics
