### PR TITLE
scale namespace declaration building

### DIFF
--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -399,7 +399,9 @@ Skipped in `setTreeDoc()` — sentinel type rarely instantiated.
   mis-binds the attribute. Synthesizing a fresh prefix to preserve both faithfully would need
   `xmlReconciliateNs`-style prefix generation, out of scope here. `AddNamespaceDecl(nil)` returns `ErrNilNode`
   and leaves `nsDefs` unchanged (a nil declaration is rejected, not appended); the dedup scan still skips any
-  nil `nsDefs` slot injected by an in-package field write.
+  nil `nsDefs` slot injected by an in-package field write. Tree construction preserves these rules through
+  the private `declareNamespace` core; `declareNamespaces` supplies a prefix-to-slot index for a wide SAX
+  declaration batch, while public one-at-a-time calls retain the allocation-free linear scan.
 - `UnlinkNode(n)` — detach a `MutableNode` from parent and siblings (delegates to the internal `unlinkNode(Node)`)
 - `unlinkNode(n)` — internal detach that works for ANY sealed node via `baseDocNode()`, including
   non-`MutableNode` nodes like `NamespaceNodeWrapper`. Attribute-aware: an `Attribute` under an `*Element` is

--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -225,7 +225,11 @@ fire `Reference`). Each invariant lives at its function:
 
 Parent selection: DTD subset → add to DTD; no current element → add to document; else → append as child.
 
-DOM fast path: when the default parser builds a DOM, start-tag attribute/ID/child linking bypasses generic duplicate-checking setters where parser invariants already guarantee the `xmlAddChild` preconditions. Public DOM shape is preserved.
+DOM fast path: when the default parser builds a DOM, start-tag attribute/ID/child linking bypasses generic
+duplicate-checking setters where parser invariants already guarantee the `xmlAddChild` preconditions. Both
+the direct path and `TreeBuilder.StartElementNS` bulk-declare namespaces through `declareNamespaces`: it uses
+the allocation-free `DeclareNamespace` scan below `attrDupSetThreshold` and a prefix-to-slot index at or above
+it. Declaration order, prefix-collapse behavior, and public DOM shape are preserved.
 
 ## Hardening / Resource-Bound Pointers
 

--- a/node.go
+++ b/node.go
@@ -1572,31 +1572,51 @@ func (n *node) prefixConflictsInUse(prefix, uri string) bool {
 // most one xmlns:prefix per element across all mutators is a serializer-level
 // concern, outside this method's scope.
 func (n *node) DeclareNamespace(prefix, uri string) error {
+	return n.declareNamespace(prefix, uri, nil)
+}
+
+// declareNamespace is DeclareNamespace with an optional prefix-to-slot index.
+// Bulk builders use the index after a declaration list becomes wide; public
+// one-at-a-time mutation keeps the allocation-free linear scan above.
+func (n *node) declareNamespace(prefix, uri string, slots map[string]int) error {
 	if n.prefixConflictsInUse(prefix, uri) {
 		return fmt.Errorf("cannot rebind namespace prefix %q while it is in use on this element: %w", prefix, ErrInvalidOperation)
 	}
-	for i, ns := range n.nsDefs {
-		if ns == nil {
-			continue
+	if slots != nil {
+		if i, ok := slots[prefix]; ok {
+			return n.replaceNamespaceDeclaration(i, prefix, uri)
 		}
-		if ns.Prefix() != prefix {
-			continue
+	} else {
+		for i, ns := range n.nsDefs {
+			if ns == nil || ns.Prefix() != prefix {
+				continue
+			}
+			return n.replaceNamespaceDeclaration(i, prefix, uri)
 		}
-		if ns.URI() == uri {
-			return nil
-		}
-		fresh, err := n.doc.CreateNamespace(prefix, uri)
-		if err != nil {
-			return err
-		}
-		n.nsDefs[i] = fresh
-		return nil
 	}
 	ns, err := n.doc.CreateNamespace(prefix, uri)
 	if err != nil {
 		return err
 	}
+	if slots != nil {
+		slots[prefix] = len(n.nsDefs)
+	}
 	n.nsDefs = append(n.nsDefs, ns)
+	return nil
+}
+
+func (n *node) replaceNamespaceDeclaration(i int, prefix, uri string) error {
+	ns := n.nsDefs[i]
+	if ns != nil {
+		if ns.URI() == uri {
+			return nil
+		}
+	}
+	fresh, err := n.doc.CreateNamespace(prefix, uri)
+	if err != nil {
+		return err
+	}
+	n.nsDefs[i] = fresh
 	return nil
 }
 

--- a/parser_internal_test.go
+++ b/parser_internal_test.go
@@ -579,6 +579,106 @@ func TestNamespaceDeclarationDuplicateAboveThreshold(t *testing.T) {
 	})
 }
 
+type wrappedTreeBuilder struct {
+	*TreeBuilder
+}
+
+func parseWithWrappedTreeBuilder(ctx context.Context, src string, clean bool) (*Document, error) {
+	return NewParser().
+		CleanNamespaces(clean).
+		SAXHandler(&wrappedTreeBuilder{TreeBuilder: NewTreeBuilder()}).
+		Parse(ctx, []byte(src))
+}
+
+// TestNamespaceDeclarationBuilderThreshold compares the parser's direct DOM
+// path with the generic SAX TreeBuilder path around the point where bulk
+// namespace declaration switches to its prefix index.
+func TestNamespaceDeclarationBuilderThreshold(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{"below threshold", attrDupSetThreshold - 1},
+		{"at threshold", attrDupSetThreshold},
+		{"above threshold", attrDupSetThreshold + 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := nsDeclTag(tc.n, false)
+			fastDoc, fastErr := NewParser().Parse(t.Context(), []byte(src))
+			saxDoc, saxErr := parseWithWrappedTreeBuilder(t.Context(), src, false)
+			require.NoError(t, fastErr)
+			require.NoError(t, saxErr)
+
+			fastNS := fastDoc.DocumentElement().Namespaces()
+			saxNS := saxDoc.DocumentElement().Namespaces()
+			require.Len(t, fastNS, tc.n)
+			require.Len(t, saxNS, tc.n)
+			for i := range tc.n {
+				wantPrefix := fmt.Sprintf("p%d", i)
+				wantURI := fmt.Sprintf("urn:x%d", i)
+				require.Equal(t, wantPrefix, fastNS[i].Prefix(), "fast path declaration order at index %d", i)
+				require.Equal(t, wantURI, fastNS[i].URI(), "fast path declaration URI at index %d", i)
+				require.Equal(t, wantPrefix, saxNS[i].Prefix(), "SAX path declaration order at index %d", i)
+				require.Equal(t, wantURI, saxNS[i].URI(), "SAX path declaration URI at index %d", i)
+			}
+
+			for _, clean := range []bool{false, true} {
+				dupSrc := nsDeclTag(tc.n, true)
+				_, fastErr = NewParser().CleanNamespaces(clean).Parse(t.Context(), []byte(dupSrc))
+				_, saxErr = parseWithWrappedTreeBuilder(t.Context(), dupSrc, clean)
+				require.Error(t, fastErr)
+				require.EqualError(t, saxErr, fastErr.Error(),
+					"TreeBuilder selection and CleanNamespaces=%t must not change the duplicate diagnostic", clean)
+			}
+		})
+	}
+}
+
+func TestNamespaceDeclarationUndeclarationBuilderParity(t *testing.T) {
+	t.Parallel()
+
+	const xml10 = `<?xml version="1.0"?><root xmlns:p="urn:x"><child xmlns:p=""/></root>`
+	_, fastErr := NewParser().Parse(t.Context(), []byte(xml10))
+	_, saxErr := parseWithWrappedTreeBuilder(t.Context(), xml10, false)
+	require.Error(t, fastErr)
+	require.EqualError(t, saxErr, fastErr.Error(),
+		"the generic TreeBuilder path must preserve the XML 1.0 prefix-undeclaration diagnostic")
+
+	const xml11 = `<?xml version="1.1"?><root xmlns:p="urn:x"><child xmlns:p=""/></root>`
+	fastDoc, fastErr := NewParser().Parse(t.Context(), []byte(xml11))
+	saxDoc, saxErr := parseWithWrappedTreeBuilder(t.Context(), xml11, false)
+	require.NoError(t, fastErr)
+	require.NoError(t, saxErr)
+	for _, doc := range []*Document{fastDoc, saxDoc} {
+		child := doc.DocumentElement().FirstChild()
+		elem, ok := child.(*Element)
+		require.True(t, ok)
+		require.Len(t, elem.Namespaces(), 1)
+		require.Equal(t, "p", elem.Namespaces()[0].Prefix())
+		require.Empty(t, elem.Namespaces()[0].URI())
+	}
+}
+
+func BenchmarkParseWideNamespaceDeclarations(b *testing.B) {
+	for _, n := range []int{attrDupSetThreshold, attrDupSetThreshold * 8, attrDupSetThreshold * 64} {
+		src := []byte(nsDeclTag(n, false))
+		b.Run(fmt.Sprintf("declarations_%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(src)))
+			for b.Loop() {
+				if _, err := NewParser().Parse(b.Context(), src); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 // newAttributeDefaultCtx builds a parserCtx that is ready to record <!ATTLIST>
 // defaults: init() seeds the lookup tables and doc supplies the owner for the
 // Attribute nodes addAttributeDefault creates.

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -136,10 +136,8 @@ func (t *TreeBuilder) StartElementNS(ctxif context.Context, localname, prefix, u
 		}
 	}
 
-	for _, ns := range namespaces {
-		if err := e.DeclareNamespace(ns.Prefix(), ns.URI()); err != nil {
-			return err
-		}
+	if err := declareNamespaces(e, namespaces); err != nil {
+		return err
 	}
 
 	for _, attr := range attrs {
@@ -221,6 +219,26 @@ func (t *TreeBuilder) StartElementNS(ctxif context.Context, localname, prefix, u
 
 	ctx.elem = e
 
+	return nil
+}
+
+type namespaceDeclaration interface {
+	Prefix() string
+	URI() string
+}
+
+// declareNamespaces preserves DeclareNamespace's collapse and conflict rules
+// while avoiding a complete nsDefs scan for each entry in a wide SAX batch.
+func declareNamespaces[T namespaceDeclaration](e *Element, namespaces []T) error {
+	var slots map[string]int
+	if len(namespaces) >= attrDupSetThreshold {
+		slots = make(map[string]int, len(namespaces))
+	}
+	for _, ns := range namespaces {
+		if err := e.declareNamespace(ns.Prefix(), ns.URI(), slots); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/tree_fastpath.go
+++ b/tree_fastpath.go
@@ -156,10 +156,8 @@ func (pctx *parserCtx) fastStartElement(localname, prefix, uri string, attrs []a
 	}
 
 	if nbNs > 0 {
-		for _, ns := range pctx.nsTab.Peek(nbNs) {
-			if err := e.DeclareNamespace(ns.Prefix(), ns.URI()); err != nil {
-				return err
-			}
+		if err := declareNamespaces(e, pctx.nsTab.Peek(nbNs)); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
- Keep DOM namespace construction near-linear for wide start tags.
- Preserve declaration order and parser diagnostics across DOM and SAX paths.
