### PR TITLE
fix XSD complex type diagnostic labels

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -177,6 +177,9 @@ package's existing error chain.
 | `schemaElemDeclError()` | `{file}:{line}: element element: Schemas parser error : element decl. '{name}': {msg}\n` |
 | `schemaElemDeclErrorAttr()` | `{file}:{line}: element element: Schemas parser error : element decl. '{name}', attribute '{attr}': {msg}\n` |
 
+`complexTypeComponent(td, src)` owns complex-type component labels: a global definition is
+`complex type 'name'`; an anonymous/local definition is `local complex type`.
+
 ### RELAX NG (`relaxng/errors.go`)
 
 | Function | Format |

--- a/xsd/check_element_consistent.go
+++ b/xsd/check_element_consistent.go
@@ -71,12 +71,14 @@ func (c *compiler) checkElementConsistent(ctx context.Context) {
 		if source == "" {
 			source = c.filename
 		}
-		c.checkContentModelConsistent(ctx, ct.td.ContentModel, source, ct.src.line, c.complexTypeComponent(ct.td, ct.src))
+		component := complexTypeComponent(ct.td, ct.src)
+		c.checkContentModelConsistent(ctx, ct.td.ContentModel, source, ct.src.line, component)
 		// The type's EFFECTIVE open-content wildcard can also resolve a same-named
 		// declared local element to a global (interleave moves an extra occurrence to
 		// the open partition; suffix matches a trailing one), so it participates in the
 		// type-table EDC exactly like a content-model wildcard.
-		c.checkWildcardElementConsistent(ctx, ct.td.ContentModel, ct.td.OpenContent, source, ct.src.line, "complexType", c.complexTypeComponent(ct.td, ct.src))
+		c.checkWildcardElementConsistent(ctx, ct.td.ContentModel, ct.td.OpenContent, source, ct.src.line,
+			"complexType", component)
 	}
 
 	// Run the same consistency check over standalone named model group
@@ -253,15 +255,6 @@ func (c *compiler) collectModelGroupParticles(mg *ModelGroup) (map[QName][]*Elem
 	}
 	walk(mg)
 	return elems, wildcards
-}
-
-// complexTypeComponent returns the diagnostic component label for a complex
-// type, matching the wording used by the other cos/derivation checks.
-func (c *compiler) complexTypeComponent(td *TypeDef, src typeDefSource) string {
-	if src.isLocal {
-		return componentLocalComplexType
-	}
-	return td.Name.Local
 }
 
 // checkContentModelConsistent collects every element declaration reachable in mg

--- a/xsd/check_facets.go
+++ b/xsd/check_facets.go
@@ -495,7 +495,9 @@ func (c *compiler) checkEnumQNameAndNotation(ctx context.Context) {
 		}
 
 		component := td.Name.Local
-		if component == "" || e.src.isLocal {
+		if td.IsComplex {
+			component = complexTypeComponent(td, e.src)
+		} else if component == "" || e.src.isLocal {
 			component = componentLocalSimpleType
 		}
 
@@ -1045,7 +1047,9 @@ func (c *compiler) checkAnyAtomicTypeUsage(ctx context.Context) {
 	for _, e := range entries {
 		td := e.td
 		component := td.Name.Local
-		if component == "" || e.src.isLocal {
+		if td.IsComplex {
+			component = complexTypeComponent(td, e.src)
+		} else if component == "" || e.src.isLocal {
 			component = componentLocalSimpleType
 		}
 		report := func(role string) {
@@ -1194,11 +1198,10 @@ func (c *compiler) checkAnySimpleTypeUsage(ctx context.Context) {
 			elemKind = elemSimpleType
 		}
 		component := td.Name.Local
-		if component == "" || e.src.isLocal {
+		if td.IsComplex {
+			component = complexTypeComponent(td, e.src)
+		} else if component == "" || e.src.isLocal {
 			component = componentLocalSimpleType
-			if td.IsComplex {
-				component = componentLocalComplexType
-			}
 		}
 		report := func(role string) {
 			c.schemaError(ctx, schemaComponentError(c.filename, e.src.line, elemKind, component,

--- a/xsd/check_facets.go
+++ b/xsd/check_facets.go
@@ -544,11 +544,12 @@ func (c *compiler) checkEnumQNameAndNotation(ctx context.Context) {
 	}
 }
 
-// checkCircularSimpleTypes reports a schema error for any simple type that
+// checkCircularSimpleTypes reports a schema error for any type definition that
 // participates in a circular definition: a union whose memberTypes reference it
-// (transitively), a list whose itemType reaches it, or a restriction whose base
-// chain returns to it (XSD §3.16.6.3 / cos-no-circular-unions and the general
-// "no circular type definitions" rule). Such a schema is invalid, and several
+// (transitively), a list whose itemType reaches it, or a restriction/complex-type
+// derivation whose base chain returns to it (XSD §3.16.6.3 /
+// cos-no-circular-unions and the general "no circular type definitions" rule).
+// Such a schema is invalid, and several
 // variety-walking compile checks (and resolveVariety/resolveItemType base
 // walks) would otherwise recurse forever on it; reporting it here surfaces the
 // real error before those walks run. It returns true when at least one circular
@@ -587,10 +588,14 @@ func (c *compiler) checkCircularSimpleTypes(ctx context.Context) bool {
 		}
 		found = true
 		component := e.td.Name.Local
-		if component == "" || e.src.isLocal {
+		elemKind := elemSimpleType
+		if e.td.IsComplex {
+			elemKind = elemComplexType
+			component = complexTypeComponent(e.td, e.src)
+		} else if component == "" || e.src.isLocal {
 			component = componentLocalSimpleType
 		}
-		c.schemaError(ctx, schemaComponentError(c.filename, e.src.line, "simpleType", component,
+		c.schemaError(ctx, schemaComponentError(c.filename, e.src.line, elemKind, component,
 			"Circular definition of the simple type; a type must not be a member, item, or base type of itself."))
 	}
 	return found
@@ -621,11 +626,11 @@ func simpleTypeReachesSelf(start *TypeDef) bool {
 	return walk(start)
 }
 
-// simpleTypeNeighbors returns the non-builtin simple types that td directly
+// simpleTypeNeighbors returns the non-builtin type definitions that td directly
 // depends on: its union member types, its list item type, and its restriction
 // base type (only when that base is a user-defined, non-builtin type). Builtin
 // XSD types are leaves and are never returned, so the walk stays within the
-// user-declared simple-type graph.
+// user-declared type graph. The base edge may connect complex types.
 func simpleTypeNeighbors(td *TypeDef) []*TypeDef {
 	if td == nil {
 		return nil

--- a/xsd/check_facets_component_test.go
+++ b/xsd/check_facets_component_test.go
@@ -1,0 +1,136 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFacetComponentLabels(t *testing.T) {
+	t.Parallel()
+
+	const notationComplex = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="T">
+    <xs:simpleContent>
+      <xs:restriction base="xs:NOTATION"/>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>`
+	const notationSimple = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="S">
+    <xs:restriction base="xs:NOTATION"/>
+  </xs:simpleType>
+</xs:schema>`
+
+	for _, version := range []struct {
+		name string
+		v11  bool
+	}{
+		{"xsd10", false},
+		{"xsd11", true},
+	} {
+		t.Run("notation complex/"+version.name, func(t *testing.T) {
+			t.Parallel()
+			errs := compileSchemaErrorsVersion(t, notationComplex, version.v11)
+			require.Contains(t, errs,
+				"complex type 'T': It is an error if the base type is the built-in 'NOTATION' and there is no 'enumeration' facet.")
+		})
+		t.Run("notation simple/"+version.name, func(t *testing.T) {
+			t.Parallel()
+			errs := compileSchemaErrorsVersion(t, notationSimple, version.v11)
+			require.Contains(t, errs,
+				"S: It is an error if the base type is the built-in 'NOTATION' and there is no 'enumeration' facet.")
+		})
+	}
+
+	t.Run("anyAtomicType complex in xsd11", func(t *testing.T) {
+		t.Parallel()
+		const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="T">
+    <xs:simpleContent>
+      <xs:restriction base="xs:anyAtomicType"/>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>`
+		errs := compileSchemaErrorsVersion(t, schema, true)
+		require.Contains(t, errs, "complex type 'T': The base type must not be the built-in 'anyAtomicType'.")
+	})
+
+	t.Run("anyAtomicType simple in xsd11", func(t *testing.T) {
+		t.Parallel()
+		const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="S">
+    <xs:restriction base="xs:anyAtomicType"/>
+  </xs:simpleType>
+</xs:schema>`
+		errs := compileSchemaErrorsVersion(t, schema, true)
+		require.Contains(t, errs, "S: The base type must not be the built-in 'anyAtomicType'.")
+	})
+
+	const anySimpleComplex = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="T">
+    <xs:simpleContent>
+      <xs:restriction base="xs:anySimpleType"/>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>`
+	const anySimpleLocal = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:restriction base="xs:anySimpleType"/>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+	const anySimpleSimple = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="S">
+    <xs:restriction base="xs:anySimpleType"/>
+  </xs:simpleType>
+</xs:schema>`
+
+	for _, version := range []struct {
+		name string
+		v11  bool
+	}{
+		{"xsd10", false},
+		{"xsd11", true},
+	} {
+		t.Run("anySimpleType complex/"+version.name, func(t *testing.T) {
+			t.Parallel()
+			errs := compileSchemaErrorsVersion(t, anySimpleComplex, version.v11)
+			require.Contains(t, errs, "complex type 'T': The base type must not be the built-in 'anySimpleType'.")
+		})
+		t.Run("anySimpleType local/"+version.name, func(t *testing.T) {
+			t.Parallel()
+			errs := compileSchemaErrorsVersion(t, anySimpleLocal, version.v11)
+			require.Contains(t, errs, "local complex type: The base type must not be the built-in 'anySimpleType'.")
+		})
+		t.Run("anySimpleType simple/"+version.name, func(t *testing.T) {
+			t.Parallel()
+			errs := compileSchemaErrorsVersion(t, anySimpleSimple, version.v11)
+			require.Contains(t, errs, "S: The base type must not be the built-in 'anySimpleType'.")
+		})
+	}
+
+	t.Run("synthetic local facet type", func(t *testing.T) {
+		t.Parallel()
+		const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="S"><xs:restriction base="xs:decimal"/></xs:simpleType>
+  <xs:complexType name="Base">
+    <xs:simpleContent><xs:extension base="S"/></xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="T">
+    <xs:simpleContent>
+      <xs:restriction base="Base">
+        <xs:minInclusive value="2"/>
+        <xs:maxInclusive value="1"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>`
+		errs := compileSchemaErrorsVersion(t, schema, true)
+		require.Contains(t, errs,
+			"local simple type: It is an error for the value of 'minInclusive' to be greater than the value of 'maxInclusive'.")
+	})
+}

--- a/xsd/check_facets_component_test.go
+++ b/xsd/check_facets_component_test.go
@@ -134,3 +134,33 @@ func TestFacetComponentLabels(t *testing.T) {
 			"local simple type: It is an error for the value of 'minInclusive' to be greater than the value of 'maxInclusive'.")
 	})
 }
+
+func TestCircularComplexTypeComponentLabels(t *testing.T) {
+	t.Parallel()
+
+	const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="T">
+    <xs:complexContent><xs:extension base="U"/></xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="U">
+    <xs:complexContent><xs:extension base="T"/></xs:complexContent>
+  </xs:complexType>
+</xs:schema>`
+	for _, version := range []struct {
+		name string
+		v11  bool
+	}{
+		{testLabelXSD10, false},
+		{testLabelXSD11, true},
+	} {
+		t.Run(version.name, func(t *testing.T) {
+			t.Parallel()
+			errs := compileSchemaErrorsVersion(t, schema, version.v11)
+			for _, name := range []string{"T", "U"} {
+				require.Contains(t, errs,
+					"element complexType: Schemas parser error : complex type '"+name+"': "+
+						"Circular definition of the simple type")
+			}
+		})
+	}
+}

--- a/xsd/check_facets_component_test.go
+++ b/xsd/check_facets_component_test.go
@@ -26,8 +26,8 @@ func TestFacetComponentLabels(t *testing.T) {
 		name string
 		v11  bool
 	}{
-		{"xsd10", false},
-		{"xsd11", true},
+		{testLabelXSD10, false},
+		{testLabelXSD11, true},
 	} {
 		t.Run("notation complex/"+version.name, func(t *testing.T) {
 			t.Parallel()
@@ -93,8 +93,8 @@ func TestFacetComponentLabels(t *testing.T) {
 		name string
 		v11  bool
 	}{
-		{"xsd10", false},
-		{"xsd11", true},
+		{testLabelXSD10, false},
+		{testLabelXSD11, true},
 	} {
 		t.Run("anySimpleType complex/"+version.name, func(t *testing.T) {
 			t.Parallel()

--- a/xsd/check_upa.go
+++ b/xsd/check_upa.go
@@ -16,11 +16,7 @@ func (c *compiler) checkUPA(ctx context.Context, td *TypeDef, src typeDefSource)
 		return
 	}
 	if !modelGroupIsDeterministic(td.ContentModel, c.schema) {
-		component := componentLocalComplexType
-		if !src.isLocal {
-			component = td.Name.Local
-		}
-		c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component,
+		c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", complexTypeComponent(td, src),
 			"The content model is not determinist."))
 	}
 }

--- a/xsd/check_upa_test.go
+++ b/xsd/check_upa_test.go
@@ -518,6 +518,51 @@ func TestUPADeterminism(t *testing.T) {
 	})
 }
 
+func TestUPAComponentLabels(t *testing.T) {
+	t.Parallel()
+
+	const global = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="T">
+    <xs:choice>
+      <xs:element name="a" type="xs:string"/>
+      <xs:element name="a" type="xs:string"/>
+    </xs:choice>
+  </xs:complexType>
+</xs:schema>`
+	const local = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:choice>
+        <xs:element name="a" type="xs:string"/>
+        <xs:element name="a" type="xs:string"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	for _, tc := range []struct {
+		name   string
+		schema string
+		want   string
+	}{
+		{"global", global, "complex type 'T': The content model is not determinist."},
+		{"local", local, "local complex type: The content model is not determinist."},
+	} {
+		for _, version := range []struct {
+			name string
+			v11  bool
+		}{
+			{"xsd10", false},
+			{"xsd11", true},
+		} {
+			t.Run(tc.name+"/"+version.name, func(t *testing.T) {
+				t.Parallel()
+				require.Contains(t, compileSchemaErrorsVersion(t, tc.schema, version.v11), tc.want)
+			})
+		}
+	}
+}
+
 // TestUPAFiniteCountedRepetitionInstance verifies that a deterministic counted
 // model `a{2}, a` not only compiles cleanly but also validates an instance with
 // three `a` children (xmllint accepts this schema + instance).

--- a/xsd/check_upa_test.go
+++ b/xsd/check_upa_test.go
@@ -552,8 +552,8 @@ func TestUPAComponentLabels(t *testing.T) {
 			name string
 			v11  bool
 		}{
-			{"xsd10", false},
-			{"xsd11", true},
+			{testLabelXSD10, false},
+			{testLabelXSD11, true},
 		} {
 			t.Run(tc.name+"/"+version.name, func(t *testing.T) {
 				t.Parallel()

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -1553,7 +1553,7 @@ func (c *compiler) validateComponentChildName(ctx context.Context, elem *helium.
 		msg := "The value '" + name + "' of attribute 'name' is not a valid 'xs:NCName'."
 		switch {
 		case isXSDElement(elem, elemComplexType):
-			c.schemaError(ctx, schemaComponentError(c.diagSource(), elem.Line(), elem.LocalName(), componentLocalComplexType, msg))
+			c.schemaError(ctx, schemaComponentError(c.diagSource(), elem.Line(), elem.LocalName(), globalComplexTypeComponent(name), msg))
 		case isXSDElement(elem, elemSimpleType):
 			c.schemaError(ctx, schemaComponentError(c.diagSource(), elem.Line(), elem.LocalName(), componentLocalSimpleType, msg))
 		default:

--- a/xsd/complextype_block_sites_test.go
+++ b/xsd/complextype_block_sites_test.go
@@ -56,7 +56,7 @@ func TestComplexTypeBlock_SubstitutionGroup(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		ver  xsd.Version
-	}{{"xsd10", xsd.Version10}, {"xsd11", xsd.Version11}} {
+	}{{testLabelXSD10, xsd.Version10}, {testLabelXSD11, xsd.Version11}} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("head TYPE block=extension rejects extension-derived member", func(t *testing.T) {
 				require.ErrorIs(t, compileValidate(t, tc.ver, `block="extension"`), xsd.ErrValidationFailed)
@@ -216,7 +216,7 @@ func TestComplexTypeBlock_SubstitutionIntermediate(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		ver  xsd.Version
-	}{{"xsd10", xsd.Version10}, {"xsd11", xsd.Version11}} {
+	}{{testLabelXSD10, xsd.Version10}, {testLabelXSD11, xsd.Version11}} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("intermediate TYPE block=extension rejects member", func(t *testing.T) {
 				require.ErrorIs(t, compileValidate(t, tc.ver, `block="extension"`), xsd.ErrValidationFailed)
@@ -318,7 +318,7 @@ func TestComplexTypeBlock_ParticleRestriction(t *testing.T) {
 </xs:schema>`
 	}
 
-	t.Run("xsd11", func(t *testing.T) {
+	t.Run(testLabelXSD11, func(t *testing.T) {
 		t.Run("base TYPE block=restriction rejects retyping restriction", func(t *testing.T) {
 			_, _, cerr := compileV11(t, schemaFor(`block="restriction"`))
 			require.Error(t, cerr)
@@ -328,7 +328,7 @@ func TestComplexTypeBlock_ParticleRestriction(t *testing.T) {
 			require.NoError(t, cerr)
 		})
 	})
-	t.Run("xsd10", func(t *testing.T) {
+	t.Run(testLabelXSD10, func(t *testing.T) {
 		t.Run("base TYPE block=restriction rejects retyping restriction", func(t *testing.T) {
 			_, cerr := compileV10(t, schemaFor(`block="restriction"`))
 			require.Error(t, cerr)

--- a/xsd/complextype_block_test.go
+++ b/xsd/complextype_block_test.go
@@ -56,7 +56,7 @@ func TestComplexTypeBlockXsiType(t *testing.T) {
 	for _, v := range []struct {
 		name string
 		ver  xsd.Version
-	}{{"xsd10", xsd.Version10}, {"xsd11", xsd.Version11}} {
+	}{{testLabelXSD10, xsd.Version10}, {testLabelXSD11, xsd.Version11}} {
 		t.Run(v.name, func(t *testing.T) {
 			t.Run("type block=extension rejects xsi:type extension", func(t *testing.T) {
 				require.ErrorIs(t, compileValidate(t, v.ver, `block="extension"`), xsd.ErrValidationFailed)

--- a/xsd/complextype_blockfinal_test.go
+++ b/xsd/complextype_blockfinal_test.go
@@ -103,3 +103,53 @@ func TestComplexTypeBlockFinalValue(t *testing.T) {
 		}
 	})
 }
+
+func TestComplexTypeBlockFinalComponentLabel(t *testing.T) {
+	t.Parallel()
+
+	for _, version := range []struct {
+		name string
+		v11  bool
+	}{
+		{testLabelXSD10, false},
+		{testLabelXSD11, true},
+	} {
+		t.Run(version.name, func(t *testing.T) {
+			t.Parallel()
+			for _, tc := range []struct {
+				name string
+				body string
+				want string
+			}{
+				{
+					"global block",
+					`<xs:complexType name="T" block="bogus"/>`,
+					"complex type 'T': The value 'bogus' of attribute 'block'",
+				},
+				{
+					"global final",
+					`<xs:complexType name="T" final="bogus"/>`,
+					"complex type 'T': The value 'bogus' of attribute 'final'",
+				},
+				{
+					"local block",
+					`<xs:element name="root"><xs:complexType block="bogus"/></xs:element>`,
+					"local complex type: The value 'bogus' of attribute 'block'",
+				},
+				{
+					"local final",
+					`<xs:element name="root"><xs:complexType final="bogus"/></xs:element>`,
+					"local complex type: The value 'bogus' of attribute 'final'",
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
+					schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">` +
+						tc.body + `</xs:schema>`
+					errs := compileSchemaErrorsVersion(t, schema, version.v11)
+					require.Contains(t, errs, tc.want)
+				})
+			}
+		})
+	}
+}

--- a/xsd/element_consistent_test.go
+++ b/xsd/element_consistent_test.go
@@ -528,3 +528,50 @@ func TestElementConsistent(t *testing.T) {
 		}
 	})
 }
+
+func TestElementConsistentComponentLabels(t *testing.T) {
+	t.Parallel()
+
+	const global = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="T">
+    <xs:sequence>
+      <xs:element name="a" type="xs:int"/>
+      <xs:element name="a" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>`
+	const local = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="a" type="xs:int"/>
+        <xs:element name="a" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	for _, tc := range []struct {
+		name   string
+		schema string
+		want   string
+	}{
+		{
+			"global",
+			global,
+			"complex type 'T': Two elements with the same name 'a' and namespace '', " +
+				"but different type definitions, appear in the content model.",
+		},
+		{
+			"local",
+			local,
+			"local complex type: Two elements with the same name 'a' and namespace '', " +
+				"but different type definitions, appear in the content model.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Contains(t, compileSchemaErrorsVersion(t, tc.schema, false), tc.want)
+		})
+	}
+}

--- a/xsd/grammar_checks_test.go
+++ b/xsd/grammar_checks_test.go
@@ -148,14 +148,27 @@ func TestComplexTypeContentModelExclusivity(t *testing.T) {
 
 	t.Run("rejects two model groups", func(t *testing.T) {
 		t.Parallel()
-		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+		const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:complexType name="T">
     <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
     <xs:choice><xs:element name="b" type="xs:string"/></xs:choice>
   </xs:complexType>
   <xs:element name="root" type="T"/>
 </xs:schema>`
-		require.Contains(t, compileFatalErrors(t, schema), "more than one content model particle")
+		for _, version := range []struct {
+			name string
+			v11  bool
+		}{
+			{testLabelXSD10, false},
+			{testLabelXSD11, true},
+		} {
+			t.Run(version.name, func(t *testing.T) {
+				t.Parallel()
+				errs := compileSchemaErrorsVersion(t, schema, version.v11)
+				require.Contains(t, errs,
+					"complex type 'T': A complex type definition must not have more than one content model particle")
+			})
+		}
 	})
 
 	t.Run("rejects sequence then all", func(t *testing.T) {

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -2535,12 +2535,10 @@ func (c *compiler) reportUnresolvedTypeRef(ctx context.Context, owner *TypeDef, 
 		elemKind = elemSimpleType
 	}
 	component := owner.Name.Local
-	if component == "" || src.isLocal {
-		if elemKind == elemComplexType {
-			component = componentLocalComplexType
-		} else {
-			component = componentLocalSimpleType
-		}
+	if owner.IsComplex {
+		component = complexTypeComponent(owner, src)
+	} else if component == "" || src.isLocal {
+		component = componentLocalSimpleType
 	}
 	msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) type definition.", qn.NS, qn.Local)
 	c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, elemKind, component, msg))

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -3639,19 +3639,12 @@ func (c *compiler) checkFinalOnTypes(ctx context.Context) {
 		// Check base type final for extension/restriction derivation.
 		if td.BaseType != nil && td.BaseType.Final != 0 {
 			baseFinal := td.BaseType.Final
+			component := complexTypeComponent(td, src)
 			if td.Derivation == DerivationExtension && baseFinal&FinalExtension != 0 {
-				component := td.Name.Local
-				if src.isLocal {
-					component = componentLocalComplexType
-				}
 				c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component,
 					"Derivation by extension is forbidden by the base type '"+td.BaseType.Name.Local+"'."))
 			}
 			if td.Derivation == DerivationRestriction && baseFinal&FinalRestriction != 0 {
-				component := td.Name.Local
-				if src.isLocal {
-					component = componentLocalComplexType
-				}
 				c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component,
 					"Derivation by restriction is forbidden by the base type '"+td.BaseType.Name.Local+"'."))
 			}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -1532,7 +1532,11 @@ func complexTypeComponent(td *TypeDef, src typeDefSource) string {
 	if src.isLocal {
 		return componentLocalComplexType
 	}
-	return "complex type '" + td.Name.Local + "'"
+	return globalComplexTypeComponent(td.Name.Local)
+}
+
+func globalComplexTypeComponent(name string) string {
+	return "complex type '" + name + "'"
 }
 
 // checkDuplicateAttrUses reports duplicate attribute uses (by expanded QName)

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -3639,7 +3639,10 @@ func (c *compiler) checkFinalOnTypes(ctx context.Context) {
 		// Check base type final for extension/restriction derivation.
 		if td.BaseType != nil && td.BaseType.Final != 0 {
 			baseFinal := td.BaseType.Final
-			component := complexTypeComponent(td, src)
+			component := td.Name.Local
+			if td.IsComplex {
+				component = complexTypeComponent(td, src)
+			}
 			if td.Derivation == DerivationExtension && baseFinal&FinalExtension != 0 {
 				c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component,
 					"Derivation by extension is forbidden by the base type '"+td.BaseType.Name.Local+"'."))

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -11,7 +11,8 @@ import (
 )
 
 func (c *compiler) parseNamedComplexType(ctx context.Context, elem *helium.Element) error {
-	name, ok, err := c.readRequiredTopLevelNCName(ctx, elem, "xsd: named complexType missing name", componentLocalComplexType, true)
+	component := globalComplexTypeComponent(collapsedAttr(elem, attrName))
+	name, ok, err := c.readRequiredTopLevelNCName(ctx, elem, "xsd: named complexType missing name", component, true)
 	if err != nil || !ok {
 		return err
 	}
@@ -102,7 +103,7 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element, l
 	c.recordTypeDefSource(td, elem.Line(), true, elem.LocalName())
 	component := componentLocalComplexType
 	if !local {
-		component = "complex type '" + collapsedAttr(elem, attrName) + "'"
+		component = globalComplexTypeComponent(collapsedAttr(elem, attrName))
 	}
 
 	// A LOCAL (anonymous/inline) xs:complexType — one whose parent is an element

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -315,7 +315,7 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element, l
 				continue
 			}
 			contentWrapperChild = ce.LocalName()
-			if err := c.parseComplexContent(ctx, ce, td); err != nil {
+			if err := c.parseComplexContent(ctx, ce, td, component); err != nil {
 				return nil, err
 			}
 		case isXSDElement(ce, elemSimpleContent):
@@ -344,7 +344,7 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element, l
 				continue
 			}
 			contentWrapperChild = ce.LocalName()
-			c.parseSimpleContent(ctx, ce, td)
+			c.parseSimpleContent(ctx, ce, td, component)
 		case isXSDElement(ce, elemAttribute):
 			if contentWrapperChild != "" {
 				reportExtraContent(ce, fmt.Sprintf("The attribute declaration '%s' is not allowed together with '%s'; attributes must be declared inside the wrapper's restriction or extension.", ce.LocalName(), contentWrapperChild))
@@ -482,7 +482,7 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element, l
 	return td, nil
 }
 
-func (c *compiler) parseComplexContent(ctx context.Context, elem *helium.Element, td *TypeDef) error {
+func (c *compiler) parseComplexContent(ctx context.Context, elem *helium.Element, td *TypeDef, component string) error {
 	// XSD 1.1: <xs:complexContent> may carry its own @mixed. The effective
 	// mixedness is complexType/@mixed OR complexContent/@mixed; if BOTH are present
 	// and disagree it is a schema error (a complexType mixed="true" with
@@ -496,7 +496,7 @@ func (c *compiler) parseComplexContent(ctx context.Context, elem *helium.Element
 		ctMixed := td.ContentType == ContentTypeMixed
 		if ctMixed && !ccMixed && c.filename != "" {
 			c.schemaError(ctx, schemaComponentError(c.diagSource(), elem.Line(),
-				elem.LocalName(), componentLocalComplexType,
+				elem.LocalName(), component,
 				"The 'mixed' attribute on 'complexType' and 'complexContent' must not conflict."))
 		}
 		if ccMixed {
@@ -509,11 +509,11 @@ func (c *compiler) parseComplexContent(ctx context.Context, elem *helium.Element
 	// it in both XSD 1.0 and 1.1. For a VALID wrapper (one derivation) the dispatch
 	// is identical to the old lenient loop; only zero/second/stray/trailing children
 	// (all invalid per the spec) are now rejected instead of silently tolerated.
-	return c.parseDerivationWrapper(ctx, elem, func(ce *helium.Element, kind DerivationKind) error {
+	return c.parseDerivationWrapper(ctx, elem, component, func(ce *helium.Element, kind DerivationKind) error {
 		if kind == DerivationRestriction {
-			return c.parseRestriction(ctx, ce, td)
+			return c.parseRestriction(ctx, ce, td, component)
 		}
-		return c.parseExtension(ctx, ce, td)
+		return c.parseExtension(ctx, ce, td, component)
 	})
 }
 
@@ -527,13 +527,13 @@ func (c *compiler) parseComplexContent(ctx context.Context, elem *helium.Element
 // for a valid wrapper (one derivation) the dispatch is identical to the old lenient
 // loops, so only the invalid forms are newly rejected in 1.0. Centralizing it keeps
 // the complexContent and simpleContent wrappers from diverging.
-func (c *compiler) parseDerivationWrapper(ctx context.Context, wrapper *helium.Element, dispatch func(ce *helium.Element, kind DerivationKind) error) error {
+func (c *compiler) parseDerivationWrapper(ctx context.Context, wrapper *helium.Element, component string, dispatch func(ce *helium.Element, kind DerivationKind) error) error {
 	report := func(ce *helium.Element, what string) {
 		if c.filename == "" {
 			return
 		}
 		c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
-			wrapper.LocalName(), componentLocalComplexType, what))
+			wrapper.LocalName(), component, what))
 	}
 	var derivationSeen bool
 	var annotationSeen bool
@@ -577,16 +577,16 @@ func (c *compiler) parseDerivationWrapper(ctx context.Context, wrapper *helium.E
 	return nil
 }
 
-func (c *compiler) parseRestriction(ctx context.Context, elem *helium.Element, td *TypeDef) error {
+func (c *compiler) parseRestriction(ctx context.Context, elem *helium.Element, td *TypeDef, component string) error {
 	td.Derivation = DerivationRestriction
 	c.recordDerivationBaseRef(ctx, elem, td)
-	return c.parseComplexContentDerivationBody(ctx, elem, td, DerivationRestriction)
+	return c.parseComplexContentDerivationBody(ctx, elem, td, DerivationRestriction, component)
 }
 
-func (c *compiler) parseExtension(ctx context.Context, elem *helium.Element, td *TypeDef) error {
+func (c *compiler) parseExtension(ctx context.Context, elem *helium.Element, td *TypeDef, component string) error {
 	td.Derivation = DerivationExtension
 	c.recordDerivationBaseRef(ctx, elem, td)
-	return c.parseComplexContentDerivationBody(ctx, elem, td, DerivationExtension)
+	return c.parseComplexContentDerivationBody(ctx, elem, td, DerivationExtension, component)
 }
 
 // recordDerivationBaseRef resolves the @base reference of a complexContent
@@ -617,7 +617,7 @@ func (c *compiler) recordDerivationBaseRef(ctx context.Context, elem *helium.Ele
 // reject stray children) run in BOTH XSD 1.0 and 1.1. openContent/assert are 1.1
 // constructs (their cases stay Version11-gated) so a 1.0 schema carrying one is a
 // stray child, which is genuinely invalid in 1.0.
-func (c *compiler) parseComplexContentDerivationBody(ctx context.Context, elem *helium.Element, td *TypeDef, kind DerivationKind) error {
+func (c *compiler) parseComplexContentDerivationBody(ctx context.Context, elem *helium.Element, td *TypeDef, kind DerivationKind, component string) error {
 	strict := true
 	var contentModelChild string
 	var directAttrChild string
@@ -632,7 +632,7 @@ func (c *compiler) parseComplexContentDerivationBody(ctx context.Context, elem *
 			return
 		}
 		c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
-			elem.LocalName(), componentLocalComplexType, what))
+			elem.LocalName(), component, what))
 	}
 
 	for child := range helium.Children(elem) {
@@ -818,7 +818,7 @@ func (c *compiler) parseComplexContentDerivationBody(ctx context.Context, elem *
 	return nil
 }
 
-func (c *compiler) parseSimpleContent(ctx context.Context, elem *helium.Element, td *TypeDef) {
+func (c *compiler) parseSimpleContent(ctx context.Context, elem *helium.Element, td *TypeDef, component string) {
 	td.ContentType = ContentTypeSimple
 	td.IsSimpleContent = true
 	// XSD 3.4.2: the <xs:simpleContent> content model is (annotation?, (restriction
@@ -827,8 +827,8 @@ func (c *compiler) parseSimpleContent(ctx context.Context, elem *helium.Element,
 	// annotation only before it, nothing else (e.g. a direct trailing <xs:openContent>
 	// is rejected). For a VALID wrapper (one derivation) the dispatch is identical to
 	// the old lenient loop; only zero/second/stray/trailing children are now rejected.
-	_ = c.parseDerivationWrapper(ctx, elem, func(ce *helium.Element, kind DerivationKind) error {
-		c.dispatchSimpleContentDerivation(ctx, ce, td, kind)
+	_ = c.parseDerivationWrapper(ctx, elem, component, func(ce *helium.Element, kind DerivationKind) error {
+		c.dispatchSimpleContentDerivation(ctx, ce, td, kind, component)
 		return nil
 	})
 }
@@ -837,7 +837,7 @@ func (c *compiler) parseSimpleContent(ctx context.Context, elem *helium.Element,
 // restriction/extension and parses its attribute children. Shared by the XSD 1.0
 // lenient loop and the XSD 1.1 strict wrapper so both behave identically once a
 // derivation is selected.
-func (c *compiler) dispatchSimpleContentDerivation(ctx context.Context, ce *helium.Element, td *TypeDef, kind DerivationKind) {
+func (c *compiler) dispatchSimpleContentDerivation(ctx context.Context, ce *helium.Element, td *TypeDef, kind DerivationKind, component string) {
 	// @base is an xs:QName: dispatch on PRESENCE via resolveQNameRef so a
 	// PRESENT-but-empty base="" (or whitespace-only) is reported once as an invalid
 	// QName, not silently treated as absent.
@@ -846,7 +846,7 @@ func (c *compiler) dispatchSimpleContentDerivation(ctx context.Context, ce *heli
 		c.markChameleonEligible(td, ce, getAttr(ce, attrBase))
 	}
 	td.Derivation = kind
-	c.parseSimpleContentChildren(ctx, ce, td, kind)
+	c.parseSimpleContentChildren(ctx, ce, td, kind, component)
 }
 
 // isSimpleTypeFacetElement reports whether localName names an XSD constraining
@@ -882,7 +882,7 @@ func derivationKindName(kind DerivationKind) string {
 // attribute use (use="prohibited") is pointless and is warned+skipped, matching
 // complexContent xs:extension (parseExtension), so it does not propagate and
 // wrongly block an attribute the base wildcard would otherwise admit.
-func (c *compiler) parseSimpleContentChildren(ctx context.Context, derivation *helium.Element, td *TypeDef, kind DerivationKind) {
+func (c *compiler) parseSimpleContentChildren(ctx context.Context, derivation *helium.Element, td *TypeDef, kind DerivationKind, component string) {
 	// XSD 3.4.2 simpleContent derivation body content models:
 	//   restriction: (annotation?, simpleType?, facet*, (attribute|attributeGroup)*,
 	//                 anyAttribute?, assert*)
@@ -910,7 +910,7 @@ func (c *compiler) parseSimpleContentChildren(ctx context.Context, derivation *h
 			return
 		}
 		c.schemaError(ctx, schemaComponentError(c.diagSource(), ae.Line(),
-			derivation.LocalName(), componentLocalComplexType, what))
+			derivation.LocalName(), component, what))
 	}
 
 	for child := range helium.Children(derivation) {

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -116,7 +116,7 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element, l
 	// secondary, so present-empty ≡ whitespace-only.
 	if local && c.filename != "" && c.ncnameCompanionUsable(ctx, elem, elemComplexType) {
 		c.schemaError(ctx, schemaComponentError(c.diagSource(), elem.Line(),
-			elem.LocalName(), componentLocalComplexType,
+			elem.LocalName(), component,
 			"A local complexType definition must not have a 'name' attribute."))
 	}
 
@@ -186,7 +186,7 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element, l
 			return
 		}
 		c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
-			elem.LocalName(), componentLocalComplexType, what))
+			elem.LocalName(), component, what))
 	}
 
 	for child := range helium.Children(elem) {

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -100,6 +100,10 @@ func (c *compiler) recordAttrGroupRef(td *TypeDef, qn QName, src attrGroupRefUse
 func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element, local bool) (*TypeDef, error) {
 	td := &TypeDef{IsComplex: true}
 	c.recordTypeDefSource(td, elem.Line(), true, elem.LocalName())
+	component := componentLocalComplexType
+	if !local {
+		component = "complex type '" + collapsedAttr(elem, attrName) + "'"
+	}
 
 	// A LOCAL (anonymous/inline) xs:complexType — one whose parent is an element
 	// or an xs:alternative — must NOT carry a @name (XSD Structures §3.4.2:
@@ -129,7 +133,7 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element, l
 			if hasAttr(elem, ba) {
 				if v := getAttr(elem, ba); !isValidFinal(v) {
 					c.schemaError(ctx, schemaComponentError(c.diagSource(), elem.Line(),
-						elem.LocalName(), componentLocalComplexType,
+						elem.LocalName(), component,
 						"The value '"+v+"' of attribute '"+ba+"' is not valid. Expected is '(#all | List of (extension | restriction))'."))
 				}
 			}

--- a/xsd/schema_attr_ws_collapse_test.go
+++ b/xsd/schema_attr_ws_collapse_test.go
@@ -1114,12 +1114,29 @@ func TestDirectTopLevelNamedComponentCollapseEmptyName(t *testing.T) {
 					require.Nil(t, schema)
 					require.Equal(t, 1, strings.Count(errs, wantNCName),
 						"version=%v: direct %s name=%q must emit exactly one invalid-NCName diagnostic; got: %s", v, tc.name, val, errs)
+					if tc.name == complexTypeName {
+						require.Contains(t, errs, "complex type '': The value '",
+							"version=%v: a global complexType must use its collapsed name in the component label; got: %s", v, errs)
+					}
 					errsByValue = append(errsByValue, errs)
 				}
 				require.Equal(t, errsByValue[0], errsByValue[1],
 					"version=%v: direct %s present-empty and whitespace-only @name must emit identical diagnostics", v, tc.name)
 			}
 		})
+	}
+}
+
+func TestGlobalComplexTypeInvalidNameComponentLabel(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:complexType name="bad:name"/></xs:schema>`
+	const want = "complex type 'bad:name': The value 'bad:name' of attribute 'name' is not a valid 'xs:NCName'."
+
+	for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+		_, errs, cerr := compileWith(t, v, schemaXML)
+		require.ErrorIs(t, cerr, xsd.ErrCompilationFailed)
+		require.Contains(t, errs, want, "version=%v: a global declaration must not use the local complex-type label", v)
 	}
 }
 
@@ -1246,6 +1263,10 @@ func TestComponentChildNameKeyedDispatchValidity(t *testing.T) {
 					require.Nil(t, schema)
 					require.Contains(t, errs, wantNCName,
 						"version=%v: name=%q must emit an invalid-NCName diagnostic; got: %s", v, bad, errs)
+					if strings.HasSuffix(tc.name, "complexType") {
+						require.Contains(t, errs, "complex type '"+strings.TrimSpace(bad)+"': The value '",
+							"version=%v: a %s complexType must use its collapsed name in the component label; got: %s", v, tc.wrapper, errs)
+					}
 				}
 
 				// Present-empty ("") and whitespace-only ("   ") emit byte-identical

--- a/xsd/test_labels_test.go
+++ b/xsd/test_labels_test.go
@@ -3,4 +3,6 @@ package xsd_test
 const (
 	testLabelEmpty          = "empty"
 	testLabelWhitespaceOnly = "whitespace-only"
+	testLabelXSD10          = "xsd10"
+	testLabelXSD11          = "xsd11"
 )

--- a/xsd/unresolved_type_ref_source_test.go
+++ b/xsd/unresolved_type_ref_source_test.go
@@ -61,6 +61,21 @@ func TestUnresolvedTypeRefElementKind(t *testing.T) {
 		require.Contains(t, errs, "element simpleType:",
 			"a simple type's unresolved base ref must report element simpleType; got: %q", errs)
 	})
+
+	t.Run("global complexType reports its name", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="T">
+    <xs:simpleContent>
+      <xs:restriction base="xs:anyAtomicType"/>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>`
+		errs := compileErrors(t, schemaXML)
+		require.Contains(t, errs,
+			"element complexType: Schemas parser error : complex type 'T': The QName value "+
+				"'{http://www.w3.org/2001/XMLSchema}anyAtomicType' does not resolve to a(n) type definition.")
+	})
 }
 
 // TestUnresolvedTypeRefImportSource verifies that an unresolved type reference in

--- a/xsd/validate_block_final_test.go
+++ b/xsd/validate_block_final_test.go
@@ -271,6 +271,34 @@ func TestFinalOnComplexType(t *testing.T) {
 	})
 }
 
+func TestFinalOnSimpleTypeComponentLabel(t *testing.T) {
+	t.Parallel()
+
+	const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="Base" final="restriction">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="Derived">
+    <xs:restriction base="Base"/>
+  </xs:simpleType>
+</xs:schema>`
+	for _, version := range []struct {
+		name string
+		v11  bool
+	}{
+		{testLabelXSD10, false},
+		{testLabelXSD11, true},
+	} {
+		t.Run(version.name, func(t *testing.T) {
+			t.Parallel()
+			errs := compileSchemaErrorsVersion(t, schema, version.v11)
+			require.Contains(t, errs,
+				"Derived: Derivation by restriction is forbidden by the base type 'Base'.")
+			require.NotContains(t, errs, "complex type 'Derived'")
+		})
+	}
+}
+
 func TestFinalOnSubstGroupHead(t *testing.T) {
 	t.Run("final=extension on head blocks extension-derived member", func(t *testing.T) {
 		t.Parallel()

--- a/xsd/validate_block_final_test.go
+++ b/xsd/validate_block_final_test.go
@@ -193,7 +193,8 @@ func TestFinalDefault(t *testing.T) {
   <xs:element name="root" type="baseType"/>
 </xs:schema>`
 		_, errs := compileWithErrors(t, schemaXML)
-		require.Contains(t, errs, "Derivation by restriction is forbidden")
+		require.Contains(t, errs,
+			"complex type 'derivedType': Derivation by restriction is forbidden by the base type 'baseType'.")
 	})
 
 	t.Run("finalDefault=extension produces compile error for extension derivation", func(t *testing.T) {
@@ -217,7 +218,8 @@ func TestFinalDefault(t *testing.T) {
   <xs:element name="root" type="baseType"/>
 </xs:schema>`
 		_, errs := compileWithErrors(t, schemaXML)
-		require.Contains(t, errs, "Derivation by extension is forbidden")
+		require.Contains(t, errs,
+			"complex type 'derivedType': Derivation by extension is forbidden by the base type 'baseType'.")
 	})
 }
 

--- a/xsd/wildcard_restricts_group_test.go
+++ b/xsd/wildcard_restricts_group_test.go
@@ -52,9 +52,9 @@ func TestWildcardRestrictsModelGroup(t *testing.T) {
 // versionName renders an xsd.Version as a stable subtest name.
 func versionName(v xsd.Version) string {
 	if v == xsd.Version11 {
-		return "xsd11"
+		return testLabelXSD11
 	}
-	return "xsd10"
+	return testLabelXSD10
 }
 
 // A base "model group" that is a §3.9.6-POINTLESS 1/1 wrapper around a single

--- a/xsd/wrapper_grammar_test.go
+++ b/xsd/wrapper_grammar_test.go
@@ -1,10 +1,98 @@
 package xsd_test
 
 import (
+	"fmt"
 	"testing"
 
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
 	"github.com/stretchr/testify/require"
 )
+
+func TestComplexTypeGrammarDiagnosticComponent(t *testing.T) {
+	t.Parallel()
+
+	defects := []struct {
+		name    string
+		body    string
+		message string
+	}{
+		{
+			name:    "mixed conflict",
+			body:    ` mixed="true"><xs:complexContent mixed="false"><xs:extension base="xs:anyType"/></xs:complexContent>`,
+			message: "must not conflict",
+		},
+		{
+			name:    "missing wrapper derivation",
+			body:    `><xs:complexContent/>`,
+			message: "must have exactly one 'restriction' or 'extension'",
+		},
+		{
+			name:    "complex content stray child",
+			body:    `><xs:complexContent><xs:extension base="xs:anyType"><xs:element name="bad"/></xs:extension></xs:complexContent>`,
+			message: "not allowed in a 'extension' derivation",
+		},
+		{
+			name:    "simple content stray child",
+			body:    `><xs:simpleContent><xs:extension base="xs:string"><xs:sequence/></xs:extension></xs:simpleContent>`,
+			message: "not allowed in a 'simpleContent' derivation",
+		},
+	}
+	versions := []struct {
+		name    string
+		version xsd.Version
+	}{
+		{name: "XSD 1.0", version: xsd.Version10},
+		{name: "XSD 1.1", version: xsd.Version11},
+	}
+	owners := []struct {
+		name      string
+		open      string
+		close     string
+		component string
+	}{
+		{
+			name:      "global",
+			open:      `<xs:complexType name="G"`,
+			close:     `</xs:complexType>`,
+			component: "complex type 'G'",
+		},
+		{
+			name:      "local",
+			open:      `<xs:element name="root"><xs:complexType`,
+			close:     `</xs:complexType></xs:element>`,
+			component: "local complex type",
+		},
+	}
+
+	for _, version := range versions {
+		for _, owner := range owners {
+			for _, defect := range defects {
+				version, owner, defect := version, owner, defect
+				t.Run(fmt.Sprintf("%s %s %s", version.name, owner.name, defect.name), func(t *testing.T) {
+					t.Parallel()
+					schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">` +
+						owner.open + defect.body + owner.close + `</xs:schema>`
+					doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+					require.NoError(t, err)
+					collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+					_, _ = xsd.NewCompiler().
+						Version(version.version).
+						Label("test.xsd").
+						ErrorHandler(collector).
+						Compile(t.Context(), doc)
+					require.NoError(t, collector.Close())
+					errors := compileErrorsString(collector.Errors())
+					require.Contains(t, errors, owner.component+":")
+					require.Contains(t, errors, defect.message)
+					if owner.name == "global" {
+						require.NotContains(t, errors, "local complex type:")
+					}
+				})
+			}
+		}
+	}
+}
 
 // TestComplexContentGrammar exercises the full XSD 1.1 (annotation?, (restriction
 // | extension)) content model of <xs:complexContent>: exactly one derivation,


### PR DESCRIPTION
- Match libxml2 component labels for global complex types in XSD schema diagnostics.
- Preserve local complex-type and simple-type wording across XSD 1.0 and 1.1.
