### PR TITLE
wrap documentation lines

### DIFF
--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -3,12 +3,14 @@
 Purpose:
 
 - Act as stable index into `helium` codebase.
-- Cache rough package structure, key files, feature status, behavior notes, and review hotspots so agents do not waste tokens rediscovering them.
+- Cache rough package structure, key files, feature status, behavior notes, and review hotspots so agents do not waste
+  tokens rediscovering them.
 - Hold repository-specific instructions that are repeatedly needed in this repo.
 
 Rules:
 
 - Keep files here stable. Do NOT store transient work product here.
-- Put transient data, command output, fetched data, scratch notes, generated review findings, and other temporary artifacts in `.tmp`.
+- Put transient data, command output, fetched data, scratch notes, generated review findings, and other temporary
+  artifacts in `.tmp`.
 - Prefer updating existing topic docs over creating overlapping docs.
 - Keep content optimized for agent consumption: terse, factual, repository-specific.

--- a/.claude/docs/context.md
+++ b/.claude/docs/context.md
@@ -18,11 +18,14 @@ Module-wide rules for Go `context.Context` + package-specific payload objects.
 - Keep payload type, option type, constructor, accessor, helper pair unexported by default.
 - Prefer exported direct mutators on `context.Context` over exporting payload type or option type.
 - If callers only need to set package-scoped values, export helpers like `WithX(ctx, value) context.Context`.
-- Export initializer only when external callers must attach package payload before calling API that accepts `context.Context`.
-- Export accessor only when external callers or sibling packages must inspect/merge payload already attached to `context.Context`.
+- Export initializer only when external callers must attach package payload before calling API that accepts
+  `context.Context`.
+- Export accessor only when external callers or sibling packages must inspect/merge payload already attached to
+  `context.Context`.
 - Export payload type only when exported accessor returns it or callers must mutate/read it directly.
 - If helper is internal execution plumbing, keep it unexported even when read side exists elsewhere.
-- If any part must be exported, use descriptive names. NEVER export bare `Context`, `NewContext`, `GetContext`, `ContextOption`.
+- If any part must be exported, use descriptive names. NEVER export bare `Context`, `NewContext`, `GetContext`,
+  `ContextOption`.
 
 ## Carrier Pattern
 
@@ -66,10 +69,15 @@ Module-wide rules for Go `context.Context` + package-specific payload objects.
 ## Current Repo Pattern
 
 - `xpath1` now uses direct mutators such as `WithNamespaces(ctx, ns)` and `WithAdditionalVariables(ctx, vars)`.
-- `xpath1` keeps `FunctionContext` + `GetFunctionContext(ctx)` public because custom function implementations need read-only evaluation state.
+- `xpath1` keeps `FunctionContext` + `GetFunctionContext(ctx)` public because custom function implementations need
+  read-only evaluation state.
 - `xpath1` hides its eval-config carrier and getter.
-- `xpath3` does NOT carry evaluation config on `context.Context`. It uses value-receiver fluent setters on the `Evaluator` value returned by `NewEvaluator` (`Namespaces`, `Variables`, `OpLimit`, `DefaultLanguage`, `URIResolver`, etc.; each returns an updated copy); `Evaluate`/`EvaluateReuse` accept a `context.Context` for cancellation/deadlines only. See `xpath3-api.md`.
-- `xpath3` internal function-evaluation state already follows unexported helper pattern: `withFnContext` + `getFnContext`.
+- `xpath3` does NOT carry evaluation config on `context.Context`. It uses value-receiver fluent setters on the
+  `Evaluator` value returned by `NewEvaluator` (`Namespaces`, `Variables`, `OpLimit`, `DefaultLanguage`, `URIResolver`,
+  etc.; each returns an updated copy); `Evaluate`/`EvaluateReuse` accept a `context.Context` for cancellation/deadlines
+  only. See `xpath3-api.md`.
+- `xpath3` internal function-evaluation state already follows unexported helper pattern: `withFnContext` +
+  `getFnContext`.
 - Future refactors should prefer `WithX(ctx, value)` style mutators when callers do not need raw payload access.
 - Treat public carrier/accessor APIs as exception driven by caller need, not default style.
 

--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -59,7 +59,8 @@ test           → helium
 
 ## Leaf packages (no helium deps)
 sink, enum, internal/bitset, internal/heliumtest, internal/parser, push, internal/stack, internal/cliutil,
-internal/encoding, internal/lexicon, internal/icu, internal/nodelink, internal/nslookup, internal/sequence, internal/strcursor,
+internal/encoding, internal/lexicon, internal/icu, internal/nodelink, internal/nslookup, internal/sequence,
+internal/strcursor,
 internal/writerctl, internal/xpath1/lexer, internal/xsdregex, internal/uripath
 
 ## Core layer
@@ -69,7 +70,8 @@ helium (root) → sax, enum, internal/*
 c14n, xpath1, xpath3, html, catalog, relaxng, stream
 
 ## Security layer (depends on processing)
-xmldsig1 (root + c14n + xpath1 + internal/lexicon + internal/xpath1/lexer + internal/xmlchar; xpath1 backs the XPath filter
+xmldsig1 (root + c14n + xpath1 + internal/lexicon + internal/xpath1/lexer + internal/xmlchar; xpath1 backs the XPath
+filter
 transform), xmlenc1 (root + c14n; c14n converts the node-set a same-document xenc:CipherReference names into
 octets)
 

--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -87,18 +87,21 @@ All error formatting matches libxml2 output for golden test compatibility.
 
 ### DOM operation sentinels (root package, `errors.go`)
 
-`ErrNilNode`, `ErrInvalidOperation`, and `ErrCyclicNode` back the guarded tree API and are all matchable via `errors.Is`:
+`ErrNilNode`, `ErrInvalidOperation`, and `ErrCyclicNode` back the guarded tree API and are all matchable via
+`errors.Is`:
 
 - **`ErrNilNode`** — a nil or typed-nil node (including Go's interface nil trap, e.g. the typed-nil `*Element`
   `Document.DocumentElement()` returns for a rootless doc) reached
   `AddChild`/`AddSibling`/`Replace`/`Walk`/`CopyNode`/`ParseInNodeContext`/`SetDocumentElement`.
-- **`ErrInvalidOperation`** — an unsupported structural op: an empty `Replace()` (matching `Document.Replace`), a non-attribute sibling/replacement of a property attribute, or duplicate replacement operands.
+- **`ErrInvalidOperation`** — an unsupported structural op: an empty `Replace()` (matching `Document.Replace`), a
+  non-attribute sibling/replacement of a property attribute, or duplicate replacement operands.
 - **`ErrCyclicNode`** — a `wouldCreateCycle` rejection in `AddChild`/`AddSibling`/`Replace` (inserting a node
   into itself or a descendant, or replacing a node with an ancestor), plus the identity-checked self-add in
   `ProcessingInstruction.AddChild` (`pi.AddChild(pi)`); a PI given any other rejected operand — including an
   ancestor — wraps `ErrInvalidOperation` like the other strict leaves.
 
-The `ErrInvalidOperation`/`ErrCyclicNode` mutation sites wrap a descriptive message via `%w`, so the human text is preserved while `errors.Is` still matches.
+The `ErrInvalidOperation`/`ErrCyclicNode` mutation sites wrap a descriptive message via `%w`, so the human text is
+preserved while `errors.Is` still matches.
 
 ### ErrParseError (root package, `errors.go`)
 
@@ -247,16 +250,21 @@ Context extraction matches libxml2's `xmlParserInputGetWindow`: skip-eol, walk b
     the reader stores a sticky `capErr` (`fmt.Errorf("... %w", ErrContentSizeExceeded)`) returned from its
     `Read`, which surfaces as `p.cur.Err()`. A declared-charset stream (incl. declared Latin-1, which
     `Parse([]byte)` and `ParseReader` decode identically) or one that settles below the cap is unaffected.
-- **`ErrHandlerUnspecified`** (exported) — returned by a `SAXCallbacks` method whose handler is unset (see SAX-callback error routing below; filtered by `handleSAXErr`, never fatal).
+- **`ErrHandlerUnspecified`** (exported) — returned by a `SAXCallbacks` method whose handler is unset (see SAX-callback
+  error routing below; filtered by `handleSAXErr`, never fatal).
 
 #### HTML SAX-callback error routing (`html/parser.go`)
 
-When a SAX callback (e.g. `InternalSubset`, `StartElement`, `Characters`) returns a non-nil error other than `ErrHandlerUnspecified`, `handleSAXErr` forwards it through one of two paths:
+When a SAX callback (e.g. `InternalSubset`, `StartElement`, `Characters`) returns a non-nil error other than
+`ErrHandlerUnspecified`, `handleSAXErr` forwards it through one of two paths:
 
-- Default (`Parser.Strict(false)`): wrapped as a warning and delivered to the SAX `Warning(err)` slot (via `emitWarning`, gated by `cfg.noWarning`). The parser continues — HTML's libxml2-style tolerance.
-- `Parser.Strict(true)`: captured in `parser.fatalSAXErr` and returned from `parse()` after the parser reaches a stable state. `ErrHandlerUnspecified` is filtered in both modes.
+- Default (`Parser.Strict(false)`): wrapped as a warning and delivered to the SAX `Warning(err)` slot (via
+  `emitWarning`, gated by `cfg.noWarning`). The parser continues — HTML's libxml2-style tolerance.
+- `Parser.Strict(true)`: captured in `parser.fatalSAXErr` and returned from `parse()` after the parser reaches a stable
+  state. `ErrHandlerUnspecified` is filtered in both modes.
 
-This is distinct from `emitError` (parser-detected malformed input → `Error(err)` slot, gated by `cfg.noError`), which has been the existing convention for tokenization/structure errors.
+This is distinct from `emitError` (parser-detected malformed input → `Error(err)` slot, gated by `cfg.noError`), which
+has been the existing convention for tokenization/structure errors.
 
 ### XSLT 3.0 (`xslt3/errors.go`)
 
@@ -283,10 +291,12 @@ matches any joined sentinel (see `dynamicErrorCause`).
 | `dynamicErrorCause(code, cause, fmt, args...)` | Like `dynamicError` but `Cause = errors.Join(ErrDynamicError, cause)` so a distinguishable sentinel (e.g. `ErrResourceTooLarge`) stays observable via `errors.Is` |
 
 **Sentinel errors** (exported):
-- `ErrStaticError`, `ErrDynamicError`, `ErrCircularRef`, `ErrNoTemplate`, `ErrTerminated`, `ErrInvalidOutput`, `ErrResourceTooLarge`
+- `ErrStaticError`, `ErrDynamicError`, `ErrCircularRef`, `ErrNoTemplate`, `ErrTerminated`, `ErrInvalidOutput`,
+  `ErrResourceTooLarge`
 
 **Internal sentinels**:
-- `errNilStylesheet` — returned by convenience wrappers (`Transform`, `TransformString`, `TransformToWriter`) when `*Stylesheet` is nil; prevents nil-pointer panic
+- `errNilStylesheet` — returned by convenience wrappers (`Transform`, `TransformString`, `TransformToWriter`) when
+  `*Stylesheet` is nil; prevents nil-pointer panic
 
 **Error code checker**: `isXSLTError(err, code) → bool` — unwraps and matches `XSLTError.Code`.
 
@@ -337,7 +347,8 @@ every other XPath evaluation failure wraps both `ErrUnsupportedTransform` and th
 `context.Canceled`, `context.DeadlineExceeded`, and XPath sentinels remain matchable through the outer
 `VerificationError`. Other context and injected-XSLT errors return unchanged.
 
-A RetrievalMethod transform list exceeding `maxRetrievalTransformSteps` wraps `ErrResourceLimitExceeded` before URI dereference, transform execution, or key resolution.
+A RetrievalMethod transform list exceeding `maxRetrievalTransformSteps` wraps `ErrResourceLimitExceeded` before URI
+dereference, transform execution, or key resolution.
 
 An external RetrievalMethod X509Data resource that fails XML parsing wraps both `ErrInvalidKeyInfo` and the
 parser error. `errors.Is` therefore matches `context.Canceled` or `context.DeadlineExceeded` when parsing stops
@@ -447,16 +458,21 @@ All validation errors flow through `ErrorHandler.Handle()`. No `strings.Builder`
   before touching the document, instead of panicking. Handler setup runs first and `closeHandler()` is
   deferred, so a closable `ErrorHandler` is closed on every exit path (including the nil guards); a nil `ctx`
   is normalized to `context.Background()` at entry
-- Errors sent to the handler are `*xsd.ValidationError` (extractable via `errors.As`) wrapped with an `ErrorLeveler` for transport. `ValidationError` fields: `Filename`, `Line`, `Element`, `AttributeName` (empty for element-level errors), `Message`.
-- `reportValidityError` / `reportValidityErrorAttr` on `validationContext` check `suppressDepth > 0` to suppress errors during union member trials
+- Errors sent to the handler are `*xsd.ValidationError` (extractable via `errors.As`) wrapped with an `ErrorLeveler` for
+  transport. `ValidationError` fields: `Filename`, `Line`, `Element`, `AttributeName` (empty for element-level errors),
+  `Message`.
+- `reportValidityError` / `reportValidityErrorAttr` on `validationContext` check `suppressDepth > 0` to suppress errors
+  during union member trials
 
 ### RelaxNG
 
-`Validate()` returns `ErrValidationFailed` sentinel on failure. Individual errors buffered internally during validation (for backtracking), flushed to `ErrorHandler` at the end.
+`Validate()` returns `ErrValidationFailed` sentinel on failure. Individual errors buffered internally during validation
+(for backtracking), flushed to `ErrorHandler` at the end.
 
 ### Schematron
 
-`Validate()` returns `ErrValidationFailed` sentinel on failure. Individual `*ValidationError` errors go to `ErrorHandler`. `Quiet()` suppresses error delivery to the handler.
+`Validate()` returns `ErrValidationFailed` sentinel on failure. Individual `*ValidationError` errors go to
+`ErrorHandler`. `Quiet()` suppresses error delivery to the handler.
 
 ### DTD
 
@@ -487,7 +503,8 @@ XSD, RelaxNG, Schematron, and DTD all use sentinel error + ErrorHandler pattern.
 ### XSD Validation Error Helpers (`xsd/validate.go`)
 
 - `reportValidityError(file, line, elemName, msg)` — sends to ErrorHandler (suppressed when `suppressDepth > 0`)
-- `reportValidityErrorAttr(file, line, elemName, attrName, msg)` — sends to ErrorHandler (suppressed when `suppressDepth > 0`)
+- `reportValidityErrorAttr(file, line, elemName, attrName, msg)` — sends to ErrorHandler (suppressed when `suppressDepth
+  > 0`)
 
 ### XSD Internal Types (`xsd/validate.go`)
 
@@ -495,8 +512,10 @@ XSD, RelaxNG, Schematron, and DTD all use sentinel error + ErrorHandler pattern.
 
 ### TypeDef Validation Methods (`xsd/validate.go`)
 
-- `(*TypeDef).Validate(ctx context.Context, value string, nsMap map[string]string) error` — validates a lexical value against a simple type; uses `NilErrorHandler` (pass/fail only)
-- `(*TypeDef).ValidateElement(ctx context.Context, elem *helium.Element, schema *Schema) error` — validates an element's content against the type; uses internal `validationErrors` collector for error messages
+- `(*TypeDef).Validate(ctx context.Context, value string, nsMap map[string]string) error` — validates a lexical value
+  against a simple type; uses `NilErrorHandler` (pass/fail only)
+- `(*TypeDef).ValidateElement(ctx context.Context, elem *helium.Element, schema *Schema) error` — validates an element's
+  content against the type; uses internal `validationErrors` collector for error messages
 
 ## Compilation vs Validation Errors
 

--- a/.claude/docs/helium-command.md
+++ b/.claude/docs/helium-command.md
@@ -9,7 +9,8 @@ User-facing command docs live in `cmd/helium/README.md`.
 - `heliumcmd.Execute(ctx, args)` is package entrypoint
 - `heliumcmd.WithIO(ctx, stdin, stdout, stderr)` injects stdio for tests/examples
 - `heliumcmd.WithStdinTTY(ctx, bool)` overrides stdin TTY detection for tests/examples
-- When no CLI-specific values exist on `ctx`, defaults are `os.Stdin`, `os.Stdout`, `os.Stderr`, + TTY detection from `os.Stdin`
+- When no CLI-specific values exist on `ctx`, defaults are `os.Stdin`, `os.Stdout`, `os.Stderr`, + TTY detection from
+  `os.Stdin`
 
 ## Command Tree
 
@@ -64,7 +65,8 @@ Primary file: `internal/cli/heliumcmd/lint.go`
 
 ### `--output FILE` safety (lint and xslt)
 
-File output (`--output`/`-o`, not stdout and not `--noout`) is written through a write-to-temp-then-atomic-rename scheme (`pendingOutput` in `safety.go`):
+File output (`--output`/`-o`, not stdout and not `--noout`) is written through a write-to-temp-then-atomic-rename scheme
+(`pendingOutput` in `safety.go`):
 
 - A temp file (`.helium-out-*`) is created (via `os.OpenFile` with `O_CREATE|O_EXCL`, mode `0666` so the
   kernel applies umask) in the SAME directory as the target; output is written there, and `os.Rename`d onto
@@ -82,8 +84,10 @@ File output (`--output`/`-o`, not stdout and not `--noout`) is written through a
   (lint), or a stylesheet read at transform time via `fn:transform(map{'stylesheet-location':...})` through
   the retained `URIResolver` (xslt).
 - On any non-OK exit code the temp file is removed (`Cleanup`) and the target is left untouched.
-- A failed commit (flush/close/rename) folds `ExitErr` into the exit status, so an incomplete write is never reported as success.
-- The pre-flight same-file rejection (`checkOutputCollision`) is kept as a fast/friendly error for the obvious `--output X X` case, but the temp+rename is what actually protects later-resolved reads.
+- A failed commit (flush/close/rename) folds `ExitErr` into the exit status, so an incomplete write is never reported as
+  success.
+- The pre-flight same-file rejection (`checkOutputCollision`) is kept as a fast/friendly error for the obvious `--output
+  X X` case, but the temp+rename is what actually protects later-resolved reads.
 - stdout output and `--noout` are unaffected (no temp file is created).
 - Output file mode: the temp is created `0666` so the kernel applies the process umask, which already matches
   `os.Create` for a NEW destination (no chmod). For an EXISTING destination `Commit` chmods the temp to the
@@ -123,16 +127,19 @@ File output (`--output`/`-o`, not stdout and not `--noout`) is written through a
 - `--output FILE` refers to the same file as an XML input or the `--schema` → rejected (`would overwrite
   input/schema`, `ExitErr`) before any file is truncated. Same-file detection uses absolute-path equality plus
   `os.SameFile` (catches `./` prefixes and symlinks).
-- `--output FILE` combined with `--noout` → rejected (`--output cannot be combined with --noout`). Exception: `--xpath` (which also sets `--noout` internally) still writes its result, so it is allowed.
+- `--output FILE` combined with `--noout` → rejected (`--output cannot be combined with --noout`). Exception: `--xpath`
+  (which also sets `--noout` internally) still writes its result, so it is allowed.
 - The output file is closed explicitly after processing; a close error is folded into the exit status (`ExitErr`).
-- `--max-input-bytes N` caps the bytes read per input (file or stdin); default `DefaultMaxInputBytes` (100 MiB). `0` disables the cap. Exceeding it fails with `input exceeds maximum size` and `ExitReadFile`.
+- `--max-input-bytes N` caps the bytes read per input (file or stdin); default `DefaultMaxInputBytes` (100 MiB). `0`
+  disables the cap. Exceeding it fails with `input exceeds maximum size` and `ExitReadFile`.
 - `--max-depth N` caps element nesting depth; default `256` (the `NewParser` default), `0` = unlimited.
   Exceeding it fails the parse (`exceeded max depth`). `--max-depth` (and `--huge`) apply to the **document
   being processed** (the linted/validated/transformed instance). Schema and stylesheet **compilation**
   (XSD/RELAX NG/Schematron/XSLT, including nested include/import/module loads) parses with the default parser
   limits; exposing those compiler-internal limits is intentionally out of scope here and left as a follow-up.
 - `--quiet` suppresses informational output: timing messages are silenced and parser/validator warnings are suppressed.
-- `--path DIRS` (colon-separated) is wired into DTD/entity resolution: a `pathSearchFS` falls back to each listed directory (by base name) when the default loader cannot open a referenced resource.
+- `--path DIRS` (colon-separated) is wired into DTD/entity resolution: a `pathSearchFS` falls back to each listed
+  directory (by base name) when the default loader cannot open a referenced resource.
 
 ### Output Modes
 
@@ -142,12 +149,15 @@ File output (`--output`/`-o`, not stdout and not `--noout`) is written through a
 
 ### `--encode ENC`
 
-- Validated at parse time against `internal/encoding.Load`; an unrecognized encoding name is rejected with `--encode: unsupported encoding` and `ExitErr` (no silent fallback).
+- Validated at parse time against `internal/encoding.Load`; an unrecognized encoding name is rejected with `--encode:
+  unsupported encoding` and `ExitErr` (no silent fallback).
 - US-ASCII and its aliases (`ascii`, `ANSI_X3.4-1968`, `csASCII`, detected via `internal/encoding.IsASCII`)
   are rejected with the same `--encode: unsupported encoding` message: `Load`'s strict ASCII encoder delegates
   to UTF-8, which would emit raw UTF-8 bytes for non-ASCII characters while declaring US-ASCII.
-- Cannot be combined with `--xpath`: the XPath path serializes node values without re-encoding, so the combination is rejected at parse time with `--encode cannot be combined with --xpath` and `ExitErr`.
-- Applied to the standard dump path via `doc.SetEncoding`, so the serializer loads the matching encoder and emits the matching encoding declaration.
+- Cannot be combined with `--xpath`: the XPath path serializes node values without re-encoding, so the combination is
+  rejected at parse time with `--encode cannot be combined with --xpath` and `ExitErr`.
+- Applied to the standard dump path via `doc.SetEncoding`, so the serializer loads the matching encoder and emits the
+  matching encoding declaration.
 - Ignored for C14N modes, which are always UTF-8 per the C14N spec.
 
 ## `helium xpath`
@@ -157,7 +167,8 @@ Primary file: `internal/cli/heliumcmd/xpath.go`
 - Usage: `helium xpath [--engine 1|3] [--max-input-bytes N] [--max-depth N] EXPR [XMLfiles ...]`
 - Default engine: `3`
 - `--max-input-bytes N` caps bytes read per input (default 100 MiB; `0` = unlimited)
-- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is left untouched
+- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is
+  left untouched
 - `EXPR` mandatory + non-empty
 - Engine `1` → `xpath1`
 - Engine `3` → `xpath3`
@@ -173,13 +184,19 @@ Primary file: `internal/cli/heliumcmd/xsd_validate.go`
 
 - Usage: `helium xsd validate [--timing] [--max-input-bytes N] [--max-depth N] SCHEMA [XMLfiles ...]`
 - Schema path mandatory positional arg
-- `--max-input-bytes N` caps bytes read per XML input (file or stdin) via `readInput`/`readInputFile`; default `DefaultMaxInputBytes` (100 MiB), `0` = unlimited; over-cap fails with `ExitReadFile`
-- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is left untouched; over-cap fails the parse (`ExitErr`)
-- Schema compiled once with `xsd.NewCompiler().Label(schema).ErrorHandler(...).CompileFile(ctx, schema)`; a `compileErrorHandler` streams compilation diagnostics (file/line/detail) to stderr and records whether any FATAL diagnostic was seen
+- `--max-input-bytes N` caps bytes read per XML input (file or stdin) via `readInput`/`readInputFile`; default
+  `DefaultMaxInputBytes` (100 MiB), `0` = unlimited; over-cap fails with `ExitReadFile`
+- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is
+  left untouched; over-cap fails the parse (`ExitErr`)
+- Schema compiled once with `xsd.NewCompiler().Label(schema).ErrorHandler(...).CompileFile(ctx, schema)`; a
+  `compileErrorHandler` streams compilation diagnostics (file/line/detail) to stderr and records whether any FATAL
+  diagnostic was seen
 - The xsd compiler may return a non-nil schema with a nil error for a malformed schema; the CLI folds that
   into a failure (`errSchemaCompilation`) when the handler saw a fatal diagnostic, so it never validates
   against a bad schema. Compilation failure → `ExitSchemaComp`
-- Each XML input parsed with `helium.NewParser()` (file inputs get `.BaseURI(name)`) + validated with `xsd.NewValidator(schema).ErrorHandler(...).Validate(ctx, doc)`, diagnostics streamed to stderr via a `writerErrorHandler`
+- Each XML input parsed with `helium.NewParser()` (file inputs get `.BaseURI(name)`) + validated with
+  `xsd.NewValidator(schema).ErrorHandler(...).Validate(ctx, doc)`, diagnostics streamed to stderr via a
+  `writerErrorHandler`
 
 ## `helium relaxng validate`
 
@@ -187,8 +204,10 @@ Primary file: `internal/cli/heliumcmd/relaxng_validate.go`
 
 - Usage: `helium relaxng validate [--timing] [--max-input-bytes N] [--max-depth N] SCHEMA [XMLfiles ...]`
 - Schema path mandatory positional arg
-- `--max-input-bytes N` caps bytes read per XML input (file or stdin) via `readInput`/`readInputFile`; default `DefaultMaxInputBytes` (100 MiB), `0` = unlimited; over-cap fails with `ExitReadFile`
-- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is left untouched; over-cap fails the parse (`ExitErr`)
+- `--max-input-bytes N` caps bytes read per XML input (file or stdin) via `readInput`/`readInputFile`; default
+  `DefaultMaxInputBytes` (100 MiB), `0` = unlimited; over-cap fails with `ExitReadFile`
+- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is
+  left untouched; over-cap fails the parse (`ExitErr`)
 - Grammar compiled once with
   `relaxng.NewCompiler().FS(helium.PermissiveFS()).Label(schema).ErrorHandler(...).CompileFile(ctx, schema)`;
   `FS(helium.PermissiveFS())` opts back into host-filesystem loading for `include`/`externalRef` (the
@@ -197,21 +216,27 @@ Primary file: `internal/cli/heliumcmd/relaxng_validate.go`
 - The RELAX NG compiler may return a non-nil grammar with a nil error (a poisoned `notAllowed` grammar) on a
   fatal diagnostic; the CLI folds that into a failure (`errSchemaCompilation`) when the handler saw a fatal
   diagnostic, so it never validates against a bad grammar. Compilation failure → `ExitSchemaComp`
-- Each XML input parsed with `helium.NewParser()` (file inputs get `.BaseURI(name)`) + validated with `relaxng.NewValidator(grammar).Label(name).ErrorHandler(...).Validate(ctx, doc)`, diagnostics streamed to stderr via a `writerErrorHandler`
+- Each XML input parsed with `helium.NewParser()` (file inputs get `.BaseURI(name)`) + validated with
+  `relaxng.NewValidator(grammar).Label(name).ErrorHandler(...).Validate(ctx, doc)`, diagnostics streamed to stderr via a
+  `writerErrorHandler`
 
 ## `helium schematron validate`
 
 Primary file: `internal/cli/heliumcmd/schematron_validate.go`
 
-- Usage: `helium schematron validate [--timing] [--max-input-bytes N] [--max-depth N] [--query-binding NAME] SCHEMA [XMLfiles ...]`
+- Usage: `helium schematron validate [--timing] [--max-input-bytes N] [--max-depth N] [--query-binding NAME] SCHEMA
+  [XMLfiles ...]`
 - Schema path mandatory positional arg
-- `--max-input-bytes N` caps bytes read per XML input (file or stdin) via `readInput`/`readInputFile`; default `DefaultMaxInputBytes` (100 MiB), `0` = unlimited; over-cap fails with `ExitReadFile`
-- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is left untouched; over-cap fails the parse (`ExitErr`)
+- `--max-input-bytes N` caps bytes read per XML input (file or stdin) via `readInput`/`readInputFile`; default
+  `DefaultMaxInputBytes` (100 MiB), `0` = unlimited; over-cap fails with `ExitReadFile`
+- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited); when absent, the `NewParser` default is
+  left untouched; over-cap fails the parse (`ExitErr`)
 - Schema compiled once with `schematron.NewCompiler().Label(path).CompileFile(ctx, path)`
 - `--query-binding NAME` forces the query language binding (`xslt`, `xslt3`, `xpath3`), overriding the
   schema's `queryBinding` attribute; an unrecognized name is rejected before compilation. Unset, the attribute
   decides, and an unsupported attribute value exits `ExitSchemaComp`
-- Each XML input parsed with `helium.NewParser()` + validated with `schematron.NewValidator(schema).Label(name).Validate(ctx, doc)`
+- Each XML input parsed with `helium.NewParser()` + validated with
+  `schematron.NewValidator(schema).Label(name).Validate(ctx, doc)`
 - Validation passes `.Label(input.name)` so error output names the current XML source
 
 ## `helium xslt`
@@ -232,17 +257,21 @@ Primary file: `internal/cli/heliumcmd/xslt.go`
   is `confinedDirFS` rooted at the **stylesheet's own directory** (not a raw permissive root), so an
   attacker-controlled SYSTEM identifier (`/etc/passwd`, `../../secret`) still cannot exfiltrate files outside
   that directory. Compiled once with `xslt3.NewCompiler().URIResolver(fileResolver{}).Compile()`
-- A filesystem `URIResolver` is installed so local `xsl:include`/`xsl:import` modules load (the compiler default-denies module loading without one)
+- A filesystem `URIResolver` is installed so local `xsl:include`/`xsl:import` modules load (the compiler default-denies
+  module loading without one)
 - `fileResolver.Resolve` accepts plain relative/absolute paths AND `file:` URIs (`localFilePath` in
   `safety.go`): a `file:` URI is parsed, only an empty or `localhost` host is accepted, the path is
   percent-decoded (and de-slashed before a Windows drive letter); any other scheme (`http`/`https`/...) is
   rejected so the resolver never reaches the network. A bare Windows drive path (`C:\...`) is not mistaken for
   a scheme.
 - Each XML input parsed with `helium.NewParser()`, transformed with `ss.Transform(doc).WriteTo(ctx, out)`
-- Flags: `--output FILE` / `-o FILE`, `--param NAME VAL` (XPath), `--stringparam NAME VAL`, `--noout`, `--noent`, `--loaddtd`, `--timing`, `--max-input-bytes N`, `--max-depth N`, `--version`
+- Flags: `--output FILE` / `-o FILE`, `--param NAME VAL` (XPath), `--stringparam NAME VAL`, `--noout`, `--noent`,
+  `--loaddtd`, `--timing`, `--max-input-bytes N`, `--max-depth N`, `--version`
 - `--noent` / `--loaddtd` → stylesheet-parser external-loading opt-in (off by default): each lifts the
   parser's default `BlockXXE` and installs `confinedDirFS` (stylesheet directory only). They affect ONLY the
   stylesheet parse; the source-document parser is always the plain secure `NewParser()` default
-- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited) and applies to BOTH the stylesheet parser and the source-document parser; when absent, the `NewParser` default is left untouched
+- `--max-depth N` caps element nesting depth (default `256`, `0` = unlimited) and applies to BOTH the stylesheet parser
+  and the source-document parser; when absent, the `NewParser` default is left untouched
 - Parameters passed via `inv.GlobalParameters()`
-- Same output safety as `helium lint`: `--output` is rejected when it matches an input or the stylesheet, or when combined with `--noout`; close errors fold into the exit status; inputs are read under the `--max-input-bytes` cap
+- Same output safety as `helium lint`: `--output` is rejected when it matches an input or the stylesheet, or when
+  combined with `--noout`; close errors fold into the exit status; inputs are read under the `--max-input-bytes` cap

--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -17,7 +17,8 @@ Fields:
   line       int         # source line number
 ```
 
-Methods: `FirstChild()`, `LastChild()`, `NextSibling()`, `PrevSibling()`, `Parent()`, `Content()` (aggregates children), `Type()`, `Name()`, `LocalName()`, `Line()`, `OwnerDocument()`
+Methods: `FirstChild()`, `LastChild()`, `NextSibling()`, `PrevSibling()`, `Parent()`, `Content()` (aggregates children),
+`Type()`, `Name()`, `LocalName()`, `Line()`, `OwnerDocument()`
 
 ### `node` — extends docnode with content and namespaces
 
@@ -30,7 +31,8 @@ Fields:
   nsDefs     []*Namespace  # all namespace declarations on this element
 ```
 
-Methods: `DeclareNamespace(prefix, uri)`, `SetActiveNamespace(prefix, uri)`, `Namespace()`, `Namespaces()`, `Prefix()`, `URI()`, `Name()` (qualifies with prefix: `prefix:localname`)
+Methods: `DeclareNamespace(prefix, uri)`, `SetActiveNamespace(prefix, uri)`, `Namespace()`, `Namespaces()`, `Prefix()`,
+`URI()`, `Name()` (qualifies with prefix: `prefix:localname`)
 
 ## Namespace Storage (critical)
 
@@ -41,7 +43,8 @@ Element has THREE namespace-related fields:
 
 `Namespace` is NOT a tree node — lightweight struct: `{etype, href, prefix, context}`. No parent/child/sibling links.
 
-`NamespaceNodeWrapper` wraps Namespace for XPath: adds docnode linkage. `Name()` = prefix, `Content()` = URI. Read-only (AddChild/AddSibling are no-ops).
+`NamespaceNodeWrapper` wraps Namespace for XPath: adds docnode linkage. `Name()` = prefix, `Content()` = URI. Read-only
+(AddChild/AddSibling are no-ops).
 
 `Element.Namespaces()` returns a cloned slice, so callers cannot replace or
 append entries in the element's `nsDefs`. Namespace lookup does not clone that
@@ -108,7 +111,8 @@ NamespaceDeclNode(18) XIncludeStartNode(19) XIncludeEndNode(20) NamespaceNode(21
 ## Key Behaviors
 
 ### Text Node Consolidation
-`Text.AddSibling(Text)` → content merged instead of creating sibling. Prevents whitespace node bloat. Mirrors libxml2 TEXT consolidation.
+`Text.AddSibling(Text)` → content merged instead of creating sibling. Prevents whitespace node bloat. Mirrors libxml2
+TEXT consolidation.
 
 ### PI Content Is A String, Not Children
 A `ProcessingInstruction` stores its content in the `data` string field (mirrors libxml2's XML_PI_NODE, whose
@@ -248,7 +252,8 @@ any other node `rawContent` falls back to `Content()`. PI/EntityRef/Entity/Names
 returned string-derived copies and are unaffected.
 
 ### Predefined Entities
-5 unexported singletons: `entityLT`, `entityGT`, `entityAmpersand`, `entityApostrophe`, `entityQuote` (resolved by name through `resolvePredefinedEntity`). Type `InternalPredefinedEntity`. Cannot be redeclared.
+5 unexported singletons: `entityLT`, `entityGT`, `entityAmpersand`, `entityApostrophe`, `entityQuote` (resolved by name
+through `resolvePredefinedEntity`). Type `InternalPredefinedEntity`. Cannot be redeclared.
 
 ### NamespaceDeclNode Special Case
 Skipped in `setTreeDoc()` — sentinel type rarely instantiated.

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -42,7 +42,8 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
     elements expanded; if `ValidateDTD` is also set, the expanded tree is validated. Off by default (nil
     disables). The interface is the dependency-inversion seam: the root package cannot import `xinclude`
     (which imports `helium`), so the caller builds and injects a configured processor
-  - **PermissiveFS() → fs.FS** — returns `internal/iofs.PermissiveRoot` (opens any path via `os.Open`), the public escape hatch for restoring host-filesystem access that `NewParser` does not grant by default
+  - **PermissiveFS() → fs.FS** — returns `internal/iofs.PermissiveRoot` (opens any path via `os.Open`), the public
+    escape hatch for restoring host-filesystem access that `NewParser` does not grant by default
   - **DirFS(root string) → fs.FS** — returns `internal/iofs.ConfinedDir`, a confined FS that opens external
     resources only at or below `root`. Refuses a `../`- or absolute-path escape AND an in-root symlink
     pointing outside `root` (enforced with `os.Root`/`os.OpenRoot`, Go 1.24+ — stronger than `os.DirFS`, which
@@ -194,9 +195,12 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   - Terminal method: `WriteTo(io.Writer, Node) → error`
 - **Write(io.Writer, Node) → error** — serialize node with default settings
 - **WriteString(Node) → (string, error)** — serialize node to string with default settings
-- **Element.FindAttribute(AttributePredicate) → (*Attribute, bool)** — attribute-node lookup by matcher; built-in matchers: `QNamePredicate`, `LocalNamePredicate`, `NSPredicate`
-- **Element.GetAttribute(qname) → (string, bool)** / **Element.GetAttributeNS(local, nsURI) → (string, bool)** — attribute value lookup by QName or expanded name
-- Element attribute setters (all return only `error`, create-or-replace-in-place by expanded name/QName via `addProperty`, and reject a colon in the name/local name):
+- **Element.FindAttribute(AttributePredicate) → (*Attribute, bool)** — attribute-node lookup by matcher; built-in
+  matchers: `QNamePredicate`, `LocalNamePredicate`, `NSPredicate`
+- **Element.GetAttribute(qname) → (string, bool)** / **Element.GetAttributeNS(local, nsURI) → (string, bool)** —
+  attribute value lookup by QName or expanded name
+- Element attribute setters (all return only `error`, create-or-replace-in-place by expanded name/QName via
+  `addProperty`, and reject a colon in the name/local name):
   - **Element.SetAttribute(name, value) / Element.SetAttributeNS(localname, value, ns)** — **LITERAL**: store
     `value` verbatim as a text child WITHOUT parsing entity references (mirrors libxml2 `xmlSetProp`). `"A&B"`
     stays the three characters `A&B`; `"&amp;"` stays five characters. The writer escapes on output, so a
@@ -209,7 +213,9 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
     malformed reference (e.g. a bare `&` in `"A&B"`) is an error. For callers building the DOM from unresolved
     attribute source text (the parser's `TreeBuilder` non-`replaceEntities` path).
   - **Element.SetBooleanAttribute(name)** — name-only attribute with NO children (distinct from an empty-string value).
-- **Document.CreateAttribute(name, value, ns) → (*Attribute, error)** — builds an attribute node with `value` PARSED into its child list (mirrors `xmlNewDocProp`); backs `SetParsedAttribute`/`SetParsedAttributeNS`. Rejects a colon in `name`.
+- **Document.CreateAttribute(name, value, ns) → (*Attribute, error)** — builds an attribute node with `value` PARSED
+  into its child list (mirrors `xmlNewDocProp`); backs `SetParsedAttribute`/`SetParsedAttributeNS`. Rejects a colon in
+  `name`.
 - Key types: `Document`, `Element`, `Attribute`, `Namespace`, `DTD`, `Entity`, `Text`, `CDATASection`, `Comment`, `PI`
 - `Node` interface — common for all node types; use ElementType enum to distinguish
 - Parse flags configured via fluent methods on Parser (internal bitset, not public)
@@ -217,13 +223,16 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   `Sink`-backed); retained by reference and shared across operations, a nil handler is treated as
   `NilErrorHandler` (discard). The root `Parser` consults it only during DTD validation (see
   `Parser.ErrorHandler` above)
-- `ErrorLeveler` interface — optional `ErrorLevel() ErrorLevel` an error implements to report its severity; `ErrorCollector`'s level filter reads it via `errors.As` (default `ErrorLevelWarning`)
+- `ErrorLeveler` interface — optional `ErrorLevel() ErrorLevel` an error implements to report its severity;
+  `ErrorCollector`'s level filter reads it via `errors.As` (default `ErrorLevelWarning`)
 - `DTDValidationError{Message, Level}` (`valid.go`) — structured DTD-validation diagnostic delivered to the
   `ErrorHandler` under `ValidateDTD(true)`; implements `ErrorLeveler` returning `ErrorLevelError`, so a
   level-filtered `ErrorCollector` keeps it. Recover via `errors.As`; `.Error()` returns `Message`
   (byte-identical to the prior `fmt.Errorf` text)
-- `CatalogResolver` interface — public interface for custom catalog resolvers (`Resolve(ctx, pubID, sysID)`, `ResolveURI(ctx, uri)`)
-- `ErrNoInternalSubset` — sentinel returned by `Document.InternalSubset()` when the document has no internal DTD subset (`IntSubset()` returns nil for the same condition); match with `errors.Is`
+- `CatalogResolver` interface — public interface for custom catalog resolvers (`Resolve(ctx, pubID, sysID)`,
+  `ResolveURI(ctx, uri)`)
+- `ErrNoInternalSubset` — sentinel returned by `Document.InternalSubset()` when the document has no internal DTD subset
+  (`IntSubset()` returns nil for the same condition); match with `errors.Is`
 - `ErrDuplicateDeclaration` — sentinel returned when a DTD declaration collides with an existing one of the
   same kind and name: a second `AddElementDecl`, `AddNotation`, or `AddAttributeDecl` for an already-declared
   element, notation, or `(element, attribute)` pair. Wrapped (via `%w`) into a message naming the kind and
@@ -233,7 +242,8 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   `AddNotation` notation name (a notation name is an XML NCName; the colon is the one name-grammar rule these
   otherwise caller-trusting builders enforce, because the parser rejects a colon-bearing `<!NOTATION>` name).
   Wrapped (via `%w`) into a message describing the violation; match with `errors.Is`
-- `ErrExternalDTDTooLarge` — sentinel error returned when a loaded external DTD subset exceeds the byte cap; enforced against actual bytes read, never the advisory `fs.FileInfo.Size()`
+- `ErrExternalDTDTooLarge` — sentinel error returned when a loaded external DTD subset exceeds the byte cap; enforced
+  against actual bytes read, never the advisory `fs.FileInfo.Size()`
 - `ErrUnsupportedXMLVersion` — sentinel returned when a document's XML declaration declares a VersionNum
   outside the 1.x family (e.g. `"0.0"`, `"2.0"`), which XML 1.0 5th ed. makes fatal (§2.8; libxml2
   `XML_ERR_UNKNOWN_VERSION`). Wrapped (via `%w`) into a message naming the version, then into `ErrParseError`;
@@ -286,7 +296,8 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   blank-skip run; used when `MaxNodeContentSize` is unset (0); a negative `MaxNodeContentSize` disables both
   the node-content and the blank-run cap
 - `MaxExternalDTDSize` — default external-DTD byte cap (10 MiB), used when `MaxExternalDTDBytes` is unset or `0`
-- `Parser.MaxExternalDTDBytes(n int)` — override the external-DTD byte cap (`0` → `MaxExternalDTDSize`; negative disables the cap)
+- `Parser.MaxExternalDTDBytes(n int)` — override the external-DTD byte cap (`0` → `MaxExternalDTDSize`; negative
+  disables the cap)
 - `AsNode[T Node](n Node) (T, bool)` — generic safe type assertion for Node types. A typed-nil pointer wrapped
   in a non-nil `Node` interface (Go's interface nil trap — e.g. the `*Element` `Document.DocumentElement()`
   returns for a rootless document) reports `(zero, false)`, never `(nil, true)`, so a caller with `ok == true`
@@ -453,7 +464,9 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
 - `BuildURI(reference, base)` — resolve a relative reference against a base; a byte-faithful port of libxml2
   `xmlBuildURI(URI, base)`, so its argument order is `(reference, base)` (reference FIRST), the reverse of
   `url.URL.ResolveReference`/RFC 3986. c14n and all in-tree callers depend on this order. `node_base.go`
-- `ResolveURI(base, ref) → (string, error)` — conventionally-ordered `(base, reference)` wrapper over `BuildURI`; returns an error when the reference cannot be resolved. Use this in new code instead of `BuildURI`'s reversed order. `node_base.go`
+- `ResolveURI(base, ref) → (string, error)` — conventionally-ordered `(base, reference)` wrapper over `BuildURI`;
+  returns an error when the reference cannot be resolved. Use this in new code instead of `BuildURI`'s reversed order.
+  `node_base.go`
 - Files: `parser.go` (API), `parserctx.go` (context/state), `parser_document.go`, `parser_element.go`,
   `parser_whitespace.go`, `parser_xml_decl.go`, `parser_encoding.go`, `parser_decl.go`, `parser_content.go`,
   `parser_dtd_subset.go`, `parser_dtd_element.go`, `parser_dtd_attr.go`, `parser_entity_decl.go`,
@@ -478,7 +491,8 @@ W3C Canonical XML. 3 modes: C14N10, ExclusiveC14N10, C14N11.
   rendered element's own excluded xml:* attribute is still emitted — XMLDSig digest interop). Strict mode is
   also fail-closed on xml:base: a degenerate/un-canonicalizable value (malformed URI, empty-authority
   "//"/"///"/"urn://") errors out of Canonicalize, where default emits best-effort bytes.
-- Files: `c14n.go` (API), `canonicalizer.go` (engine), `xmlbase.go` (xml:base join), `nsstack.go`, `sort.go`, `escape.go`
+- Files: `c14n.go` (API), `canonicalizer.go` (engine), `xmlbase.go` (xml:base join), `nsstack.go`, `sort.go`,
+  `escape.go`
 - Imports: helium
 
 ## xpath1/
@@ -488,19 +502,25 @@ XPath 1.0 expression parsing and evaluation.
 - **Compile(string) → (*Expression, error)** / **MustCompile(string) → *Expression** — parse XPath
 - **Expression.Evaluate(ctx, Node) → (*Result, error)**
 - **NewEvaluator() → Evaluator** — create clone-on-write evaluation configuration
-  - `Namespaces`, `Variables`, `Function`, `FunctionNS`, `OpLimit` — configure namespace, variable, extension-function, and operation-limit state
-  - `Validate(*Expression) → error` — statically require every variable, function name, and QName prefix to resolve against the evaluator configuration without evaluating the expression
+  - `Namespaces`, `Variables`, `Function`, `FunctionNS`, `OpLimit` — configure namespace, variable, extension-function,
+    and operation-limit state
+  - `Validate(*Expression) → error` — statically require every variable, function name, and QName prefix to resolve
+    against the evaluator configuration without evaluating the expression
   - `Evaluate(ctx, *Expression, Node) → (*Result, error)` — evaluate with the configured state
 - **Find(ctx, Node, string) → ([]Node, error)** — convenience: compile+evaluate→node-set
 - **Evaluate(ctx, Node, string) → (*Result, error)** — convenience: compile+evaluate
-- **WithNamespaces(ctx, ns) → context.Context** / **WithVariables(ctx, vars) → context.Context** / **WithOpLimit(ctx, n) → context.Context** — attach XPath evaluation settings to `context.Context`
-- **WithFunction(ctx, name, fn) → context.Context** / **WithFunctionNS(ctx, uri, name, fn) → context.Context** — register custom functions on `context.Context`
-- **WithFunctions(ctx, fns) → context.Context** / **WithFunctionsNS(ctx, fns) → context.Context** — bulk function registration
+- **WithNamespaces(ctx, ns) → context.Context** / **WithVariables(ctx, vars) → context.Context** / **WithOpLimit(ctx, n)
+  → context.Context** — attach XPath evaluation settings to `context.Context`
+- **WithFunction(ctx, name, fn) → context.Context** / **WithFunctionNS(ctx, uri, name, fn) → context.Context** —
+  register custom functions on `context.Context`
+- **WithFunctions(ctx, fns) → context.Context** / **WithFunctionsNS(ctx, fns) → context.Context** — bulk function
+  registration
 - `Result` types: NodeSetResult, BooleanResult, NumberResult, StringResult
 - `FunctionContext` — read-only custom-function evaluation state; retrieve via `GetFunctionContext(ctx)`
 - Merge helpers: `WithAdditionalNamespaces(ctx, ns)`, `WithAdditionalVariables(ctx, vars)`
 - Limits: recursion 5000, node-set 10M, configurable op limit
-- Robustness: `eval` and axis-iteration loops honor `ctx.Err()` so a cancelled context aborts promptly; `Evaluate` on a nil/zero-value `Expression` returns `ErrNilExpression` instead of panicking
+- Robustness: `eval` and axis-iteration loops honor `ctx.Err()` so a cancelled context aborts promptly; `Evaluate` on a
+  nil/zero-value `Expression` returns `ErrNilExpression` instead of panicking
 - Files: `xpath.go` (API), `parser.go`, `lexer.go`, `eval.go`, `expr.go`, `axes.go`, `functions.go`, `token.go`
 - Imports: helium
 
@@ -509,9 +529,12 @@ XPath 1.0 expression parsing and evaluation.
 XPath 3.1 expression parsing and evaluation.
 
 - **NewCompiler() → Compiler** — create fluent builder for expression compilation
-  - `Compile(string) → (*Expression, error)` / `MustCompile(string) → *Expression` / `CompileExpr(Expr) → (*Expression, error)` — terminal methods
-- **NewEvaluator(EvaluatorOption) → Evaluator** — create evaluator from a flags bitmask (`DefaultEvaluatorOptions` = clone-on-write; `EvalBorrowing` = setters borrow caller-owned maps/slices without cloning)
-  - `Evaluate(ctx, *Expression, Node) → (*Result, error)` — terminal method (`ctx` is cancellation only; config comes from the setters below)
+  - `Compile(string) → (*Expression, error)` / `MustCompile(string) → *Expression` / `CompileExpr(Expr) → (*Expression,
+    error)` — terminal methods
+- **NewEvaluator(EvaluatorOption) → Evaluator** — create evaluator from a flags bitmask (`DefaultEvaluatorOptions` =
+  clone-on-write; `EvalBorrowing` = setters borrow caller-owned maps/slices without cloning)
+  - `Evaluate(ctx, *Expression, Node) → (*Result, error)` — terminal method (`ctx` is cancellation only; config comes
+    from the setters below)
 - **Expression.Validate(map[string]string) → error** — static namespace-prefix validation;
   **Expression.EvaluateReuse(ctx, *EvalState, Node) → (Result, error)** — low-allocation evaluation;
   **Expression.DumpVM(io.Writer) → error** — compiled VM instruction dump
@@ -531,7 +554,8 @@ XPath 3.1 expression parsing and evaluation.
   `AllowXML11Chars()`, `DocOrderCache(*DocOrderCache)`, `TraceWriter(io.Writer)`, `Parser(helium.Parser)` (XML
   parser used by `fn:parse-xml`/`fn:parse-xml-fragment`/`fn:doc`; supplies parse policy — limits, FS,
   XXE/network; unset → default `helium.NewParser()`)
-- `Result` — wraps `Sequence`; methods: `Nodes()`, `IsBoolean()`, `IsNumber()`, `IsString()`, `IsAtomic()`, `Atomics()`, `Sequence()`, `StringValue()`, `Copy()`
+- `Result` — wraps `Sequence`; methods: `Nodes()`, `IsBoolean()`, `IsNumber()`, `IsString()`, `IsAtomic()`, `Atomics()`,
+  `Sequence()`, `StringValue()`, `Copy()`
 - **Reuse:** `Evaluator.NewEvalState(Node) → *EvalState` builds reusable state; `Expression.EvaluateReuse`
   runs against it. The returned `Result` is valid only until the next `EvaluateReuse` on the same `EvalState`
   (backing storage is overwritten) — use `Result.Copy()` to retain it. `EvalState` has
@@ -558,7 +582,8 @@ XPath 3.1 expression parsing and evaluation.
   Go `regexp` (staying linear — no backtracking-ReDoS regression for RE2-compatible patterns like `^(a+)+b`);
   `limit` (N+1 for a budget of N; `<=0` = uncapped) bounds that pass's allocation to the budget, never to the
   input match count
-- XPath 3.1 features: FLWOR, quantified, if-then-else, try-catch, maps, arrays, inline functions, HOFs, arrow operator, simple map, string concat, value/general/node comparisons
+- XPath 3.1 features: FLWOR, quantified, if-then-else, try-catch, maps, arrays, inline functions, HOFs, arrow operator,
+  simple map, string concat, value/general/node comparisons
 - Built-in functions: 100+ across fn:, math:, map:, array: namespaces
 - Type system: Sequence ([]Item), AtomicValue, NodeItem, MapItem, ArrayItem, FunctionItem
 - Structured errors: XPathError with W3C error codes (XPTY0004, FOER0000, etc.)
@@ -582,7 +607,8 @@ XPath 3.1 expression parsing and evaluation.
   `functions_math.go`, `functions_misc.go`, `functions_json.go`, `functions_json_xml.go`,
   `functions_serialize.go`, `functions_constructors.go` (XSD typed constructors, incl. xs:error),
   `functions_unparsed_text.go`
-- Imports: helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence
+- Imports: helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor,
+  internal/sequence
 
 ## xslt3/
 
@@ -604,7 +630,8 @@ XSLT 3.0 stylesheet compilation + transformation on helium DOM with `xpath3` eva
 - **Compiler.StaticParameters(*Parameters) → Compiler** / **Compiler.SetStaticParameter(string, Sequence) →
   Compiler** / **Compiler.ClearStaticParameters() → Compiler** / **Compiler.ImportSchemas(...*xsd.Schema) →
   Compiler** — compile-time static params + schema imports
-- **Compiler.MaxResourceBytes(int64) → Compiler** — set the per-resource read cap inherited by invocations (0 = [MaxResourceBytes] default, negative = unbounded, positive = that cap)
+- **Compiler.MaxResourceBytes(int64) → Compiler** — set the per-resource read cap inherited by invocations (0 =
+  [MaxResourceBytes] default, negative = unbounded, positive = that cap)
 - **Compiler.Parser(helium.Parser) → Compiler** / **Invocation.Parser(helium.Parser) → Invocation** — the
   parser governing parse policy (limits, FS, XXE/network) for stylesheet, schema, and runtime source/`fn:doc`
   parsing; **forwarded** into the `xsd.Compiler`s and `xpath3.Evaluator`s the engine builds internally. xslt3
@@ -619,11 +646,14 @@ XSLT 3.0 stylesheet compilation + transformation on helium DOM with `xpath3` eva
   carried on the `Stylesheet` and inherited by `fn:transform` nested compiles and (unless overridden) by
   runtime invocations. Serialization parameter documents and imported XSD schemas are always parsed
   XXE-blocked.
-- **Compiler.Compile(ctx, *Document) → (*Stylesheet, error)** / **Compiler.MustCompile(ctx, *Document) → *Stylesheet** — terminal compile methods
+- **Compiler.Compile(ctx, *Document) → (*Stylesheet, error)** / **Compiler.MustCompile(ctx, *Document) → *Stylesheet** —
+  terminal compile methods
 - **Transform(ctx, *Document, *Stylesheet) → (*Document, error)** / **TransformToWriter(ctx, *Document,
   *Stylesheet, io.Writer) → error** / **TransformString(ctx, *Document, *Stylesheet) → (string, error)** —
   convenience wrappers; nil `*Stylesheet` returns error here
-- **Stylesheet.Transform(*Document) → Invocation** / **Stylesheet.ApplyTemplates(*Document) → Invocation** / **Stylesheet.CallTemplate(string) → Invocation** / **Stylesheet.CallFunction(string, ...Sequence) → Invocation** — invocation entrypoints
+- **Stylesheet.Transform(*Document) → Invocation** / **Stylesheet.ApplyTemplates(*Document) → Invocation** /
+  **Stylesheet.CallTemplate(string) → Invocation** / **Stylesheet.CallFunction(string, ...Sequence) → Invocation** —
+  invocation entrypoints
 - **Invocation.SourceDocument(*Document) → Invocation** / **Mode(string)** / **Selection(Sequence)**
   *(ApplyTemplates only)* / **GlobalParameters(*Parameters)** / **TunnelParameters(*Parameters)** /
   **SetParameter(string, Sequence)** / **SetTunnelParameter(string, Sequence)** /
@@ -653,7 +683,9 @@ XSLT 3.0 stylesheet compilation + transformation on helium DOM with `xpath3` eva
   `fn:doc`/`fn:unparsed-text`, plus `xsl:source-document`, `xsl:merge`, and `fn:stream-available`; without
   them those instructions error (`FODC0002`) or report unavailable per the default-deny model (no implicit
   `os.ReadFile`).
-- **Invocation.Do(ctx) → (*Document, error)** / **Invocation.Serialize(ctx) → (string, error)** / **Invocation.WriteTo(ctx, io.Writer) → error** / **Invocation.ResolvedOutputDef() → *OutputDef** — terminal execution + resolved primary output metadata
+- **Invocation.Do(ctx) → (*Document, error)** / **Invocation.Serialize(ctx) → (string, error)** /
+  **Invocation.WriteTo(ctx, io.Writer) → error** / **Invocation.ResolvedOutputDef() → *OutputDef** — terminal execution
+  + resolved primary output metadata
 - **NewParameters() → *Parameters** — mutable XSLT parameter carrier keyed by expanded name
 - **TransformFunction(...TransformOption) → xpath3.Function** — standalone `fn:transform()` for registering on
   a bare `xpath3.Evaluator` (`Evaluator.Functions(nil, {fn:transform: ...})`), for callers driving xpath3
@@ -740,8 +772,11 @@ XSLT 3.0 stylesheet compilation + transformation on helium DOM with `xpath3` eva
   result-value)` (the principal gets `base-output-uri`, each secondary its href key); its return value
   replaces the entry's value in the result map, across all three delivery formats (document node, serialized
   string, raw items).
-- `fn:transform` serialized delivery serializes every emitted principal and secondary result. Any result serialization failure raises `FOXT0003`.
-- Key types: `Stylesheet`, `Compiler`, `Invocation`, `Parameters`, `OutputDef`, `URIResolver`, `PackageResolver`, `MessageHandler`, `ResultDocumentHandler`, `RawResultHandler`, `PrimaryItemsHandler`, `AnnotationHandler`, `TransformOption`
+- `fn:transform` serialized delivery serializes every emitted principal and secondary result. Any result serialization
+  failure raises `FOXT0003`.
+- Key types: `Stylesheet`, `Compiler`, `Invocation`, `Parameters`, `OutputDef`, `URIResolver`, `PackageResolver`,
+  `MessageHandler`, `ResultDocumentHandler`, `RawResultHandler`, `PrimaryItemsHandler`, `AnnotationHandler`,
+  `TransformOption`
 - Resource limits: `MaxResourceBytes` (const, 10 MiB default per-resource read cap) + `ErrResourceTooLarge`
   (error returned when an external resource exceeds the cap); enforced against actual bytes read, configurable
   per Compiler/Invocation. The same cap doubles as the xsl:analyze-string match-count ceiling: matches are
@@ -788,8 +823,10 @@ XSLT 3.0 stylesheet compilation + transformation on helium DOM with `xpath3` eva
   `schema_context.go`, `schema_resolver_fs.go`, `package_*.go`, `streamability*.go`, `errors.go`,
   `resource_limit.go` (per-resource read cap + `MaxResourceBytes`/`ErrResourceTooLarge`); the XSLT element
   registry lives in `xslt3/internal/elements` (`elements.go`, `data.go`, see below)
-- Imports: helium, xpath3, xsd, html, internal/lexicon, internal/nodelink, internal/sequence, internal/writerctl, xslt3/internal/elements
-- Tests: hand-written unit tests only. The W3C XSLT 3.0 conformance suite lives in the sibling `helium-w3c-tests` module (fetches upstream, depends on this module via a replace directive)
+- Imports: helium, xpath3, xsd, html, internal/lexicon, internal/nodelink, internal/sequence, internal/writerctl,
+  xslt3/internal/elements
+- Tests: hand-written unit tests only. The W3C XSLT 3.0 conformance suite lives in the sibling `helium-w3c-tests` module
+  (fetches upstream, depends on this module via a replace directive)
 
 ## xslt3/internal/elements/
 
@@ -815,7 +852,8 @@ XML Schema (XSD) compilation and validation. Defaults to XSD 1.0; XSD 1.1 is opt
 Toggle" section in CLAUDE.md for what is implemented in 1.1.
 
 - **NewCompiler() → Compiler** — create fluent builder for schema compilation
-  - `Label(name)`, `BaseDir(dir)`, `FS(fs.FS)`, `ErrorHandler(h)`, `Version(Version)` — builder methods (clone-on-write). `Version(Version10|Version11)` selects the XSD spec version (default `Version10`)
+  - `Label(name)`, `BaseDir(dir)`, `FS(fs.FS)`, `ErrorHandler(h)`, `Version(Version)` — builder methods
+    (clone-on-write). `Version(Version10|Version11)` selects the XSD spec version (default `Version10`)
   - `Compiler.Parser(helium.Parser)` — sets the parser used to parse the schema document and all nested
     `xs:include`/`xs:import`/`xs:redefine` targets; supplies parse policy (limits, FS, XXE/network). Distinct
     from `FS`, which *fetches* schema bytes; the injected parser governs *parse policy* of those bytes. Unset
@@ -833,7 +871,8 @@ Toggle" section in CLAUDE.md for what is implemented in 1.1.
     passed through unchanged, so the name handed to the FS is the canonical nested-schema URI; when `BaseDir`
     is a local path, names use `filepath.Join` and may be absolute / OS-style (rejected by `fs.ValidPath` FSes
     like `os.DirFS`/`fstest.MapFS`)
-  - `Compile(ctx, *Document) → (*Schema, error)` / `CompileFile(ctx, path) → (*Schema, error)` — terminal methods; return `(nil, ErrCompilationFailed)` on fatal schema diagnostics
+  - `Compile(ctx, *Document) → (*Schema, error)` / `CompileFile(ctx, path) → (*Schema, error)` — terminal methods;
+    return `(nil, ErrCompilationFailed)` on fatal schema diagnostics
 - **NewValidator(schema) → Validator** — create fluent builder for validation
   - `Label(name)`, `ErrorHandler(h)`, `Annotations(*TypeAnnotations)`, `NilledElements(*NilledElements)`,
     `IDNodes(*IDNodes)` — builder methods. `IDNodes` collects the PSVI is-id nodes (XDM 3.1): every
@@ -843,7 +882,8 @@ Toggle" section in CLAUDE.md for what is implemented in 1.1.
     observes a per-node property, it does not enforce document ID uniqueness). Feeds
     `xpath3.Evaluator.IDNodes` for `fn:id`/`fn:element-with-id`
   - `Validate(ctx, *Document) → error` — terminal method
-- **(*TypeDef).Validate(ctx, value, nsMap) → error** — validate a lexical value against a simple type; nsMap (prefix→URI) may be nil
+- **(*TypeDef).Validate(ctx, value, nsMap) → error** — validate a lexical value against a simple type; nsMap
+  (prefix→URI) may be nil
 - **(*TypeDef).ValidateElement(ctx, elem, schema) → error** — validate an element's content against a type
 - `Schema.LookupElement(local, ns)`, `Schema.LookupType(local, ns)`, `Schema.NamedTypes()`, `Schema.TargetNamespace()`
 - **Schema.Declarations() → xpath3.SchemaDeclarations** — an `xpath3.SchemaDeclarations` view over the
@@ -888,7 +928,8 @@ Toggle" section in CLAUDE.md for what is implemented in 1.1.
 - `ErrValidationFailed` — sentinel error returned by `Validate()` when the document is invalid; individual
   errors delivered via `ErrorHandler`. `Validate()` also returns `ErrNilSchema` (no compiled schema) and
   `ErrNilDocument` (nil document); a nil `ctx` is normalized to `context.Background()`
-- `ErrCompilationFailed` — sentinel error returned by `Compile()`/`CompileFile()` when the schema has one or more fatal errors; the returned schema is nil and individual diagnostics are delivered via `ErrorHandler`
+- `ErrCompilationFailed` — sentinel error returned by `Compile()`/`CompileFile()` when the schema has one or more fatal
+  errors; the returned schema is nil and individual diagnostics are delivered via `ErrorHandler`
 - Files: `xsd.go` (API), `doc.go`, `schema.go` (data model), `constants.go`, `compile.go` +
   `compile_imports.go` (compile orchestration/imports), `resolve_uri.go` (shared schema-location URI resolver
   `ResolveSchemaURI`/`URIScheme`), `read_types.go` + `read_particles.go` + `read_elements.go` (schema
@@ -902,16 +943,21 @@ Toggle" section in CLAUDE.md for what is implemented in 1.1.
   `schema_decls.go` (schema-aware XPath adapter), `errors.go`
 - Imports: helium, xpath1/, xpath3/ (XSD 1.1 assertions + conditional type assignment), internal/domutil,
   internal/lexicon, internal/xpath1/lexer
-- Status: see `.claude/docs/libxml2-parity.md` for libxml2 golden counts and W3C XSD 1.1 conformance run policy; do not cache branch-specific counts here
+- Status: see `.claude/docs/libxml2-parity.md` for libxml2 golden counts and W3C XSD 1.1 conformance run policy; do not
+  cache branch-specific counts here
 
 ## relaxng/
 
 RELAX NG schema compilation and validation.
 
 - **NewCompiler() → Compiler** — create fluent builder for grammar compilation
-  - `Label(name)`, `BaseDir(dir)`, `FS(fs.FS)`, `MaxResourceBytes(int)`, `ErrorHandler(h)` — builder methods (clone-on-write)
-  - `Compiler.BaseDir(dir)` — base directory for resolving relative paths in `include` and `externalRef` during compilation
-  - `Compiler.Parser(helium.Parser)` — sets the parser used to parse the grammar and its `include`/`externalRef` targets; supplies parse policy (limits, FS, XXE/network), distinct from the fetch `FS`. Unset → default `helium.NewParser()`.
+  - `Label(name)`, `BaseDir(dir)`, `FS(fs.FS)`, `MaxResourceBytes(int)`, `ErrorHandler(h)` — builder methods
+    (clone-on-write)
+  - `Compiler.BaseDir(dir)` — base directory for resolving relative paths in `include` and `externalRef` during
+    compilation
+  - `Compiler.Parser(helium.Parser)` — sets the parser used to parse the grammar and its `include`/`externalRef`
+    targets; supplies parse policy (limits, FS, XXE/network), distinct from the fetch `FS`. Unset → default
+    `helium.NewParser()`.
   - `Compiler.FS(fs.FS)` — sets the `fs.FS` used to load schemas referenced by `include` and `externalRef`.
     **Secure by default**: the default (and what a nil value restores) is a deny-all FS
     (`internal/iofs.DenyAll`, opens nothing), mirroring `helium.NewParser`, so an untrusted schema cannot read
@@ -929,13 +975,16 @@ RELAX NG schema compilation and validation.
 - **NewValidator(grammar) → Validator** — create fluent builder for validation
   - `Filename(name)`, `ErrorHandler(h)` — builder methods
   - `Validate(ctx, *Document) → error` — terminal method
-- Pattern-based: element, attribute, group, choice, interleave, optional, zeroOrMore, oneOrMore, ref, data, value, list, mixed, notAllowed
+- Pattern-based: element, attribute, group, choice, interleave, optional, zeroOrMore, oneOrMore, ref, data, value, list,
+  mixed, notAllowed
 - Supports: include with override, externalRef, parentRef, anyName/nsName/ncName, data types
 - Group backtracking for greedy pattern over-consumption
 - `ValidateError.Output` — libxml2-compatible error string; `ValidateError.Errors` — structured `[]ValidationError`
 - `ValidationError{Filename, Line, Element, Message}` — per-error structured type
-- Files: `relaxng.go` (API + config), `doc.go`, `grammar.go` (data model), `parse.go` (compiler), `parse_check.go` (compile checks), `validate.go` (engine), `errors.go` (error types + formatting)
-- Imports: helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xsdregex, internal/xmlchar, internal/uripath
+- Files: `relaxng.go` (API + config), `doc.go`, `grammar.go` (data model), `parse.go` (compiler), `parse_check.go`
+  (compile checks), `validate.go` (engine), `errors.go` (error types + formatting)
+- Imports: helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xsdregex,
+  internal/xmlchar, internal/uripath
 - Status: 159/159 golden tests passing
 
 ## html/
@@ -967,7 +1016,8 @@ HTML 4.01 parser producing helium DOM or SAX events.
   `MaxContentSize` never rejects ordinary names like `script`) that grows only when `MaxContentSize` exceeds
   the floor; `parseDoctype` checks `fatalErr` after EACH scanner so an over-cap run on a streaming reader
   fails promptly without a further blocking read; default 16 MiB)
-- Terminal: **Parse(ctx, []byte)**, **ParseReader(ctx, io.Reader)**, **ParseFile(ctx, path)**, **ParseWithSAX(ctx, []byte, SAXHandler)**, **NewPushParser(ctx)**, **NewSAXPushParser(ctx, SAXHandler)**
+- Terminal: **Parse(ctx, []byte)**, **ParseReader(ctx, io.Reader)**, **ParseFile(ctx, path)**, **ParseWithSAX(ctx,
+  []byte, SAXHandler)**, **NewPushParser(ctx)**, **NewSAXPushParser(ctx, SAXHandler)**
 - **NewWriter() → Writer** — create fluent writer builder
 - Writer methods: `DefaultDTD(bool)`, `Format(bool)`, `PreserveCase(bool)`, `EscapeURIAttributes(bool)`,
   `EscapeControlChars(bool)`, `NullNamespaceHTMLOnly(bool)` (HTML 4.01 rule: a void element only in the null
@@ -985,7 +1035,8 @@ HTML 4.01 parser producing helium DOM or SAX events.
   accepted (one-byte EOF probe), but the cap filling with more bytes still to come fails closed with
   `ErrContentSizeExceeded` (`encoding_reader.go`)
 - Entity resolution: 2125 WHATWG + 106 legacy HTML4; legacy entities work without `;`
-- Files: `html.go` (API), `parser.go`, `entities.go`, `elements.go`, `dump.go` (serializer), `tree.go` (DOM builder), `sax.go`
+- Files: `html.go` (API), `parser.go`, `entities.go`, `elements.go`, `dump.go` (serializer), `tree.go` (DOM builder),
+  `sax.go`
 - Imports: helium, sax/
 
 ## xinclude/
@@ -993,20 +1044,23 @@ HTML 4.01 parser producing helium DOM or SAX events.
 XInclude 1.0 processing with recursive inclusion and fallback.
 
 - **NewProcessor() → Processor** — create fluent builder
-- Processor methods: `NoXIncludeMarkers()`, `NoBaseFixup()`, `Resolver(Resolver)`, `BaseURI(string)`, `MaxIncludeSize(int)`, `MaxIncludeDepth(int)`, `ErrorHandler(helium.ErrorHandler)`, `Parser(helium.Parser)`
+- Processor methods: `NoXIncludeMarkers()`, `NoBaseFixup()`, `Resolver(Resolver)`, `BaseURI(string)`,
+  `MaxIncludeSize(int)`, `MaxIncludeDepth(int)`, `ErrorHandler(helium.ErrorHandler)`, `Parser(helium.Parser)`
 - `Processor.Parser(helium.Parser)` — supplies the **resource limits**
   (depth/name-length/amplification/content-model-depth) used to parse included documents. XInclude still
   forces its own loading policy: external-DTD loading is on and the filesystem is confined to the `Resolver`'s
   sandbox (the injected parser's FS is NOT used for included docs — the `Resolver` is the security boundary).
   Unset → default `helium.NewParser()` base.
 - Terminal: **Process(ctx, *Document) → (int, error)**, **ProcessTree(ctx, Node) → (int, error)**
-- `Resolver` interface — custom resource loader; receives the href already resolved against the effective base (base arg is informational only — do NOT re-resolve, or the base directory is double-applied)
+- `Resolver` interface — custom resource loader; receives the href already resolved against the effective base (base arg
+  is informational only — do NOT re-resolve, or the base directory is double-applied)
 - **Secure by default**: an unset `Resolver` denies all filesystem access (`NewFSResolver(iofs.DenyAll{})`),
   mirroring `helium.NewParser()`'s deny-all FS — untrusted input cannot disclose local files via
   `<xi:include>`. Opt in with `Resolver(NewFSResolver(fsys))` (confined `fs.FS`, e.g. `os.Root.FS`) or
   `Resolver(NewFSResolver(helium.PermissiveFS()))` for historical os.Open passthrough. NOTE:
   `NewFSResolver(nil)` is still permissive — only the processor's *unset* default is deny-all
-- `Processor.MaxIncludeSize(int)` — per-include byte cap; unset or ≤ 0 uses the default 10 MiB (unexported `defaultMaxIncludeSize`); over-cap reads fail with `ErrIncludeTooLarge`
+- `Processor.MaxIncludeSize(int)` — per-include byte cap; unset or ≤ 0 uses the default 10 MiB (unexported
+  `defaultMaxIncludeSize`); over-cap reads fail with `ErrIncludeTooLarge`
 - **Aggregate cap (internal, no public knob)**: across the whole expansion the cumulative materialized bytes
   are bounded at `maxIncludeAggregateMultiplier` (100) × the effective per-include cap (1 GiB by default;
   proportional, so lowering `MaxIncludeSize` lowers it), and the total spliced-resource count at
@@ -1020,7 +1074,8 @@ XInclude 1.0 processing with recursive inclusion and fallback.
 - `Processor.MaxIncludeDepth(int)` — xi:include nesting-depth cap; unset or ≤ 0 uses the default 40
   (unexported `defaultMaxIncludeDepth`); over-cap fails with "maximum include depth exceeded". Bounds nesting
   only — cyclic includes are caught separately by circular detection
-- Default `NewFSResolver` converts absolute `file:` hrefs to OS paths via `internal/iofs.FileURIToPath` (non-local hosts rejected)
+- Default `NewFSResolver` converts absolute `file:` hrefs to OS paths via `internal/iofs.FileURIToPath` (non-local hosts
+  rejected)
 - Max URI 2000 chars, circular detection, doc/text caching
 - Files: `xinclude.go`
 - Imports: helium, xpointer/, internal/encoding/, internal/iofs/, internal/lexicon/
@@ -1032,8 +1087,10 @@ XPointer expression evaluation with scheme cascading.
 - **Evaluate(ctx, *Document, string) → ([]Node, error)**
 - Schemes: xpointer(), xpath1() → XPath; element(/1/2/3) → child-sequence; xmlns() → ns binding; shorthand → ID lookup
 - Multiple scheme parts left-to-right; first non-empty result wins
-- `Compile(string) → (*Expression, error)` + `Expression.Evaluate(ctx, *Document) → ([]Node, error)` for reuse across documents
-- `ErrNilExpression` — sentinel returned by `Expression.Evaluate` when the receiver is nil or an uncompiled (zero-value) `Expression`
+- `Compile(string) → (*Expression, error)` + `Expression.Evaluate(ctx, *Document) → ([]Node, error)` for reuse across
+  documents
+- `ErrNilExpression` — sentinel returned by `Expression.Evaluate` when the receiver is nil or an uncompiled (zero-value)
+  `Expression`
 - `ErrNilDocument` — sentinel returned by `Expression.Evaluate`/`Evaluate` when the document is nil
 - Files: `xpointer.go`
 - Imports: helium, xpath1/, internal/xpath1/lexer, internal/xmlchar/
@@ -1048,11 +1105,14 @@ Schematron schema compilation and validation.
   XXE/network); unset → default `helium.NewParser()`. `QueryBinding` forces the query language binding and
   ignores the schema's `queryBinding` attribute; `DefaultQueryBinding` only chooses the fallback for a schema
   that names none
-- **Validator** (fluent, clone-on-write): `NewValidator(schema)` → `.Label(s)` / `.Quiet()` / `.ErrorHandler(h)` → `.Validate(ctx, doc)`
-- `ErrValidationFailed` — sentinel returned by `Validator.Validate` on validation failure; individual `*ValidationError` delivered to ErrorHandler
+- **Validator** (fluent, clone-on-write): `NewValidator(schema)` → `.Label(s)` / `.Quiet()` / `.ErrorHandler(h)` →
+  `.Validate(ctx, doc)`
+- `ErrValidationFailed` — sentinel returned by `Validator.Validate` on validation failure; individual `*ValidationError`
+  delivered to ErrorHandler
 - `ErrNoSchema` — sentinel returned by `Validator.Validate` when the Validator has no compiled schema
 - `ErrCompileFailed` — sentinel returned by `Compiler.Compile`/`CompileFile` when compilation fails
-- `ErrUnsupportedQueryBinding` — sentinel returned by `ParseQueryBinding` and by `Compiler.Compile`/`CompileFile` for a query language binding this package does not implement
+- `ErrUnsupportedQueryBinding` — sentinel returned by `ParseQueryBinding` and by `Compiler.Compile`/`CompileFile` for a
+  query language binding this package does not implement
 - **QueryBinding** — `QueryBindingUnspecified` / `QueryBindingXPath1` (`xslt`, absent attribute) /
   `QueryBindingXPath3` (`xslt3`, `xpath3`); `ParseQueryBinding(s)` maps an attribute value (trimmed,
   case-insensitive), `Schema.QueryBinding()` reports the resolved binding. Every other value is refused,
@@ -1072,7 +1132,8 @@ OASIS XML Catalog resolution for public/system IDs and URIs.
 - **Load(ctx, path) → (*Catalog, error)** — convenience wrapper around `NewLoader().Load`
 - **NewLoader() → Loader** — fluent value-style loader; methods return updated copies
 - **Loader.ErrorHandler(h) → Loader** — deliver parse warnings to a handler
-- **Loader.MaxBytes(n) → Loader** — cap catalog file size; exceed → `ErrCatalogTooLarge` (default `MaxCatalogSize`, 10 MiB)
+- **Loader.MaxBytes(n) → Loader** — cap catalog file size; exceed → `ErrCatalogTooLarge` (default `MaxCatalogSize`, 10
+  MiB)
 - **Catalog.Resolve(ctx, pubID, sysID) → string** — resolve external identifier
 - **Catalog.ResolveURI(ctx, uri) → string** — resolve URI reference
 - **Catalog.ResolveResult(ctx, pubID, sysID) → (uri string, broke bool)** / **Catalog.ResolveURIResult(ctx,
@@ -1092,7 +1153,8 @@ Streaming XML writer (no DOM needed).
 
 - **NewWriter(io.Writer, ...Option) → *Writer**
 - Options: WithIndent(string), WithQuoteChar(byte)
-- Methods: StartDocument/EndDocument, StartElement/EndElement, WriteAttribute, WriteString (escaped), WriteRaw (unescaped), WriteComment, WritePI, WriteCDATA, StartDTD/EndDTD, WriteDTDElement/Entity/Attlist/Notation, Flush
+- Methods: StartDocument/EndDocument, StartElement/EndElement, WriteAttribute, WriteString (escaped), WriteRaw
+  (unescaped), WriteComment, WritePI, WriteCDATA, StartDTD/EndDTD, WriteDTDElement/Entity/Attlist/Notation, Flush
 - State machine: tracks open elements, namespace scopes, self-close optimization
 - Files: `stream.go` (single ~1100 line file)
 - Imports: internal/encoding/, internal/xmlchar/
@@ -1101,8 +1163,10 @@ Streaming XML writer (no DOM needed).
 
 SAX2 event-driven parsing interface definitions.
 
-- `SAX2Handler` interface — callbacks: StartDocument, EndDocument, StartElement, EndElement, Characters, Comment, PI, CData, DTD events, entity/notation/element/attribute declarations
-- `WithDocumentLocator(ctx, loc)` / `GetDocumentLocator(ctx)` — attach or read the current document locator on callback `context.Context`
+- `SAX2Handler` interface — callbacks: StartDocument, EndDocument, StartElement, EndElement, Characters, Comment, PI,
+  CData, DTD events, entity/notation/element/attribute declarations
+- `WithDocumentLocator(ctx, loc)` / `GetDocumentLocator(ctx)` — attach or read the current document locator on callback
+  `context.Context`
 - Files: `sax.go`
 - Imports: helium (node types)
 
@@ -1125,7 +1189,8 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   and `clone` re-copies it, so a later mutation of the caller's `Transforms` slice cannot alter a configured
   Signer or race with signing. `ExcC14NTransform(prefixes...)` copies the prefix varargs and `Prefixes()`
   returns a copy, so a transform's prefix list is immutable to callers.
-  - `SignatureAlgorithm(uri)`, `CanonicalizationMethod(uri)`, `Reference(ReferenceConfig)`, `KeyInfo(KeyInfoBuilder)`, `SignatureID(id)`, `AllowSHA1(bool)` — builder methods
+  - `SignatureAlgorithm(uri)`, `CanonicalizationMethod(uri)`, `Reference(ReferenceConfig)`, `KeyInfo(KeyInfoBuilder)`,
+    `SignatureID(id)`, `AllowSHA1(bool)` — builder methods
   - `SignEnveloped(ctx, doc, parent, key)`, `SignEnveloping(ctx, doc, content, key)`, `SignDetached(ctx, doc,
     key)` — terminal methods. Each honors `ctx` symmetrically with verification: an already-cancelled/expired
     context short-circuits at the top of the call (before the Signature skeleton is built, any caller content
@@ -1287,7 +1352,8 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
     Per-reference errors keep their `VerificationError` index and complete URI fields, while `Error()` renders
     the URI through `lexer.DiagnosticExcerpt`. Opt-in Manifest inner references use a separate all-siblings
     preparation pass and remain advisory.
-- **NewEnvelopedReference() → ReferenceConfig** — WHOLE-DOCUMENT enveloped defaults: empty URI (always resolves to the document element, regardless of the `SignEnveloped` parent) + enveloped-signature transform + ExcC14N + SHA-256
+- **NewEnvelopedReference() → ReferenceConfig** — WHOLE-DOCUMENT enveloped defaults: empty URI (always resolves to the
+  document element, regardless of the `SignEnveloped` parent) + enveloped-signature transform + ExcC14N + SHA-256
 - **NewEnvelopedReferenceByID(id) → ReferenceConfig** — element-scoped enveloped defaults: `URI="#id"` (covers
   only the element carrying that id) + enveloped-signature transform + ExcC14N + SHA-256. Correct for signing
   a specific nested element (e.g. a SAML Assertion by its ID); the id must be recognized as an ID attribute
@@ -1505,7 +1571,8 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   run through `ecdsaDERToRaw`; Ed25519: `Sign` with `crypto.Hash(0)` over the raw message). A `crypto.Signer`
   whose public-key type does not match the algorithm → `ErrKeyMismatch`.
 - Digests: SHA-1, SHA-224, SHA-256, SHA-384, SHA-512
-- **SHA-1 rejected by default** (rsa-sha1/ecdsa-sha1/hmac-sha1/sha1) on both sign and verify → `ErrWeakAlgorithm`; opt in with `Signer.AllowSHA1(true)` / `Verifier.AllowSHA1(true)` for legacy interop. SHA-224+ unaffected.
+- **SHA-1 rejected by default** (rsa-sha1/ecdsa-sha1/hmac-sha1/sha1) on both sign and verify → `ErrWeakAlgorithm`; opt
+  in with `Signer.AllowSHA1(true)` / `Verifier.AllowSHA1(true)` for legacy interop. SHA-224+ unaffected.
 - Errors: `ErrNoKeySource` sentinel — returned by verify when no usable KeySource is configured (nil cfg,
   untyped-nil, or typed-nil KeySource/func); `ErrWeakAlgorithm` — SHA-1 used without opt-in;
   `ErrReferenceNotFound` also covers a nil-resolver external reference and every `FSReferenceResolver`
@@ -1580,7 +1647,8 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
   - `PrivateKey(key)`, `ECPrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)`, `BlockAlgorithm(uri)`,
     `AllowUnauthenticatedCBC(bool)`, `StrictPKCS7Padding(bool)`, `MaxEncryptedKeys(n)`,
     `MaxEncryptedKeyBytes(n)`, `MaxCipherValueBytes(n)`, `CipherReferenceResolver(r)` — builder methods
-  - `Decrypt(ctx, elem)`, `DecryptBytes(ctx, elem)` — terminal methods; the latter returns binary plaintext without XML parsing
+  - `Decrypt(ctx, elem)`, `DecryptBytes(ctx, elem)` — terminal methods; the latter returns binary plaintext without XML
+    parsing
 - **ReferenceResolver** (`reference_resolver.go`) — single-method interface `ResolveReference(ctx, uri)
   (io.ReadCloser, error)` supplying the octet STREAM of an EXTERNAL `xenc:CipherReference`, plus
   **FSReferenceResolver(fsys, root)**, the only implementation shipped. `uri` is always the JOINED,
@@ -1639,7 +1707,8 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
   child (`base64CharacterData`, `parseConcatKDFHexAttribute`, `ecdhCurveForURI`) take no `ctx` because the
   walk that calls them already polled and `abort`s what they return. `ParseEncryptedDataForTest`
   (`export_test.go`) parses under `context.Background()`, so a parser-only test sees the parse's own verdict
-- `Decrypt` does **not** mutate the tree (unlike `EncryptElement`/`EncryptContent`, which splice `EncryptedData` in): `elem` stays put and the returned nodes are detached; reinsertion is the caller's call
+- `Decrypt` does **not** mutate the tree (unlike `EncryptElement`/`EncryptContent`, which splice `EncryptedData` in):
+  `elem` stays put and the returned nodes are detached; reinsertion is the caller's call
 - A **non-empty** `Decryptor.SessionKey` is an EARLY RETURN, not a key preference:
   `decryptElement`/`decryptBytes` use it and return before candidate selection, per-candidate validation, and
   per-candidate key resolution in `resolveSessionKeyFromEncryptedKey`. The `MaxEncryptedKeys` cap sits ahead
@@ -2099,11 +2168,13 @@ whose resolver returns `[]byte` and has no stream to close. -->
 
 Drop-in replacement for encoding/xml backed by helium parser.
 
-- **NewDecoder(ctx, io.Reader) → *Decoder** / **NewTokenDecoder(ctx, TokenReader) → *Decoder** / **NewEncoder(io.Writer) → *Encoder**
+- **NewDecoder(ctx, io.Reader) → *Decoder** / **NewTokenDecoder(ctx, TokenReader) → *Decoder** / **NewEncoder(io.Writer)
+  → *Encoder**
 - **Marshal(v) → ([]byte, error)** / **Unmarshal([]byte, v) → error**
 - API mirrors encoding/xml; strict mode only; undeclared namespace prefixes rejected
 - Known differences: empty elements self-closed, xmlns before regular attrs, InputOffset approximate
-- Files: `api.go`, `decoder.go`, `directive.go` (prolog scanner), `encoder.go`, `marshal.go`, `unmarshal.go`, `types.go`, `namespace.go`, `escape.go`, `compat_errors.go`, `doc.go`
+- Files: `api.go`, `decoder.go`, `directive.go` (prolog scanner), `encoder.go`, `marshal.go`, `unmarshal.go`,
+  `types.go`, `namespace.go`, `escape.go`, `compat_errors.go`, `doc.go`
 - Imports: helium, stream/, internal/encoding/, internal/xmlchar/
 
 ## sink/
@@ -2111,7 +2182,8 @@ Drop-in replacement for encoding/xml backed by helium parser.
 Generic channel-based async event sink.
 
 - **New[T](ctx, Handler[T], ...Option) → *Sink[T]** — nil handler is replaced with a no-op (delivery never panics)
-- **Sink.Handle(ctx, T)** — async send (blocks if buffer full); re-entrant call from within a Handler is best-effort non-blocking
+- **Sink.Handle(ctx, T)** — async send (blocks if buffer full); re-entrant call from within a Handler is best-effort
+  non-blocking
 - **Sink.Close()** — drain and stop; self-close from within a Handler returns immediately (no deadlock)
 - WithBufferSize(n) — default 256; negative values clamped to 0 (unbuffered)
 - Nil-safe: Handle() on nil *Sink is no-op
@@ -2129,7 +2201,8 @@ the same typed constants without redefining parallel enum sets.
 - `AttributeType` — CDATA, ID, IDREF, IDREFS, ENTITY, ENTITIES, NMTOKEN, NMTOKENS, ENUMERATION, NOTATION
 - `AttributeDefault` — REQUIRED, IMPLIED, FIXED
 - `ElementType` — UNDEFINED, EMPTY, ANY, MIXED, ELEMENT
-- `EntityType` — InternalGeneralEntity, ExternalGeneralParsedEntity, ExternalGeneralUnparsedEntity, InternalParameterEntity, ExternalParameterEntity, InternalPredefinedEntity
+- `EntityType` — InternalGeneralEntity, ExternalGeneralParsedEntity, ExternalGeneralUnparsedEntity,
+  InternalParameterEntity, ExternalParameterEntity, InternalPredefinedEntity
 - Files: `enum.go`
 - Imports: none
 
@@ -2158,7 +2231,8 @@ Shared spec vocabulary strings reused across packages.
 - XML vocabulary: common prefixes + attribute/value names such as `xml:base`
 - Catalog vocabulary: OASIS catalog element names, attribute names, `prefer` values
 - XSLT vocabulary: `XSLTElement*` constants for all XSLT element local names
-- Streamability helpers: `IsFnNamespacePrefix`, `StreamFnLocalName` (shared by xpath3/xslt3/xpathstream; normalizes EQName `Q{...}local` fn calls)
+- Streamability helpers: `IsFnNamespacePrefix`, `StreamFnLocalName` (shared by xpath3/xslt3/xpathstream; normalizes
+  EQName `Q{...}local` fn calls)
 - Files: `ns.go`, `xml.go`, `catalog.go`, `xslt.go`, `fn.go`
 - Imports: none
 
@@ -2207,12 +2281,14 @@ Constructors: `NewHTTPResolver(*http.Client)`, `NewFileResolver(fs.FS)`; `FileUR
 
 ## internal/xpathstream/
 
-Streamability analysis helpers for XPath 3.1 expressions. Moved from xpath3 public API to reduce exported surface. Used by xslt3 streaming analysis.
+Streamability analysis helpers for XPath 3.1 expressions. Moved from xpath3 public API to reduce exported surface. Used
+by xslt3 streaming analysis.
 
 - **WalkExpr(Expr, func(Expr) bool)** — AST walker
 - **ExprHasDownwardStep / ExprUsesUpwardAxis / ExprUsesPrecedingAxis / ExprUsesDescendantOrSelf** — axis queries
 - **ExprUsesFunction / ExprUsesContextItem / ExprHasUpThenDownNavigation** — expression property queries
-- **PredicateIsNonMotionless / PredicateIsNonMotionlessWithStep / ExprTreeHasNonMotionlessPredicate** — predicate analysis
+- **PredicateIsNonMotionless / PredicateIsNonMotionlessWithStep / ExprTreeHasNonMotionlessPredicate** — predicate
+  analysis
 - **CountDownwardSelections** — downward selection counter
 - Files: `xpathstream.go`
 - Imports: xpath3
@@ -2264,7 +2340,8 @@ Parser option bitset type and constants. Bit positions match libxml2's XML_PARSE
 
 ## internal/xmlchar/
 
-XML 1.0 character classification and name validation. Single source of truth for the NCName/QName/Name productions, plus XML Char range, encoding-name, and PI-target validation shared across packages.
+XML 1.0 character classification and name validation. Single source of truth for the NCName/QName/Name productions, plus
+XML Char range, encoding-name, and PI-target validation shared across packages.
 
 - **IsChar(rune) → bool** — XML 1.0 Char production (legal document character)
 - **IsNCNameStartChar(rune) → bool** — XML 1.0 NCName start character production
@@ -2282,18 +2359,23 @@ XML 1.0 character classification and name validation. Single source of truth for
 XSD builtin value validation and comparison, extracted from `xsd/`.
 
 - **Version10 / Version11** — lexical-rule selector for version-sensitive builtins
-- **ValidateBuiltin(value, builtinLocal string, version Version) error** — validate value against an XSD builtin type lexical space under XSD 1.0 or 1.1 rules
+- **ValidateBuiltin(value, builtinLocal string, version Version) error** — validate value against an XSD builtin type
+  lexical space under XSD 1.0 or 1.1 rules
 - **Compare(a, b, builtinLocal string) (int, bool)** — type-aware comparison (-1/0/+1, ok)
 - **CompareDecimal(a, b string) int** — decimal comparison via math/big.Rat (-2 on error)
-- **CompareFloatFacetBound(a, b, builtinLocal string) (int, bool)** — float/double bound comparison ordering NaN as equal-to-NaN and greater-than-finite (schema-consistency check)
+- **CompareFloatFacetBound(a, b, builtinLocal string) (int, bool)** — float/double bound comparison ordering NaN as
+  equal-to-NaN and greater-than-finite (schema-consistency check)
 - **CanonicalKey(s, builtinLocal string) (string, bool)** — canonical value-space key (e.g. for enumeration de-dup)
 - **WhiteSpace(builtinLocal string) string** — the type's XSD whiteSpace facet ("preserve"/"replace"/"collapse")
 - **Normalize(s, builtinLocal string) string** — apply the type's whiteSpace facet to a lexical value
 - **IsFloatNaN(s string) bool** — reports whether a float/double lexical is NaN
 - **XSDFields(s string) []string** — split on XSD list whitespace
 - **Orderable(builtinLocal string) bool** — whether the primitive value space is ordered (range facets may apply)
-- **IsDecimalFamily(builtinLocal string) bool** — whether the type is xs:decimal or a derived integer (digit facets may apply)
-- **LengthApplicable(builtinLocal string) bool** — whether length/minLength/maxLength facets apply and CONSTRAIN the value (string-derived, binary, anyURI, QName, NOTATION — enforced per XSD 1.0/libxml2 parity); shared by relaxng and xsd
+- **IsDecimalFamily(builtinLocal string) bool** — whether the type is xs:decimal or a derived integer (digit facets may
+  apply)
+- **LengthApplicable(builtinLocal string) bool** — whether length/minLength/maxLength facets apply and CONSTRAIN the
+  value (string-derived, binary, anyURI, QName, NOTATION — enforced per XSD 1.0/libxml2 parity); shared by relaxng and
+  xsd
 - **CountTotalDigits(value string) int** — significant total-digit count for the totalDigits facet
 - **CountFractionDigits(value string) int** — significant fraction-digit count for the fractionDigits facet
 - Files: `validate.go`, `compare.go`, `facets.go`
@@ -2327,14 +2409,21 @@ Importable implementation behind `helium` CLI. Used by `cmd/helium` wrapper and 
 
 - Entry points: `Execute(ctx, args)`, context mutators `WithIO(ctx, stdin, stdout, stderr)`, `WithStdinTTY(ctx, bool)`
 - Subcommands: `lint`, `xpath`, `xsd validate`, `relaxng validate`, `schematron validate`, `xslt`
-- Context behavior: when stdio carriers are absent, defaults to `os.Stdin`, `os.Stdout`, `os.Stderr`, and TTY detection from `os.Stdin`
+- Context behavior: when stdio carriers are absent, defaults to `os.Stdin`, `os.Stdout`, `os.Stderr`, and TTY detection
+  from `os.Stdin`
 - Lint behavior: parse args, detect stdin/TTY, process XML, run XInclude/XSD/XPath/C14N, emit xmllint-style exit codes
-- XPath behavior: mandatory positional expr, default engine `3`, `--engine 1|3`, XML from file args or stdin, type-aware result output for xpath1/xpath3
-- RELAX NG behavior: compile grammar from mandatory positional schema path, parse XML input(s), validate via `relaxng.NewValidator().Validate`, return schema/validation exit codes
-- Schematron behavior: compile schema from mandatory positional schema path, parse XML input(s), validate via `schematron.NewValidator(schema).Validate`, return schema/validation exit codes
-- XSD behavior: compile schema from mandatory positional schema path, parse XML input(s), validate via `xsd.NewValidator(schema).Validate`, return schema/validation exit codes
-- XSLT behavior: compile stylesheet from mandatory positional path, parse XML input(s), transform via `ss.Transform(doc).WriteTo`, supports `--param`/`--stringparam`/`--output`/`--noout`
-- Files: `cli.go`, `exitcode.go`, `lint.go`, `xpath.go`, `relaxng_validate.go`, `schematron_validate.go`, `xsd_validate.go`, `xslt.go`
+- XPath behavior: mandatory positional expr, default engine `3`, `--engine 1|3`, XML from file args or stdin, type-aware
+  result output for xpath1/xpath3
+- RELAX NG behavior: compile grammar from mandatory positional schema path, parse XML input(s), validate via
+  `relaxng.NewValidator().Validate`, return schema/validation exit codes
+- Schematron behavior: compile schema from mandatory positional schema path, parse XML input(s), validate via
+  `schematron.NewValidator(schema).Validate`, return schema/validation exit codes
+- XSD behavior: compile schema from mandatory positional schema path, parse XML input(s), validate via
+  `xsd.NewValidator(schema).Validate`, return schema/validation exit codes
+- XSLT behavior: compile stylesheet from mandatory positional path, parse XML input(s), transform via
+  `ss.Transform(doc).WriteTo`, supports `--param`/`--stringparam`/`--output`/`--noout`
+- Files: `cli.go`, `exitcode.go`, `lint.go`, `xpath.go`, `relaxng_validate.go`, `schematron_validate.go`,
+  `xsd_validate.go`, `xslt.go`
 - Imports: helium, c14n/, relaxng/, schematron/, xsd/, xslt3/, xinclude/, xpath1/, xpath3/, catalog/, internal/cliutil/
 
 ## cmd/helium/

--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -83,7 +83,8 @@ forbidden in `psAttributeValue`; PE handling restricted in `psDTD`).
   nested reparse while `Entity.Content()` remains decoded
 
 ### SAX & Tree Building
-- `sax` (sax.SAX2Handler) — callbacks (default: TreeBuilder; `Parser.SAXHandler(nil)` restores that default, so this is never nil at parse time)
+- `sax` (sax.SAX2Handler) — callbacks (default: TreeBuilder; `Parser.SAXHandler(nil)` restores that default, so this is
+  never nil at parse time)
 - `doc *Document` — parsed document; `elem *Element` — current element
 
 ### DTD & Entities
@@ -147,18 +148,24 @@ from the invariant charset (default IBM-037); ASCII-compatible parses the decl a
   different Unicode family than a consumed BOM is fatal `ErrEncodingBOMMismatch` (§4.3.3; stricter than
   libxml2). Reads `pctx.declaredEncoding` (recorded unconditionally at the leaf EncName parsers), so it fires
   under `IgnoreEncoding`/`LenientXMLDecl`.
-- Strict fixed-width decode — `withStrictDecode` (`internal/encoding/strict.go`): malformed UTF-16/32/UCS-2/4 → fatal `ErrInvalidEncodedChar`; surfaced via `UTF8Cursor.Err()` at the document-end gate.
+- Strict fixed-width decode — `withStrictDecode` (`internal/encoding/strict.go`): malformed UTF-16/32/UCS-2/4 → fatal
+  `ErrInvalidEncodedChar`; surfaced via `UTF8Cursor.Err()` at the document-end gate.
 - Strict US-ASCII decode — `asciiEncoding` (`internal/encoding/ascii.go`): any byte ≥ 0x80 → fatal `ErrInvalidASCII`.
 
 ## File Responsibilities
 
-Each file's functions carry the spec citations (XML/Namespaces clauses, W3C test IDs) and libxml2-parity notes in their doc comments; below is the ownership map.
+Each file's functions carry the spec citations (XML/Namespaces clauses, W3C test IDs) and libxml2-parity notes in their
+doc comments; below is the ownership map.
 
-- `parserctx.go` — parser context, input/cursor stack, SAX dispatch, location/error reporting (`errorAtLevel` blank-run/cursor-error preference)
+- `parserctx.go` — parser context, input/cursor stack, SAX dispatch, location/error reporting (`errorAtLevel`
+  blank-run/cursor-error preference)
 - `parser_document.go` — top-level pipeline (`parseDocument`, `parseContent`, recovery re-sync)
-- `parser_element.go` — recursive element parsing; `parseStartTag` enforces P40/P44 inter-attribute whitespace + Namespaces §3 prefix-binding/reserved-URI WFCs (`validateDefaultNamespaceDecl`)
-- `parser_xml_decl.go` / `parser_decl.go` — XML/Text declaration parsing; EncodingDecl [80]/EncName [81] enforcement (`parseEncodingName`, `parseEncodingDeclFromCursor`); name/QName helpers
-- `parser_dtd_*` — DTD handling by declaration kind; `parseExternalID` found-bool (empty-vs-absent ExternalID); NotationDecl [82] / EntityDef [73] mandatory-body enforcement
+- `parser_element.go` — recursive element parsing; `parseStartTag` enforces P40/P44 inter-attribute whitespace +
+  Namespaces §3 prefix-binding/reserved-URI WFCs (`validateDefaultNamespaceDecl`)
+- `parser_xml_decl.go` / `parser_decl.go` — XML/Text declaration parsing; EncodingDecl [80]/EncName [81] enforcement
+  (`parseEncodingName`, `parseEncodingDeclFromCursor`); name/QName helpers
+- `parser_dtd_*` — DTD handling by declaration kind; `parseExternalID` found-bool (empty-vs-absent ExternalID);
+  NotationDecl [82] / EntityDef [73] mandatory-body enforcement
 - `parser_entity_decl.go` — entity declaration bodies, balanced-chunk parsing
 - `parser_entity_ref.go` — references, char refs, replay, amplification checks
 
@@ -168,8 +175,10 @@ Flow: `parseReference()` → `parseEntityRef()` → `entityCheck()` → parse co
 / `parseExternalEntityPrivate`) → deliver to SAX (expand + replay node children when `replaceEntities`, else
 fire `Reference`). Each invariant lives at its function:
 
-- Amplification guard — `entityCheck` / `entityCheckBytes` (`parser_entity_ref.go`); external content read through `io.LimitReader` (`externalEntityMaxBytes` 10 MiB) charged raw-only to avoid double-counting the fixed cost
-- WFC Entity Declared under standalone="yes" (§4.1/§2.9) — `getEntity` / `undeclaredEntityValidityError` (`parser_entity_ref.go`)
+- Amplification guard — `entityCheck` / `entityCheckBytes` (`parser_entity_ref.go`); external content read through
+  `io.LimitReader` (`externalEntityMaxBytes` 10 MiB) charged raw-only to avoid double-counting the fixed cost
+- WFC Entity Declared under standalone="yes" (§4.1/§2.9) — `getEntity` / `undeclaredEntityValidityError`
+  (`parser_entity_ref.go`)
 - Balanced replacement text (WFC §4.3.2) — `parseBalancedChunkInternal` → `ErrEntityNotWellBalanced`; nested
   internal-entity parsing inherits the parent effective XML version, and its lexical replacement form retains
   XML 1.1 restricted-character-reference origin so XML 1.1 validates a reference separately from a raw literal
@@ -192,13 +201,17 @@ fire `Reference`). Each invariant lives at its function:
   check (`isValidXMLVersion`) is stricter than the grammar: the family check alone would pass a non-VersionNum
   like `1.x` (it has the `1.` prefix) and the grammar alone would pass `2.0`. A path enforcing only one of the
   two reopens the accept-then-fail-to-serialize gap
-- Character-reference provenance (element-content validity, §3.2.1 E15) — `charDataFromCharRef` flag in `parseReference`; `fromCharRef` node field (see `node-types.md`)
+- Character-reference provenance (element-content validity, §3.2.1 E15) — `charDataFromCharRef` flag in
+  `parseReference`; `fromCharRef` node field (see `node-types.md`)
 - Parameter entity refs — `parsePEReference` (`parser_dtd_subset.go`): charges the PE's OWN replacement bytes
   (not post-expansion), `padPEContent` §4.4.8; external PE load via `loadExternalParameterEntityContent`
   (XXE-gated, base-URI- and TextDecl-version-scoped, active-PE recursion guard)
-- PE references inside/adjacent to markup decls (external subset) — `skipBlanksPE` (`parser_whitespace.go`) + `dtdRefetch`; boundary violations → `ErrEntityBoundary` (VC Proper Declaration/Group/PE Nesting)
+- PE references inside/adjacent to markup decls (external subset) — `skipBlanksPE` (`parser_whitespace.go`) +
+  `dtdRefetch`; boundary violations → `ErrEntityBoundary` (VC Proper Declaration/Group/PE Nesting)
 - WFC PEs in Internal Subset (§2.8) — `expandEntityValueForRefCheck` `%` branch → `ErrPEReferenceInInternalSubset`
-- Attribute-value entity WFCs (No External Ref / No `<` / Entity Declared) — `checkEntityInAttValue` / `lookupGeneralEntity`, memoized via `entWFCValidated`/`entWFCChecked`; DTD defaults re-scanned by `validateAttributeDefaultsWFC`
+- Attribute-value entity WFCs (No External Ref / No `<` / Entity Declared) — `checkEntityInAttValue` /
+  `lookupGeneralEntity`, memoized via `entWFCValidated`/`entWFCChecked`; DTD defaults re-scanned by
+  `validateAttributeDefaultsWFC`
 - `decodeEntities()` — SubstitutionType None(0)/Ref(1)/PERef(2)/Both(3); recursion capped at depth > 40
 
 ## Tree Builder (SAX→DOM)
@@ -247,7 +260,9 @@ the negative-sentinel option disables the cap for trusted input.
 - **Blank-run cap** (`skipBlankRun`/`blankRunLimit`, `parser_whitespace.go`) — the same cap bounds a
   contiguous whitespace run in 4 KiB chunks; sticky `blankRunErr`, preferred by `errorAtLevel`. DTD
   subset/INCLUDE loops call `skipBlankRun` directly (not `skipBlanks`, which consumes `%pe;` unexpanded).
-- **Character buffering** (`deliverCharacters`, `CharBufferSize`) — UTF-8-boundary-respecting chunking; bounded streaming-SAX char-data path `parseCharDataChunkedSAX` (no DOM built) with a documented over-budget blank-run reclassification policy.
+- **Character buffering** (`deliverCharacters`, `CharBufferSize`) — UTF-8-boundary-respecting chunking; bounded
+  streaming-SAX char-data path `parseCharDataChunkedSAX` (no DOM built) with a documented over-budget blank-run
+  reclassification policy.
 - **UTF-8 fast paths** — `parseQName`/`parseNCName`/`parseAttributeValueInternal` try
   `ScanQNameBytes`/`ScanNCNameBytes`/`ScanSimpleAttrValue`, intern before advancing (advance may compact the
   cursor buffer, invalidating borrowed slices), and use `AdvanceFast()` when the run is proven newline-free.
@@ -279,9 +294,11 @@ char-ref) re-check `ctx.Err()` and disambiguate exhaustion from a sticky cursor 
 
 ## Push Parser
 
-Both push parsers use the `push` package (`push.Parser[T]`): a background goroutine reading a thread-safe stream via `ParseReader`; `pp.Push(chunk)` / `doc, err := pp.Close()`.
+Both push parsers use the `push` package (`push.Parser[T]`): a background goroutine reading a thread-safe stream via
+`ParseReader`; `pp.Push(chunk)` / `doc, err := pp.Close()`.
 
-- **XML** (`parser.go` + `push/`) — progressive from the first byte; stream `Read` returns available bytes without waiting to fill, context-aware wait (see Context Cancellation)
+- **XML** (`parser.go` + `push/`) — progressive from the first byte; stream `Read` returns available bytes without
+  waiting to fill, context-aware wait (see Context Cancellation)
 - **HTML** (`html/html.go` + `push/`) — progressive only AFTER the 1024-byte (or EOF) charset prescan
   (`wrapReaderForHTML`, `html/encoding_reader.go`) and once a streamable encoding is settled; an undeclared
   valid-UTF-8 stream defers to EOF/Close (`deferredLatin1Reader`, bounded by `contentLimit()`, fail-closed at
@@ -294,14 +311,19 @@ Both push parsers use the `push` package (`push.Parser[T]`): a background gorout
 
 ## HTML Content Bounding (`html/parser.go`, `html/options.go`)
 
-`Parser.MaxContentSize` (`parseConfig.maxContentSize`, effective via `contentLimit()`, 16 MiB default). Two meanings; rationale at each function:
+`Parser.MaxContentSize` (`parseConfig.maxContentSize`, effective via `contentLimit()`, 16 MiB default). Two meanings;
+rationale at each function:
 
 - **Soft cap (chunkable)**: normal data-state text (`parseCharacters`), raw-text (`parseRawContent`), RCDATA
   (`parseRCDATAContent`), plaintext (`parsePlaintext`) — chunk boundaries never split a rune
   (`clampTextChunkToRune`, `peekRuneToken`); a section over the cap still parses, in multiple chunks
-- **Hard cap (indivisible)**: comments/bogus comments/PIs (`parseComment`/`parseBogusComment`/`parsePI`) → `fatalErr` wrapping `ErrContentSizeExceeded`
-- **Hard cap (tag-level tokens)**: `parseName`/`parseAttrName`/`skipWhitespace` bound `PeekAt` growth against `scanTokenLimit()` (floored at 16 MiB so a small `MaxContentSize` never rejects `script`)
-- **Leading-whitespace deferral** — `emitCharacters` + `pendingWS`/`deferPendingWS`: significance (`StripBlanks`) + implied-`<body>` insertion are decided at the first non-whitespace byte; `pendingWS` bounded by `contentLimit()`, fail-closed
+- **Hard cap (indivisible)**: comments/bogus comments/PIs (`parseComment`/`parseBogusComment`/`parsePI`) → `fatalErr`
+  wrapping `ErrContentSizeExceeded`
+- **Hard cap (tag-level tokens)**: `parseName`/`parseAttrName`/`skipWhitespace` bound `PeekAt` growth against
+  `scanTokenLimit()` (floored at 16 MiB so a small `MaxContentSize` never rejects `script`)
+- **Leading-whitespace deferral** — `emitCharacters` + `pendingWS`/`deferPendingWS`: significance (`StripBlanks`) +
+  implied-`<body>` insertion are decided at the first non-whitespace byte; `pendingWS` bounded by `contentLimit()`,
+  fail-closed
 - **Char-ref bounding** — `parseCharRefBounded` (shared by normal data + RCDATA): fixed 32-byte name
   lookahead; unresolved-literal / ambiguous-legacy-prefix work charged against the cap;
   `consumeNumericCharRefBounded` (saturating digit run), `parseSaturatedCharRefLiteral` (bounded spool, no
@@ -323,7 +345,8 @@ attr exists). Explicit namespace declarations always win over ATTLIST defaults.
 - **RecoverOnError** — on a recoverable error in `parseContent()`: save `recoverErr`, `disableSAX=true`,
   `skipToRecoverPoint()` (advance to next `<`), continue, return partial document + saved error. Applies to
   genuine parse errors only — NOT context cancellation (above).
-- **StopParser(ctx)** — `stopped=true`, `instate=psEOF`; returns the parsed-so-far document + nil error (partial document, unlike cancellation's nil document + context error).
+- **StopParser(ctx)** — `stopped=true`, `instate=psEOF`; returns the parsed-so-far document + nil error (partial
+  document, unlike cancellation's nil document + context error).
 
 ## Key Parser Fluent Method Effects
 

--- a/.claude/docs/saxon-layout.md
+++ b/.claude/docs/saxon-layout.md
@@ -221,7 +221,8 @@ Other: `boolean`, `anyURI`, `base64Binary`, `hexBinary`, `NOTATION`
 
 ### Axes (in `AxisInfo.java`)
 
-13 XPath axes: `child`, `descendant`, `parent`, `ancestor`, `following-sibling`, `preceding-sibling`, `following`, `preceding`, `attribute`, `namespace`, `self`, `descendant-or-self`, `ancestor-or-self`
+13 XPath axes: `child`, `descendant`, `parent`, `ancestor`, `following-sibling`, `preceding-sibling`, `following`,
+`preceding`, `attribute`, `namespace`, `self`, `descendant-or-self`, `ancestor-or-self`
 
 ### Name Handling
 

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -49,8 +49,11 @@ testdata/libxml2-compat/
 
 ### Package Naming
 
-- **`*_test.go`** (external `xxx_test` package) — golden file comparison, SAX events, serialization. Preferred for all new tests.
-- **`*_internal_test.go`** (internal `xxx` package) — tests needing unexported access. In the root package there is one per production area: `dtd_internal_test.go`, `node_internal_test.go`, `parser_internal_test.go`, `writer_internal_test.go`.
+- **`*_test.go`** (external `xxx_test` package) — golden file comparison, SAX events, serialization. Preferred for all
+  new tests.
+- **`*_internal_test.go`** (internal `xxx` package) — tests needing unexported access. In the root package there is one
+  per production area: `dtd_internal_test.go`, `node_internal_test.go`, `parser_internal_test.go`,
+  `writer_internal_test.go`.
 
 ### Test Shape
 
@@ -122,7 +125,8 @@ bug that prompted it.
 - Write comments for users, not maintainers. Explain visible behavior, required context, and why API calls matter.
 - Prefer `func Example_*()` + deterministic `// Output:` blocks when behavior is stable.
 - Keep shared setup/helpers in `*_helpers_test.go` so example bodies stay easy to read.
-- CLI examples call importable entrypoints (e.g. `internal/cli/heliumcmd.Execute`) directly. Do NOT spawn subprocesses unless behavior requires it.
+- CLI examples call importable entrypoints (e.g. `internal/cli/heliumcmd.Execute`) directly. Do NOT spawn subprocesses
+  unless behavior requires it.
 - Do NOT use `examples/` for scratch programs, golden fixtures, or temporary experiments.
 
 ## Test Helpers
@@ -210,12 +214,14 @@ result for the current run live in the header comment of
 ## Fuzzing
 
 - Public-package fuzz coverage lives in package-local `fuzz_test.go` files.
-- Direct fuzz targets exist for `.`, `c14n`, `catalog`, `html`, `relaxng`, `schematron`, `sink`, `stream`, `xinclude`, `xpath1`, `xpath3`, `xpointer`, `xsd`, `xmldsig1`, `xmlenc1`, `xslt3`.
+- Direct fuzz targets exist for `.`, `c14n`, `catalog`, `html`, `relaxng`, `schematron`, `sink`, `stream`, `xinclude`,
+  `xpath1`, `xpath3`, `xpointer`, `xsd`, `xmldsig1`, `xmlenc1`, `xslt3`.
 - `shim` intentionally excluded from repo fuzz matrix.
 - `enum` + `sax` intentionally excluded from direct fuzzing → constants/interface-only surface.
 - Bound fuzz input sizes early. Return on oversize inputs.
 - Prefer in-memory stubs over filesystem/network access.
-- Parse/compile/validate/transform fuzz targets MUST tolerate invalid intermediate inputs by returning early instead of asserting.
+- Parse/compile/validate/transform fuzz targets MUST tolerate invalid intermediate inputs by returning early instead of
+  asserting.
 - `xmlenc1`'s `FuzzDecrypt` puts FIXED RSA, EC, and AES key material on one `Decryptor` (all three are
   settable together) and leaves `SessionKey` unset, so the input alone selects which key-protection path runs
   — RSA-OAEP, ECDH-ES, or AES key wrap — and every branch is reachable from the one target. The keys are
@@ -232,16 +238,23 @@ result for the current run live in the header comment of
 
 ## Fuzz CI
 
-- Each matrix job restores newest Go fuzz corpus for same `go.mod`/package/ref, then falls back to same `go.mod`/package across refs.
+- Each matrix job restores newest Go fuzz corpus for same `go.mod`/package/ref, then falls back to same `go.mod`/package
+  across refs.
 - Each matrix job saves its corpus under an immutable run/attempt key after success or failure.
-- Pull requests run NO fuzzing — `ci.yml` is normal test/build/lint/vuln verification only, so PR turnaround stays fast and deterministic (live fuzzing is nondeterministic and cannot gate a PR without flaking).
+- Pull requests run NO fuzzing — `ci.yml` is normal test/build/lint/vuln verification only, so PR turnaround stays fast
+  and deterministic (live fuzzing is nondeterministic and cannot gate a PR without flaking).
 - `fuzz.yml` runs fuzzing OFF the PR path, always non-gating:
-  - on every `push` to `main` (in practice, each PR merge) → short `60s` per target, for a prompt signal attributed to the pushed commit.
+  - on every `push` to `main` (in practice, each PR merge) → short `60s` per target, for a prompt signal attributed to
+    the pushed commit.
   - on the weekly `schedule` → deep `5m` per target.
   - on manual `workflow_dispatch` → its `fuzz-time` input (default `5m`).
-- Fuzz targets are discovered per package via `go test ./<pkg>/ -list '^Fuzz' -run '^$'`; each target writes a separate log and retains its raw `go test` status.
-- Every nonzero raw status or log-capture failure uploads target log + metadata (`package`, target, Go version, fuzz budget, raw/log statuses, classification) as a diagnostic artifact; log-capture failures fail the job.
-- Only Go coordinator failures matching the complete deadline-only signature are warnings ([golang/go#75804](https://github.com/golang/go/issues/75804)); any extra diagnostic, panic, worker hang, source failure, or crashing input fails the job.
+- Fuzz targets are discovered per package via `go test ./<pkg>/ -list '^Fuzz' -run '^$'`; each target writes a separate
+  log and retains its raw `go test` status.
+- Every nonzero raw status or log-capture failure uploads target log + metadata (`package`, target, Go version, fuzz
+  budget, raw/log statuses, classification) as a diagnostic artifact; log-capture failures fail the job.
+- Only Go coordinator failures matching the complete deadline-only signature are warnings
+  ([golang/go#75804](https://github.com/golang/go/issues/75804)); any extra diagnostic, panic, worker hang, source
+  failure, or crashing input fails the job.
 - Go-written crashing corpus files are uploaded separately for real failures; fuzz artifacts are not committed.
 
 ## Common Test Patterns
@@ -305,7 +318,9 @@ on-demand-fetched fixtures, and the skip/expectation metadata (`expectations/xsd
 `helium => ../helium` and uses a local `go.work` to test against an in-progress branch. Run it from there: `go
 run ./cmd/w3cgen fetch xsd11 && go run ./cmd/w3cgen generate xsd11 && go test ./...`.
 
-Helium keeps only the **unit regression** `xsd/union_cycle_overflow_test.go` (cyclic simpleType must error, not stack-overflow), guarding the in-tree fix (`baseChain` in `simplevalue_core.go`, `checkCircularSimpleTypes` in `check_facets.go`).
+Helium keeps only the **unit regression** `xsd/union_cycle_overflow_test.go` (cyclic simpleType must error, not
+stack-overflow), guarding the in-tree fix (`baseChain` in `simplevalue_core.go`, `checkCircularSimpleTypes` in
+`check_facets.go`).
 
 ## Skip Maps
 

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -1,6 +1,7 @@
 # Validation Pipeline
 
-Three validation engines: XSD (grammar-based), RELAX NG (pattern-based), Schematron (rule-based). All follow compile→validate pattern.
+Three validation engines: XSD (grammar-based), RELAX NG (pattern-based), Schematron (rule-based). All follow
+compile→validate pattern.
 
 ## XSD
 
@@ -1771,7 +1772,8 @@ mode, so the libxml2-compat goldens stay byte-identical. ID/IDREF members inside
 union ARE covered: `collectIDFromValue`'s union branch resolves the active member
 (`unionActiveMember`) and recurses to the atomic ID/IDREF leaf (and `idFamilyType`
 recurses into union members), so a duplicate union xs:ID across owners and a
-dangling union xs:IDREF both fail. `xs:ENTITY`/`xs:ENTITIES` value-space validity is enforced by the separate `validateEntities` pass (`validate_entity.go`), not this one. NOTE: this skip-exclusion is for the
+dangling union xs:IDREF both fail. `xs:ENTITY`/`xs:ENTITIES` value-space validity is enforced by the separate
+`validateEntities` pass (`validate_entity.go`), not this one. NOTE: this skip-exclusion is for the
 ID/IDREF DATATYPE pass only; pass-2 IDC selectors (`xs:key`/`xs:unique`) still
 match skip-content nodes by XPath — helium deliberately includes skip-matched
 nodes in an ancestor IDC (see `TestIDCFieldSkipWildcardSelectedSelf`), so the
@@ -1816,8 +1818,10 @@ Files: `relaxng/relaxng.go` (API), `parse.go` (compiler), `validate.go` (engine)
 ### Compile: Document → Grammar
 
 1. **Find root** — `<grammar>` or bare pattern (e.g., `<element>`)
-2. **Parse grammar content** — process `<start>`, `<define>` elements; handle `combine="choice"/"interleave"`; support `<div>` containers
-3. **Parse patterns** (recursive) — element, attribute, group, choice, interleave, optional, zeroOrMore, oneOrMore, ref, parentRef, data, value, list, mixed, text, empty, notAllowed
+2. **Parse grammar content** — process `<start>`, `<define>` elements; handle `combine="choice"/"interleave"`; support
+   `<div>` containers
+3. **Parse patterns** (recursive) — element, attribute, group, choice, interleave, optional, zeroOrMore, oneOrMore, ref,
+   parentRef, data, value, list, mixed, text, empty, notAllowed
 4. **Resolve references (scoped)** — each `<grammar>` (including nested ones) gets its own lexical
    `grammarScope` with a `defines` table and a `parent` link. Every `<ref>`/`<parentRef>` node is recorded
    with the scope it was parsed in (`compiler.pendingRefs`); after the whole tree is parsed,
@@ -1833,7 +1837,8 @@ Files: `relaxng/relaxng.go` (API), `parse.go` (compiler), `validate.go` (engine)
    only inside a removed component are never recorded in `pendingRefs` and so never trigger a spurious fatal
    unresolved-ref. The override names are also `delete`d from the scope after parsing (to clear any entry
    leaked by a nested `<include>`) before the overrides are applied.
-5. **Check reference cycles** — `checkRefCycles` walks each define body across every scope, following `pattern.resolved` (cycle set keyed by define-pattern POINTER, not name); element patterns break the chain
+5. **Check reference cycles** — `checkRefCycles` walks each define body across every scope, following `pattern.resolved`
+   (cycle set keyed by define-pattern POINTER, not name); element patterns break the chain
 6. **Rule checks** — compile-time semantic validation (`checkPattern` also follows `pattern.resolved`; visited
    set keyed by `{define pattern, ruleFlags}` so a define reached under a new ancestor context — e.g. once
    normally and once under `<list>` — is re-checked in each context)
@@ -1873,12 +1878,16 @@ Pattern-matching engine with backtracking:
    - **Attribute**: match against instance attrs
    - **Group**: sequential with backtracking
    - **Choice**: try alternatives, prefer branches making progress
-   - **Interleave**: unordered member-by-member matching; a repeatable member-group (zeroOrMore/oneOrMore of group) restarts its members each iteration so a sibling branch can consume elements between group members across iterations
+   - **Interleave**: unordered member-by-member matching; a repeatable member-group (zeroOrMore/oneOrMore of group)
+     restarts its members each iteration so a sibling branch can consume elements between group members across
+     iterations
    - **ZeroOrMore/OneOrMore/Optional**: repetition with suppressed errors
-   - **Ref/ParentRef**: follow the compile-time-resolved `pattern.resolved` scoped pointer and recurse (no by-name lookup)
+   - **Ref/ParentRef**: follow the compile-time-resolved `pattern.resolved` scoped pointer and recurse (no by-name
+     lookup)
    - **Data/Value**: type checking
    - **List**: split text, validate items
-3. Element validation: match name, validate attrs, build child list (skip non-content: EntityRef/PI/Comment), validate content, check all attrs+content consumed
+3. Element validation: match name, validate attrs, build child list (skip non-content: EntityRef/PI/Comment), validate
+   content, check all attrs+content consumed
 
 ### Backtracking Strategy (`backtrackGroupFlexible` / `backtrackGroupNaive`)
 
@@ -2055,7 +2064,9 @@ nameClass { kind (ncName|ncAnyName|ncNsName|ncChoice), name, ns, left/right, exc
 
 ## Schematron
 
-Files: `schematron/schematron.go` (API), `parse.go` (compiler), `validate.go` (engine), `schema.go` (model), `querybinding.go` (query language binding), `engine.go` + `engine_xpath1.go` + `engine_xpath3.go` (query language engines)
+Files: `schematron/schematron.go` (API), `parse.go` (compiler), `validate.go` (engine), `schema.go` (model),
+`querybinding.go` (query language binding), `engine.go` + `engine_xpath1.go` + `engine_xpath3.go` (query language
+engines)
 
 ### Query language bindings
 
@@ -2076,8 +2087,10 @@ namespace-bound `runner`, whose `evaluate` returns a `value`. The `value` interf
 conversions — `nodeSet`, `effectiveBoolean`, `stringValue`, `nodeName` — so compilation and validation never
 name a concrete XPath package. Differences that matter:
 
-- `effectiveBoolean` cannot fail under XPath 1.0. Under XPath 3.1 a sequence of more than one item starting with an atomic value raises FORG0006, which is reported and treated as a false test.
-- `stringValue` (`<value-of>`) takes the string-value of the first node under XPath 1.0, and joins every atomized item with a single space under XPath 3.1 (the XSLT 2.0-and-later rule).
+- `effectiveBoolean` cannot fail under XPath 1.0. Under XPath 3.1 a sequence of more than one item starting with an
+  atomic value raises FORG0006, which is reported and treated as a false test.
+- `stringValue` (`<value-of>`) takes the string-value of the first node under XPath 1.0, and joins every atomized item
+  with a single space under XPath 3.1 (the XSLT 2.0-and-later rule).
 - `<let>` binds an XPath 1.0 object under the 1.0 binding, and a whole sequence under 3.1.
 
 Rule contexts go through `contextToXPath` in both bindings, so a context that is an XSLT match pattern but not
@@ -2097,11 +2110,14 @@ document mutated between two `Validate` calls is re-indexed.
 Three-phase parsing (after the binding is resolved):
 1. **Phase 1: Title** — optional `<title>`
 2. **Phase 2: Namespace declarations** — all `<ns prefix="x" uri="...">` → `schema.namespaces` map
-3. **Phase 3: Patterns** — `<pattern>` → `<rule context="xpath">` → `<let>`, `<assert test="xpath">`, `<report test="xpath">`
+3. **Phase 3: Patterns** — `<pattern>` → `<rule context="xpath">` → `<let>`, `<assert test="xpath">`, `<report
+   test="xpath">`
 
-Message content parsed into `[]messagePart`: text literals, `<name path="..."/>` (element name), `<value-of select="..."/>` (XPath value).
+Message content parsed into `[]messagePart`: text literals, `<name path="..."/>` (element name), `<value-of
+select="..."/>` (XPath value).
 
-**Namespace gating:** structural elements are only recognized when in the detected Schematron namespace (`isSchematronElement`/`elementInNamespace`). Foreign-namespaced elements are handled differently depending on position:
+**Namespace gating:** structural elements are only recognized when in the detected Schematron namespace
+(`isSchematronElement`/`elementInNamespace`). Foreign-namespaced elements are handled differently depending on position:
 - **Required structural position → fatal/rejected.** Where a specific Schematron element is expected (e.g. a
   `<rule>` under `<pattern>`, checked via `isSchematronElement(elem, schNS, "rule")` in `compilePattern`), a
   foreign element like `<x:rule>` does NOT satisfy the requirement and is rejected with a fatal `Expecting a
@@ -2112,7 +2128,9 @@ Message content parsed into `[]messagePart`: text literals, `<name path="..."/>`
   `<x:assert>` inside a `<rule>` is not executed; likewise foreign `<name>`/`<value-of>` inside message
   content (`parseMessageElement`) are ignored, not interpolated.
 
-Structural attributes (`context`, `test`, `select`, `name`, `id`, `prefix`, `uri`, `value`, `path`) are read unqualified-only via `getStructuralAttr` (`NSPredicate{..., NamespaceURI: ""}`); a prefixed `x:test` is not read as Schematron.
+Structural attributes (`context`, `test`, `select`, `name`, `id`, `prefix`, `uri`, `value`, `path`) are read
+unqualified-only via `getStructuralAttr` (`NSPredicate{..., NamespaceURI: ""}`); a prefixed `x:test` is not read as
+Schematron.
 
 **Fatal compile errors:** `compileSchema` wraps the configured handler in a `fatalTrackingHandler`. If any
 `ErrorLevelFatal` diagnostic is emitted (no pattern, pattern with no rule, rule with no test, etc.),
@@ -2124,11 +2142,13 @@ source through `lexer.DiagnosticExcerpt`; diagnostics stay valid UTF-8 and short
 
 ### Validate: Document + Schema → Errors
 
-`Validate` returns `ErrNoSchema` (typed) when the Validator has no compiled schema (`NewValidator(nil)` or zero-value), guarding against a nil-deref panic.
+`Validate` returns `ErrNoSchema` (typed) when the Validator has no compiled schema (`NewValidator(nil)` or zero-value),
+guarding against a nil-deref panic.
 
 1. Create XPath context with schema's namespaces
 2. For each pattern/rule: evaluate `contextExpr` against document root → node set
-   - If the context XPath **errors at evaluation**, surface an `XPath error : ...` diagnostic and mark the document invalid (the rule's assertions can't be checked, so it is not silently skipped)
+   - If the context XPath **errors at evaluation**, surface an `XPath error : ...` diagnostic and mark the document
+     invalid (the rule's assertions can't be checked, so it is not silently skipped)
    - **First-match-only (ISO Schematron):** within a pattern, each node is processed by only the FIRST rule
      whose context matches it. A per-pattern `map[helium.Node]bool` (reset each pattern) skips nodes already
      claimed by an earlier rule. Scope is per pattern, so a later pattern still fires for the same node.

--- a/.claude/docs/xpath3-api.md
+++ b/.claude/docs/xpath3-api.md
@@ -146,7 +146,8 @@ falls back to parse+lower through the VM backend on the same lexer if the fast p
 not retain the parsed AST on the `Expression`; `AST()` reparses from `source` on demand. `CompileExpr()` keeps
 the caller-provided AST and lowers it without mutating the input tree.
 
-`StreamInfo()` returns a snapshot of precomputed streamability properties (axis usage bitmask, downward steps, function names, etc.). Streamability query helpers live in `internal/xpathstream`, not on the xpath3 package.
+`StreamInfo()` returns a snapshot of precomputed streamability properties (axis usage bitmask, downward steps, function
+names, etc.). Streamability query helpers live in `internal/xpathstream`, not on the xpath3 package.
 
 `StaticReferences(namespaces)` walks the expression's AST (reparsing from `source` when no AST is retained)
 and reports its FREE variable references (those not bound by an enclosing for/let/quantified binding or
@@ -164,7 +165,8 @@ an unknown/non-built-in type (XPST0008, via `IsKnownXSDType`), or an unknown, wr
 or a schema-element()/schema-attribute() node test (which references a global declaration outside the CTA
 static context), which the CTA static context disallows.
 
-`DumpVM()` writes a textual disassembly of compiled VM instructions. Use it for debugging or tooling around lowered expressions.
+`DumpVM()` writes a textual disassembly of compiled VM instructions. Use it for debugging or tooling around lowered
+expressions.
 
 ## Result
 
@@ -256,11 +258,13 @@ Pass bindings as plain maps: variables via `Evaluator.Variables(map[string]Seque
 `Evaluator.HTTPClient`), `fn:doc`, `fn:doc-available`, `fn:json-doc`, and the `fn:unparsed-text*` family error
 with `FODC0002` / `FOUT1170` for every URI — there is no implicit `http.DefaultClient` and no implicit
 `os.ReadFile`. Built-in helpers in `internal/unparsedtext`:
-- `FileURIResolver{BaseDir}` — file resolver confined to `BaseDir` (refuses `..` traversal and absolute paths outside it)
+- `FileURIResolver{BaseDir}` — file resolver confined to `BaseDir` (refuses `..` traversal and absolute paths outside
+  it)
 - `NewFileResolver(fs.FS)` — file resolver backed by `io/fs`
 - `NewHTTPResolver(*http.Client)` — http(s) resolver; caller owns transport, timeouts, redirect policy
 
-User functions supplied via `Evaluator.Functions` take precedence over built-ins: the resolver checks user-registered functions before the built-in registry, so a user function CAN override a built-in in the `fn:` namespace.
+User functions supplied via `Evaluator.Functions` take precedence over built-ins: the resolver checks user-registered
+functions before the built-in registry, so a user function CAN override a built-in in the `fn:` namespace.
 
 ## Low-allocation reuse
 

--- a/.claude/docs/xpath3-architecture.md
+++ b/.claude/docs/xpath3-architecture.md
@@ -140,13 +140,19 @@ func NodePrefix(n helium.Node) string
 
 ## Runtime Model
 
-- `Compile()` first tries a direct compile fast path for simple path-like expressions and simple predicate comparisons, then falls back to shared parse+lower on the same token stream
-- Direct fast-path parsing emits `vmLocationPathExpr` / `vmLocationStep` payloads immediately for simple location paths instead of building AST `LocationPath` / `Step` nodes first
+- `Compile()` first tries a direct compile fast path for simple path-like expressions and simple predicate comparisons,
+  then falls back to shared parse+lower on the same token stream
+- Direct fast-path parsing emits `vmLocationPathExpr` / `vmLocationStep` payloads immediately for simple location paths
+  instead of building AST `LocationPath` / `Step` nodes first
 - Shared fallback path is `string -> lexer ([]Token) -> parser (Expr AST) -> VM lowering`
-- String-based `Compile()` uses an ownership-taking lowering path that can reuse parsed slices, then keeps only `source` + `vmProgram`; AST-inspection helpers reparse on demand
-- Non-trivial lowered nodes become indexed `vmInstruction`s; `vmInstruction` now stores a generic payload, not just AST `Expr`s
-- Location paths and `PathExpr` path segments are lowered to VM-specific payload types (`vmLocationPathExpr`, `vmLocationStep`, `vmPathExpr`) instead of reusing AST `LocationPath` nodes in the instruction stream
-- Common location-path predicates are also lowered to VM-specific inline predicate payloads for hot cases such as `[N]`, `[position() = N]`, `[@attr]`, and `[@attr = "literal"]`
+- String-based `Compile()` uses an ownership-taking lowering path that can reuse parsed slices, then keeps only `source`
+  + `vmProgram`; AST-inspection helpers reparse on demand
+- Non-trivial lowered nodes become indexed `vmInstruction`s; `vmInstruction` now stores a generic payload, not just AST
+  `Expr`s
+- Location paths and `PathExpr` path segments are lowered to VM-specific payload types (`vmLocationPathExpr`,
+  `vmLocationStep`, `vmPathExpr`) instead of reusing AST `LocationPath` nodes in the instruction stream
+- Common location-path predicates are also lowered to VM-specific inline predicate payloads for hot cases such as `[N]`,
+  `[position() = N]`, `[@attr]`, and `[@attr = "literal"]`
 - Child Expr references inside lowered payloads become `compiledExprRef` when they need their own instruction slot
 - VM executes compiled refs by opcode, then reuses existing `eval_*` helpers via `exprEvaluator`
 - `CompileExpr()` uses non-mutating lowering and keeps the caller-provided AST

--- a/.claude/docs/xpath3-eval.md
+++ b/.claude/docs/xpath3-eval.md
@@ -29,7 +29,8 @@ func (ec *evalContext) withVar(name string, val Sequence) *evalContext  // new s
 ## Dispatch
 
 - `Compile()` lowers AST to `vmProgram` and collects prefix-validation requirements during the same pass
-- The string-based `Compile()` path can reuse parsed slices during lowering because the compiled expression keeps `source` + `vmProgram` and reparses AST only for AST/streamability access
+- The string-based `Compile()` path can reuse parsed slices during lowering because the compiled expression keeps
+  `source` + `vmProgram` and reparses AST only for AST/streamability access
 - `Expression.Evaluate()` executes `vmProgram` when present
 - `evalWith()` enforces recursion depth for raw eval + VM eval
 - `dispatchExpr()` contains shared Expr-type dispatch
@@ -61,12 +62,14 @@ existing `eval_*` helpers for language semantics.
 ## Evaluation Rules by Expr Type
 
 ### SequenceExpr (comma)
-Evaluate each item, concatenate sequences through `appendBoundedSeq` so the aggregate honors `maxNodes` / OpLimit / cancellation (each operand is individually capped, but the concatenation must be bounded too).
+Evaluate each item, concatenate sequences through `appendBoundedSeq` so the aggregate honors `maxNodes` / OpLimit /
+cancellation (each operand is individually capped, but the concatenation must be bounded too).
 
 ### LocationPath
 1. Start: root node (absolute) or context node (relative)
 2. Per step: traverse axis → filter by NodeTest → apply predicates → dedup doc order
-3. Hot axes (`child`, `attribute`, `self`, `parent`) fuse traversal and node-test filtering directly in `xpath3`, avoiding the generic `TraverseAxis` + extra filtered-slice path
+3. Hot axes (`child`, `attribute`, `self`, `parent`) fuse traversal and node-test filtering directly in `xpath3`,
+   avoiding the generic `TraverseAxis` + extra filtered-slice path
 4. Return merged node-set
 
 **Cancellation:** the fused hot child/attribute loops check `ctx.Err()` once per enumerated node (the
@@ -335,12 +338,14 @@ and the default xpath3 behavior is unchanged.
 
 - Stateless between `Expression.Evaluate` calls
 - `evalContext` created fresh per call, discarded after
-- Hot-path node/item rebinding during predicates, path steps, and simple-map evaluation mutates the current `evalContext` temporarily and restores it afterward instead of allocating copied child contexts
+- Hot-path node/item rebinding during predicates, path steps, and simple-map evaluation mutates the current
+  `evalContext` temporarily and restores it afterward instead of allocating copied child contexts
 - Default language comes from `WithDefaultLanguage`; built-ins fall back to `"en"` when unset
 - `DocOrderCache` lazy, O(n) build, O(1) lookup: one flat `map[helium.Node]sortKey` covering every indexed
   document, so a position lookup is a single hash probe with no parent-chain walk. A second map records each
   document root's registration order, which orders nodes from different trees
-- Inline functions and named function refs snapshot the dynamic context they close over, so later focus rebinding does not change captured behavior
+- Inline functions and named function refs snapshot the dynamic context they close over, so later focus rebinding does
+  not change captured behavior
 
 ## Safety Limits
 

--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -102,7 +102,8 @@ to the inline-function parameter/return paths and `coerceFunctionItem`
 ## Functions by File
 
 ### `functions_node.go`
-`node-name`, `nilled`, `string`, `data`, `base-uri`, `document-uri`, `root`, `path`, `has-children`, `innermost`, `outermost`, `id`, `idref`, `lang`, `local-name`, `name`, `namespace-uri`, `number`, `generate-id`
+`node-name`, `nilled`, `string`, `data`, `base-uri`, `document-uri`, `root`, `path`, `has-children`, `innermost`,
+`outermost`, `id`, `idref`, `lang`, `local-name`, `name`, `namespace-uri`, `number`, `generate-id`
 
 `fn:nilled` returns the PSVI [nil] property of an element node (`()` for a non-element): true iff the node is
 in the evaluator's `NilledElements` set (`Evaluator.NilledElements`, populated from
@@ -127,7 +128,8 @@ element's parent).
 `contains`, `starts-with`, `ends-with`, `substring-before`, `substring-after`, `matches`, `replace`,
 `tokenize`, `analyze-string` (partial; result DOM built with helium)
 
-Regex: use Go `regexp` package by default; fall back to `github.com/dlclark/regexp2` for patterns requiring backreferences, character class subtraction, or large quantifiers. Map XPath flags (`i`,`m`,`s`,`x`) to Go equivalents.
+Regex: use Go `regexp` package by default; fall back to `github.com/dlclark/regexp2` for patterns requiring
+backreferences, character class subtraction, or large quantifiers. Map XPath flags (`i`,`m`,`s`,`x`) to Go equivalents.
 Compiled regexes are cached by pattern + flags pair so repeated literal calls do not repay
 translation/compilation cost. The cache (`regexLRUCache` in `regex_cache.go`) is a bounded LRU with a
 1024-entry cap and least-recently-used eviction, so many distinct dynamic patterns cannot grow process memory
@@ -179,7 +181,8 @@ Error/trace: `error` (raises `FOER0000` with optional code/description/value), `
 `count`, `avg`, `max`, `min`, `sum`, `distinct-values`
 
 ### `functions_sequence.go`
-`empty`, `exists`, `head`, `tail`, `insert-before`, `remove`, `reverse`, `subsequence`, `unordered`, `zero-or-one`, `one-or-more`, `exactly-one`, `deep-equal`, `index-of`
+`empty`, `exists`, `head`, `tail`, `insert-before`, `remove`, `reverse`, `subsequence`, `unordered`, `zero-or-one`,
+`one-or-more`, `exactly-one`, `deep-equal`, `index-of`
 
 ### `functions_datetime.go`
 Constructors: `dateTime`
@@ -535,7 +538,8 @@ transport/timeouts/redirect policy you control. `fn:doc` parses retrieved bytes 
 `BlockXXE(true).AllowNetwork(false)` so the returned document cannot pull additional externals.
 
 ### `functions_qname.go`
-`QName`, `resolve-QName`, `prefix-from-QName`, `local-name-from-QName`, `namespace-uri-from-QName`, `namespace-uri-for-prefix`, `in-scope-prefixes`
+`QName`, `resolve-QName`, `prefix-from-QName`, `local-name-from-QName`, `namespace-uri-from-QName`,
+`namespace-uri-for-prefix`, `in-scope-prefixes`
 
 ### `functions_hof.go`
 `for-each`, `filter`, `fold-left`, `fold-right`, `apply`, `function-lookup`, `function-arity`, `function-name`
@@ -573,7 +577,8 @@ only after a slice has already been allocated:
   before each append, so a callback returning an unbounded lazy `Sequence` is rejected without ever
   materializing it. `appendBounded` (the slice-taking variant) is still used where the source is already a
   materialized slice.
-- Fold accumulators check `seqLen(acc) > maxNodes` after each step; `seqLen` is O(1) on a lazy range, so an oversized lazy accumulator is rejected without materialization.
+- Fold accumulators check `seqLen(acc) > maxNodes` after each step; `seqLen` is O(1) on a lazy range, so an oversized
+  lazy accumulator is rejected without materialization.
 - The iterative walkers `array:flatten` and `map:find` (`mapFindIter`) use an explicit stack of `seqCursor`
   frames (a member/value list + member/item index, in `functions_array.go`) that yields one `Item` per
   `next()` via `Sequence.Get`, instead of expanding child sequences into temporary `[]Item` slices. This
@@ -583,7 +588,8 @@ only after a slice has already been allocated:
   still avoids the intermediate slice amplification.
 
 ### `functions_map.go`
-`map:merge`, `map:size`, `map:keys`, `map:contains`, `map:get`, `map:put`, `map:entry`, `map:remove`, `map:for-each`, `map:find`
+`map:merge`, `map:size`, `map:keys`, `map:contains`, `map:get`, `map:put`, `map:entry`, `map:remove`, `map:for-each`,
+`map:find`
 
 ### `functions_array.go`
 `array:size`, `array:get`, `array:put`, `array:append`, `array:subarray`, `array:remove`,
@@ -591,12 +597,14 @@ only after a slice has already been allocated:
 `array:filter`, `array:fold-left`, `array:fold-right`, `array:for-each`, `array:for-each-pair`, `array:sort`
 
 ### `functions_math.go`
-`math:pi`, `math:exp`, `math:exp10`, `math:log`, `math:log10`, `math:pow`, `math:sqrt`, `math:sin`, `math:cos`, `math:tan`, `math:asin`, `math:acos`, `math:atan`, `math:atan2`
+`math:pi`, `math:exp`, `math:exp10`, `math:log`, `math:log10`, `math:pow`, `math:sqrt`, `math:sin`, `math:cos`,
+`math:tan`, `math:asin`, `math:acos`, `math:atan`, `math:atan2`
 
 All delegate to Go `math` package.
 
 ### `functions_misc.go`
-`static-base-uri`, `default-collation`, `available-environment-variables`, `environment-variable`, `current-dateTime`, `current-date`, `current-time`, `implicit-timezone`, `generate-id`
+`static-base-uri`, `default-collation`, `available-environment-variables`, `environment-variable`, `current-dateTime`,
+`current-date`, `current-time`, `implicit-timezone`, `generate-id`
 
 ### `format_number.go`
 `format-number` (full ICU-style decimal format patterns)

--- a/.claude/docs/xpath3-parser.md
+++ b/.claude/docs/xpath3-parser.md
@@ -4,7 +4,9 @@
 
 ### Inherited from xpath1
 
-`EOF`, `Number`, `String`, `Name`, `Star`, `VariableRef`, `Slash`, `SlashSlash`, `Pipe`, `Plus`, `Minus`, `Equals`, `NotEquals`, `Less`, `LessEq`, `Greater`, `GreaterEq`, `And`, `Or`, `Mod`, `Div`, `LParen`, `RParen`, `LBracket`, `RBracket`, `At`, `ColonColon`, `Comma`, `Dot`, `DotDot`, `Colon`
+`EOF`, `Number`, `String`, `Name`, `Star`, `VariableRef`, `Slash`, `SlashSlash`, `Pipe`, `Plus`, `Minus`, `Equals`,
+`NotEquals`, `Less`, `LessEq`, `Greater`, `GreaterEq`, `And`, `Or`, `Mod`, `Div`, `LParen`, `RParen`, `LBracket`,
+`RBracket`, `At`, `ColonColon`, `Comma`, `Dot`, `DotDot`, `Colon`
 
 ### New in XPath 3.1
 
@@ -56,7 +58,10 @@
 
 Same one-pass approach as `xpath1/lexer.go`. All tokens emitted to `[]Token` upfront.
 
-Keyword disambiguation: `and`, `or`, `div`, `mod`, `idiv`, `intersect`, `except`, `to`, `eq`, `ne`, `lt`, `le`, `gt`, `ge`, `union`, `instance`, `cast`, `castable`, `treat`, `as`, `in`, `return`, `satisfies`, `then`, `else`, `some`, `every`, `for`, `let`, `where`, `if`, `try`, `catch`, `stable`, `ascending`, `descending` are operators/keywords ONLY when preceded by a value-producing token. Otherwise → `Name`.
+Keyword disambiguation: `and`, `or`, `div`, `mod`, `idiv`, `intersect`, `except`, `to`, `eq`, `ne`, `lt`, `le`, `gt`,
+`ge`, `union`, `instance`, `cast`, `castable`, `treat`, `as`, `in`, `return`, `satisfies`, `then`, `else`, `some`,
+`every`, `for`, `let`, `where`, `if`, `try`, `catch`, `stable`, `ascending`, `descending` are operators/keywords ONLY
+when preceded by a value-producing token. Otherwise → `Name`.
 
 ## Parser (`parser.go`)
 
@@ -64,7 +69,8 @@ Recursive descent. Parse depth limit: 200.
 
 Entry: `Parse(input string) (Expr, error)` → `parseExpression()`.
 
-Step detection and path continuation use `PeekAt`-based lookahead so the hot path can classify separators, axis specifiers, and QName-vs-function-call ambiguities without advancing and backing up the lexer cursor.
+Step detection and path continuation use `PeekAt`-based lookahead so the hot path can classify separators, axis
+specifiers, and QName-vs-function-call ambiguities without advancing and backing up the lexer cursor.
 
 ### Precedence (low → high)
 
@@ -100,14 +106,20 @@ Step detection and path continuation use `PeekAt`-based lookahead so the hot pat
 
 ### Special Parses
 
-- **Named function ref**: `fn:upper-case#1` → `NamedFunctionRef{Prefix:"fn", Name:"upper-case", Arity:1}`. Detected when `Hash` follows name in `parsePrimaryExpr`.
-- **Inline function**: `function($x as xs:integer) as xs:boolean { $x > 0 }` → `InlineFunctionExpr`. Body delimited by `{ }`.
-- **Partial application**: `substring(?, 2)` → `FunctionCall{Args:[PlaceholderExpr{}, NumberExpr{2}]}`. Evaluator detects placeholders → returns `FunctionItem`.
+- **Named function ref**: `fn:upper-case#1` → `NamedFunctionRef{Prefix:"fn", Name:"upper-case", Arity:1}`. Detected when
+  `Hash` follows name in `parsePrimaryExpr`.
+- **Inline function**: `function($x as xs:integer) as xs:boolean { $x > 0 }` → `InlineFunctionExpr`. Body delimited by
+  `{ }`.
+- **Partial application**: `substring(?, 2)` → `FunctionCall{Args:[PlaceholderExpr{}, NumberExpr{2}]}`. Evaluator
+  detects placeholders → returns `FunctionItem`.
 - **Map constructor**: `map { "key": "value" }` → `MapConstructorExpr`.
 - **Array (square)**: `[1, 2, 3]` → `ArrayConstructorExpr{SquareBracket:true}`. Each expr = one member.
 - **Array (curly)**: `array { 1, 2, 3 }` → `ArrayConstructorExpr{SquareBracket:false}`. Single sequence.
 - **FLWOR**: `for`/`let` clauses collected until `return`. `for` and `let` can interleave.
-- **Sequence types**: `parseSequenceType` → `parseItemType` → `parseKindTest`. Kind tests: `node()`, `element(name, type)`, `attribute(name, type)`, `document-node(element(...))`, `text()`, `comment()`, `processing-instruction(target)`, `namespace-node()`, `schema-element(name)`, `schema-attribute(name)`, `function(*)`, `map(*)`, `array(*)`, `item()`.
+- **Sequence types**: `parseSequenceType` → `parseItemType` → `parseKindTest`. Kind tests: `node()`, `element(name,
+  type)`, `attribute(name, type)`, `document-node(element(...))`, `text()`, `comment()`,
+  `processing-instruction(target)`, `namespace-node()`, `schema-element(name)`, `schema-attribute(name)`, `function(*)`,
+  `map(*)`, `array(*)`, `item()`.
 
 ## AST Nodes (`expr.go`)
 

--- a/.claude/docs/xpath3-types.md
+++ b/.claude/docs/xpath3-types.md
@@ -65,7 +65,8 @@ type NodeItemUnionMember struct {
   `xs:list itemType="<union>"` atomizes each token by its own active member (agreeing with `$value`) instead
   of forcing every token through one static base; nil/short slice falls back to `atomizeListToken` on the
   declared item type
-- `QNameNoDefaultNS` → set from `Evaluator.QNameValueNoDefaultNamespace()`; when true an UNPREFIXED QName/NOTATION value atomizes to no namespace (XSD value-space semantics) instead of the node's default namespace
+- `QNameNoDefaultNS` → set from `Evaluator.QNameValueNoDefaultNamespace()`; when true an UNPREFIXED QName/NOTATION value
+  atomizes to no namespace (XSD value-space semantics) instead of the node's default namespace
 
 `resolveQNameFromNode` predeclares the `xml` prefix (→ the XML namespace) without requiring a binding on any
 node, matching `xsd.resolveLexicalQName`, so an xs:QName value such as `xml:lang`/`xml:space` atomizes
@@ -138,7 +139,8 @@ Produced by: inline functions, named refs (`fn#2`), partial application.
 ## MapItem
 
 Immutable. `Put` returns new map (copy-on-write).
-Construction + outward-facing accessors clone `Sequence` values via `cloneSequence`. Caller mutation MUST NOT change stored contents.
+Construction + outward-facing accessors clone `Sequence` values via `cloneSequence`. Caller mutation MUST NOT change
+stored contents.
 
 KEYS are cloned too: every map ingress (`newSingleEntryMap`, `NewMap`, `Put`, `MergeMaps`, `MapBuilder.Add`)
 clones the `AtomicValue` key via `cloneMapKey` (an O(1) single-atomic copy reusing `deepCloneAtomicValue`),
@@ -253,7 +255,8 @@ Per XPath 3.1 Section 2.6.2:
 - Array → flattened to the atomization of its members (recursively); a function or map member raises `FOTY0013`
 - Function/map → error `FOTY0013`
 
-The same flatten-arrays / error-on-function-or-map rule governs the `||` string-concatenation path (`concatToString`, `eval_operators.go`): array operands flatten to their atomized members, only function and map items raise `FOTY0014`.
+The same flatten-arrays / error-on-function-or-map rule governs the `||` string-concatenation path (`concatToString`,
+`eval_operators.go`): array operands flatten to their atomized members, only function and map items raise `FOTY0014`.
 
 The typed-value atomizer (`atomizeTypedValue`, `functions_node.go`) applies a per-item pre-check
 (`typedValueItemCheck` / `typedValueItemCheckFor`, an `atomizeItemCheck`) that selects a typed-value ACTION

--- a/.claude/docs/xsd11-content-models.md
+++ b/.claude/docs/xsd11-content-models.md
@@ -4,7 +4,9 @@
 > 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the
 > governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
 
-- **UPA weakening** (`check_upa.go` `entriesOverlap`: in 1.1 an element competing with a wildcard is not a cos-nonambig violation — the element wins). Element-over-wildcard precedence is enforced at validation, gated `vc.version == Version11`:
+- **UPA weakening** (`check_upa.go` `entriesOverlap`: in 1.1 an element competing with a wildcard is not a cos-nonambig
+  violation — the element wins). Element-over-wildcard precedence is enforced at validation, gated `vc.version ==
+  Version11`:
   - CHOICE (`validate_elem.go` `matchChoice`/`tryMatchChoice`): a branch consuming the current child via an
     element leaf AS ITS FIRST CONSUMING TERM beats one consuming it via a wildcard, regardless of declaration
     order/nesting. Classifier `particleConsumesViaElement` →

--- a/.claude/docs/xsd11-doc-walks.md
+++ b/.claude/docs/xsd11-doc-walks.md
@@ -4,7 +4,8 @@
 > 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the
 > governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
 
-- **document-wide xs:ID/xs:IDREF/xs:IDREFS validation** (`validate_id.go`): a third validation walk, run in BOTH XSD 1.0 and 1.1 (cvc-id is version-INDEPENDENT), enforcing ID uniqueness and IDREF referential integrity.
+- **document-wide xs:ID/xs:IDREF/xs:IDREFS validation** (`validate_id.go`): a third validation walk, run in BOTH XSD 1.0
+  and 1.1 (cvc-id is version-INDEPENDENT), enforcing ID uniqueness and IDREF referential integrity.
   - Ownership: an attribute ID belongs to its element, an element-content ID to its PARENT. On the DOCUMENT
     ROOT an element-content ID has no parent, denoting NO element — `idOwner` nil, `recordID` skips it, the
     value never enters the table, any xs:IDREF to it dangles (W3C idIDREF s3_3_4ii26/ii27).
@@ -26,7 +27,8 @@
     finalized). `attrUseIsIDType` counts iff the resolved type is atomic (`resolveVariety ==
     TypeVarietyAtomic`) with builtin base xs:ID; a list of xs:ID or a union with an xs:ID member does NOT
     count. Gated to Version10.
-  - DEFERRED gap: the full "wild IDs" rule, where a declared ID attribute use plus a wildcard-admitted global ID attribute is invalid even with the declared use absent.
+  - DEFERRED gap: the full "wild IDs" rule, where a declared ID attribute use plus a wildcard-admitted global ID
+    attribute is invalid even with the declared use absent.
   - list/union values decompose to atomic ID/IDREF leaves via the active-member resolver. Element-content
     collection is SKIPPED when the element has CHILD ELEMENTS (`hasChildElement`; simple content forbids them,
     so pass 1 already rejected it structurally; `elemTextContent` ignores children, and a default/fixed must

--- a/.claude/docs/xsd11-identity-constraints.md
+++ b/.claude/docs/xsd11-identity-constraints.md
@@ -23,8 +23,10 @@
   (`hasAttr`, so empty-but-present `name=""`/`refer=""` is still rejected); `refer` is rejected for EVERY
   kind, not just keyref.
 - **identity-constraint structural rules** (version-INDEPENDENT — BOTH XSD 1.0 and 1.1):
-  - `parseIDConstraint` (`read_elements.go`) rejects a constraint `@name` that is not a valid `xs:NCName` (`xmlchar.IsValidNCName`, so `a:b`/`1foo` fail) and a `@refer` on a non-keyref (key/unique).
-  - `checkKeyRefRefers` (`compile.go`) rejects a keyref whose `{fields}` cardinality differs from the referenced key/unique's.
+  - `parseIDConstraint` (`read_elements.go`) rejects a constraint `@name` that is not a valid `xs:NCName`
+    (`xmlchar.IsValidNCName`, so `a:b`/`1foo` fail) and a `@refer` on a non-keyref (key/unique).
+  - `checkKeyRefRefers` (`compile.go`) rejects a keyref whose `{fields}` cardinality differs from the referenced
+    key/unique's.
   - `checkIDConstraintPlacement` (`check_idc.go`, a DOM walk over the entry document and every
     included/imported/redefined/overridden document) enforces schema-for-schemas placement:
     `xs:key`/`xs:unique`/`xs:keyref` valid ONLY as a child of an `xs:element` declaration (elsewhere — top
@@ -59,7 +61,9 @@
   declared use, typed OR untyped; a default/fixed insertion; a strict/lax wildcard WITH a matching global) and
   `validateWildcardAttr`, so an UNTYPED assessed attribute ({type definition} = xs:anySimpleType) is assessed
   though it records no `*TypeDef`. A field node is:
-  - **GOVERNED** (contributes its typed value): an assessed attribute (always simple; untyped = xs:anySimpleType) OR an assessed element whose type is simple (`!IsComplex`) or complex with SIMPLE content (`ContentType == ContentTypeSimple`).
+  - **GOVERNED** (contributes its typed value): an assessed attribute (always simple; untyped = xs:anySimpleType) OR an
+    assessed element whose type is simple (`!IsComplex`) or complex with SIMPLE content (`ContentType ==
+    ContentTypeSimple`).
   - **VIOLATION** (a cvc-identity-constraint.3 non-simple error): an assessed COMPLEX element with
     element-only/mixed/empty content (idG006/idK012) — BOTH versions — OR, in XSD 1.0 (no skipped-node
     relaxation), ANY unassessed/unresolved node (idZ015: a skip/lax-without-global-admitted attribute, an

--- a/.claude/docs/xsd11-representation.md
+++ b/.claude/docs/xsd11-representation.md
@@ -376,7 +376,8 @@
   (minLength ≤ length ≤ maxLength). So `xs:IDREFS` restricted to `length=5`,`minLength=1` is permitted (own 1
   == inherited intrinsic 1), while a fresh tighter bound — `length=5`,`minLength=2` (own 2 ≠ 1) or base
   `maxLength=10` restated as `length=5`,`maxLength=8` (own 8 ≠ 10) — stays an error.
-- **complexType `@block`/`@final` enum** (version-INDEPENDENT): `parseComplexType` (`read_types.go`, via `isValidFinal`) rejects a `<xs:complexType>` `@block`/`@final` not drawn from `{#all, extension, restriction}`.
+- **complexType `@block`/`@final` enum** (version-INDEPENDENT): `parseComplexType` (`read_types.go`, via `isValidFinal`)
+  rejects a `<xs:complexType>` `@block`/`@final` not drawn from `{#all, extension, restriction}`.
 - **content-model group reference representation** (§3.8.2, version-INDEPENDENT): `checkContentModelGroupRef`
   (`read_particles.go`) enforces that an `<xs:group>` particle in a content model is a REFERENCE — content
   `(annotation?)` with only `@ref`; a `@name`, a missing `@ref`, or any non-annotation element child is a
@@ -406,7 +407,8 @@
   (src-import.1.1), and a no-`@namespace` import in a schema lacking a `targetNamespace` (src-import.1.2); the
   invalid import is reported and skipped. `Compile` (`compile.go`) also rejects an empty schema
   `targetNamespace=""`.
-- **local complexType `@name` prohibition** (version-INDEPENDENT): `parseComplexType` (`read_types.go`, `local` flag) rejects a `@name` on an inline (non-top-level) `<xs:complexType>`.
+- **local complexType `@name` prohibition** (version-INDEPENDENT): `parseComplexType` (`read_types.go`, `local` flag)
+  rejects a `@name` on an inline (non-top-level) `<xs:complexType>`.
 - **required `@schemaLocation`** (src-include.1/src-redefine.1 §4.2.3, version-INDEPENDENT): `processIncludes`
   (`compile_imports.go`) treats an ABSENT `@schemaLocation` on `<xs:include>`/`<xs:redefine>` as a fatal
   schema-representation error, distinct from a present-but-unresolvable location hint (a warning).

--- a/.claude/docs/xsd11-types.md
+++ b/.claude/docs/xsd11-types.md
@@ -4,10 +4,14 @@
 > 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the
 > governing rule and its conformance evidence. See `xsd11.md` for the index and version-resolution framing.
 
-- the 1.1-only lexical forms (`+INF` for xs:double/xs:float; year `0000` on the date types — both gated in `internal/xsd/value` via a `value.Version` argument; relaxng is pinned to `value.Version10`);
+- the 1.1-only lexical forms (`+INF` for xs:double/xs:float; year `0000` on the date types — both gated in
+  `internal/xsd/value` via a `value.Version` argument; relaxng is pinned to `value.Version10`);
 - the 1.1 built-in datatypes (xs:dateTimeStamp, xs:dayTimeDuration, xs:yearMonthDuration, xs:anyAtomicType, xs:error);
-- **xs:assert on complex types** (`assert.go`): parsed from complexType/restriction/extension AND simpleContent extension/restriction; pre-compiled via xpath3; evaluated after content validation (EBV false → invalid); inherited down the base chain.
-  - `$value`: the element's TYPED simple value for a simpleContent complex type (empty sequence for complex content); an EMPTY element's default/fixed effective value is substituted before typing → `$value` schema-normalized.
+- **xs:assert on complex types** (`assert.go`): parsed from complexType/restriction/extension AND simpleContent
+  extension/restriction; pre-compiled via xpath3; evaluated after content validation (EBV false → invalid); inherited
+  down the base chain.
+  - `$value`: the element's TYPED simple value for a simpleContent complex type (empty sequence for complex content); an
+    EMPTY element's default/fixed effective value is substituted before typing → `$value` schema-normalized.
   - Isolated tree: deep copy rooted in NO document, comment/PI stripped → `/`/`//` raises XPDY0050. In-scope
     namespaces re-declared (incl. an inherited default-namespace prefix "" so `namespace-uri-for-prefix('',
     .)` resolves); PSVI annotations onto DESCENDANT elements + ALL attributes but NOT the assertion ROOT (type
@@ -28,7 +32,8 @@
     target type (`Q{ns}local` via `schemaAnnotationParts`) not the lexical prefix → an UNPREFIXED user type
     via `xpathDefaultNamespace` resolves. An ALREADY-RESOLVED QName cast SOURCE (prefix declared only on the
     INSTANCE node) is re-validated by `qnameCastLexical` using the value's OWN URI.
-  - QName/NOTATION atomization (`resolveQNameFromNode`) predeclares `xml` → the XML namespace with no node binding (matching `xsd.resolveLexicalQName`) → `xml:lang`/`xml:space` atomizes.
+  - QName/NOTATION atomization (`resolveQNameFromNode`) predeclares `xml` → the XML namespace with no node binding
+    (matching `xsd.resolveLexicalQName`) → `xml:lang`/`xml:space` atomizes.
   - A list-typed node splits on XSD whitespace ONLY (space/tab/CR/LF via `xsdListFields`; NBSP/other Unicode
     whitespace NOT separators), each token via `atomizeListTokenAt`. A UNION item type → each token through
     its value-resolved ACTIVE member (`nodeItemFor` → per-token leaf in `NodeItem.ListItemLeaves` via
@@ -64,7 +69,8 @@
     VALUE atomizes to NO namespace (XSD value-space; a prefixed value still resolves); under it `castToQName`
     also skips the default-namespace fallback for an unprefixed cast target. Default xpath3 (flag off)
     unchanged.
-  - A self-referential cast (`cast`/`castable as t:T` inside t:T's OWN assertion) is guarded by a per-validation `(type, value)` cast stack in the context (`castGuardKey` in `schema_decls.go`): a repeat fails closed.
+  - A self-referential cast (`cast`/`castable as t:T` inside t:T's OWN assertion) is guarded by a per-validation `(type,
+    value)` cast stack in the context (`castGuardKey` in `schema_decls.go`): a repeat fails closed.
   - An EMPTY DEFAULTED/FIXED DESCENDANT element's schema value is materialized: `validateSimpleContent`
     records each empty element's effective default/fixed value (plus the DECLARATION namespace context for a
     QName/NOTATION prefix) in `vc.assertEffectiveValues`; `isolatedAssertTree`/`mapAssertAnnotations`
@@ -92,7 +98,8 @@
     `buildValueSequence`/`typedAtomic`/`atomicForType`) PRESERVING a NAMED user type's identity (user type
     name as `TypeName`, builtin cast type as `BaseType`, mirroring `AtomizeItem`/`data()`) across the atomic,
     QName/NOTATION, list-item, and union-leaf paths, so `$value instance of t:MyInt` holds.
-  - The context item is ABSENT, so `.`/`position()`/`last()` raise a dynamic error → unsatisfied; assertions ANDed along the restriction chain; same SchemaDeclarations adapter.
+  - The context item is ABSENT, so `.`/`position()`/`last()` raise a dynamic error → unsatisfied; assertions ANDed along
+    the restriction chain; same SchemaDeclarations adapter.
   - `validateValue` evaluates these facets, so the COMPILE-TIME throwaway contexts reaching it — the attribute
     default/fixed check (`checkAttrUseConstraints`, `link_refs.go`) and the facet value-against-base /
     enumeration / union-member checks (`check_facets.go`) — are built with `schema: c.schema` so a

--- a/.claude/docs/xsd11.md
+++ b/.claude/docs/xsd11.md
@@ -1,10 +1,14 @@
 # XSD 1.1 Implementation State — Index
 
-Detailed feature-by-feature state of the XSD 1.1 opt-in path (`Compiler.Version(xsd.Version11)`). This is the current implementation surface, not a changelog. **Read the relevant sub-doc below before working in that area of `xsd/`.**
+Detailed feature-by-feature state of the XSD 1.1 opt-in path (`Compiler.Version(xsd.Version11)`). This is the current
+implementation surface, not a changelog. **Read the relevant sub-doc below before working in that area of `xsd/`.**
 
-Version-resolution rules and the `SkipDatatypeIntegrityChecks` contract that gate everything below live in `CLAUDE.md` → "XSD — Version Toggle".
+Version-resolution rules and the `SkipDatatypeIntegrityChecks` contract that gate everything below live in `CLAUDE.md` →
+"XSD — Version Toggle".
 
-Convention across all sub-docs: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated with the 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the governing rule and its conformance evidence.
+Convention across all sub-docs: **version-INDEPENDENT** rules run in both 1.0 and 1.1; all others are `Version11`-gated
+with the 1.0 path byte-identical to origin. Spec citations (§, cvc-*, cos-*, src-*) and W3C test IDs identify the
+governing rule and its conformance evidence.
 
 XSD 1.1 is fully implemented. The committed W3C conformance snapshot reports
 **1,049 pass / 0 skip / 0 fail** in `xsd/summary-xsd11.md`. Sub-docs by area:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,8 @@ The following is a set of guidelines that we ask you to follow when you contribu
 
 # Please Be Nice
 
-[Main source; if wordings differ, the main source supersedes this copy](https://github.com/lestrrat-go/contributions/blob/main/Contributions.md)
+[Main source; if wordings differ, the main source supersedes this
+copy](https://github.com/lestrrat-go/contributions/blob/main/Contributions.md)
 
 Please be nice when you contact us.
 
@@ -48,19 +49,24 @@ We are willing to help, but only as long as you are being nice to us.
 
 # Please Read The Examples First
 
-[Main source; if wordings differ, the main source supersedes this copy](https://github.com/lestrrat-go/contributions/blob/main/Contributions.md)
+[Main source; if wordings differ, the main source supersedes this
+copy](https://github.com/lestrrat-go/contributions/blob/main/Contributions.md)
 
 On most of the projects that we provide, we have example test code available,
-most likely in the [`examples/`](../examples) directory. Before asking questions or filing issues, please make sure to take a look at the examples.
+most likely in the [`examples/`](../examples) directory. Before asking questions or filing issues, please make sure to
+take a look at the examples.
 
-Specifically for Go projects, please first look for files with names `*_example_test.go`, which contain the runnable example code.
+Specifically for Go projects, please first look for files with names `*_example_test.go`, which contain the runnable
+example code.
 
-If the examples do not solve your problems, feel free to proceed with your report. If there are missing examples or inaccuracies, please do not hesitate to contact us.
+If the examples do not solve your problems, feel free to proceed with your report. If there are missing examples or
+inaccuracies, please do not hesitate to contact us.
 
 
 # Please Use Correct Medium (GitHub Issues / Discussions)
 
-[Main source; this is a specialized version copied from the main source](https://github.com/lestrrat-go/contributions/blob/main/Contributions.md)
+[Main source; this is a specialized version copied from the main
+source](https://github.com/lestrrat-go/contributions/blob/main/Contributions.md)
 
 This project uses [GitHub Issues](https://github.com/lestrrat-go/helium/issues) to deal with technical issues
 including bug reports, proposing new API, and otherwise issues that are directly actionable.
@@ -70,7 +76,8 @@ questions/discussions should be posted to [GitHub Discussions](https://github.co
 
 # Please Include (Pseudo)code for Any Technical Issues
 
-[Main source; if wordings differ, the main source supersedes this copy](https://github.com/lestrrat-go/contributions/blob/main/Contributions.md)
+[Main source; if wordings differ, the main source supersedes this
+copy](https://github.com/lestrrat-go/contributions/blob/main/Contributions.md)
 
 Your report should contain clear, concise description of the issue that you are facing.
 However, at the same time please always include (pseudo)code in report.
@@ -95,7 +102,9 @@ Please help us help you by providing us with a reproducible code.
 # Reviewer/Reviewee Guidelines
 
 If you are curious about what what gets reviewed and why some decisions
-are made the way they are, please read [this document](https://github.com/lestrrat-go/contributions/blob/main/Reviews.md) to get some insight into the thinking process.
+are made the way they are, please read [this
+document](https://github.com/lestrrat-go/contributions/blob/main/Reviews.md) to get some insight into the thinking
+process.
 
 # Brown M&M Clause
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,8 @@ assignees: ''
 
 **Contribution Guidelines**
 
-Before filing an issue, please read [CONTRIBUTING.md](https://github.com/lestrrat-go/helium/blob/main/.github/CONTRIBUTING.md).
+Before filing an issue, please read
+[CONTRIBUTING.md](https://github.com/lestrrat-go/helium/blob/main/.github/CONTRIBUTING.md).
 
 **Describe the bug**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,8 @@ assignees: ''
 
 **Contribution Guidelines**
 
-Before filing an issue, please read [CONTRIBUTING.md](https://github.com/lestrrat-go/helium/blob/main/.github/CONTRIBUTING.md).
+Before filing an issue, please read
+[CONTRIBUTING.md](https://github.com/lestrrat-go/helium/blob/main/.github/CONTRIBUTING.md).
 
 **Abstract**
 

--- a/.github/ISSUE_TEMPLATE/others.md
+++ b/.github/ISSUE_TEMPLATE/others.md
@@ -9,7 +9,8 @@ assignees: ''
 
 **Contribution Guidelines**
 
-Before filing an issue, please read [CONTRIBUTING.md](https://github.com/lestrrat-go/helium/blob/main/.github/CONTRIBUTING.md).
+Before filing an issue, please read
+[CONTRIBUTING.md](https://github.com/lestrrat-go/helium/blob/main/.github/CONTRIBUTING.md).
 
 **Context**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,39 +8,80 @@ Go and grew broader native Go APIs and features along the way.
 
 ## XPath 3.1 — XSD Version
 
-The xpath3 package targets **XSD 1.1 only**. This means `+INF` is a valid lexical form for xs:double and xs:float, and xs:dateTimeStamp is a recognized type. QT3 tests with `dependency type="xsd-version" value="1.0"` are skipped.
+The xpath3 package targets **XSD 1.1 only**. This means `+INF` is a valid lexical form for xs:double and xs:float, and
+xs:dateTimeStamp is a recognized type. QT3 tests with `dependency type="xsd-version" value="1.0"` are skipped.
 
 ## XSD — Version Toggle
 
-The xsd package defaults to **XSD 1.0** and treats 1.1 as **opt-in** via `Compiler.Version(xsd.Version11)` (or a `vc:minVersion="1.1"` hint on the root `<xs:schema>` when no explicit version is set). The resolved version is frozen onto the compiled `Schema` so the `Validator` applies the same semantics. 1.0 stays the default so existing behavior and goldens are unchanged.
+The xsd package defaults to **XSD 1.0** and treats 1.1 as **opt-in** via `Compiler.Version(xsd.Version11)` (or a
+`vc:minVersion="1.1"` hint on the root `<xs:schema>` when no explicit version is set). The resolved version is frozen
+onto the compiled `Schema` so the `Validator` applies the same semantics. 1.0 stays the default so existing behavior and
+goldens are unchanged.
 
-`resolveVersion` (`compile.go`) resolves in order: a forced `Compiler.Version()` (always wins) → a `vc:minVersion="1.1"`-or-higher hint on the root → a configured `Compiler.DefaultVersion(v)` (the opt-in fallback for a schema silent on version) → `Version10`. `DefaultVersion` never overrides a forced version or a vc hint — it only chooses the fallback. The STANDALONE default stays `Version10`; `DefaultVersion` lets an embedding layer opt its schemas into 1.1 by default while still honoring an explicit version.
+`resolveVersion` (`compile.go`) resolves in order: a forced `Compiler.Version()` (always wins) → a
+`vc:minVersion="1.1"`-or-higher hint on the root → a configured `Compiler.DefaultVersion(v)` (the opt-in fallback for a
+schema silent on version) → `Version10`. `DefaultVersion` never overrides a forced version or a vc hint — it only
+chooses the fallback. The STANDALONE default stays `Version10`; `DefaultVersion` lets an embedding layer opt its schemas
+into 1.1 by default while still honoring an explicit version.
 
-`Validator.SkipDatatypeIntegrityChecks(true)` suppresses the document-wide datatype-integrity walks in `validateDocument` (`cfg.skipDatatypeIntegrity`): the xs:ID/xs:IDREF/xs:IDREFS uniqueness+referential-integrity walk (version-INDEPENDENT — runs in both 1.0 and 1.1) and the XSD 1.1-only xs:ENTITY/xs:ENTITIES walk; content-model, type, and xs:key/unique/keyref identity-constraint validation are unaffected. It is for callers that validate an element/subtree as a fragment and enforce document-scope ID/IDREF integrity themselves (xslt3). In 1.0 it suppresses the ID/IDREF walk (the ENTITY walk never runs there).
+`Validator.SkipDatatypeIntegrityChecks(true)` suppresses the document-wide datatype-integrity walks in
+`validateDocument` (`cfg.skipDatatypeIntegrity`): the xs:ID/xs:IDREF/xs:IDREFS uniqueness+referential-integrity walk
+(version-INDEPENDENT — runs in both 1.0 and 1.1) and the XSD 1.1-only xs:ENTITY/xs:ENTITIES walk; content-model, type,
+and xs:key/unique/keyref identity-constraint validation are unaffected. It is for callers that validate an
+element/subtree as a fragment and enforce document-scope ID/IDREF integrity themselves (xslt3). In 1.0 it suppresses the
+ID/IDREF walk (the ENTITY walk never runs there).
 
-XSD 1.1 is fully implemented behind the `Version11` opt-in. The committed W3C conformance snapshot reports **1,049 pass / 0 skip / 0 fail** (`xsd/summary-xsd11.md`). The complete feature-by-feature implementation state — every 1.1 construct, its file/function, spec clause, version gating, W3C test evidence, and remaining gaps — lives in `.claude/docs/xsd11.md`. **Read that doc before any work in `xsd/`.** Feature areas covered there:
+XSD 1.1 is fully implemented behind the `Version11` opt-in. The committed W3C conformance snapshot reports **1,049 pass
+/ 0 skip / 0 fail** (`xsd/summary-xsd11.md`). The complete feature-by-feature implementation state — every 1.1
+construct, its file/function, spec clause, version gating, W3C test evidence, and remaining gaps — lives in
+`.claude/docs/xsd11.md`. **Read that doc before any work in `xsd/`.** Feature areas covered there:
 
-- Type system: xs:assert (complex + simpleContent), xs:assertion facet, conditional type assignment (xs:alternative), simpleContent content-type narrowing, attribute inheritance, 1.1 built-in datatypes, simple-type 1.1 edges.
-- Content models: UPA weakening, open content (xs:openContent / xs:defaultOpenContent), xs:all relaxations, wildcard notNamespace/notQName, particle-restriction relaxations, content-model backtracking, Wildcard EDC.
-- Identity constraints: field-node classification/canonicalization, @ref, @xpathDefaultNamespace, structural rules, skip-wildcard scoping.
+- Type system: xs:assert (complex + simpleContent), xs:assertion facet, conditional type assignment (xs:alternative),
+  simpleContent content-type narrowing, attribute inheritance, 1.1 built-in datatypes, simple-type 1.1 edges.
+- Content models: UPA weakening, open content (xs:openContent / xs:defaultOpenContent), xs:all relaxations, wildcard
+  notNamespace/notQName, particle-restriction relaxations, content-model backtracking, Wildcard EDC.
+- Identity constraints: field-node classification/canonicalization, @ref, @xpathDefaultNamespace, structural rules,
+  skip-wildcard scoping.
 - Document-wide walks: xs:ID/IDREF/IDREFS and xs:ENTITY/ENTITIES integrity.
-- Schema composition & representation: xs:override, xsi: attribute references, conditional inclusion (vc:), NCName/QName whitespace collapse, xs:notation, and the many version-INDEPENDENT XML-representation/structural checks.
+- Schema composition & representation: xs:override, xsi: attribute references, conditional inclusion (vc:), NCName/QName
+  whitespace collapse, xs:notation, and the many version-INDEPENDENT XML-representation/structural checks.
 
 Do NOT enforce 1.1-only clauses in the 1.0/default path — 1.0 must stay byte-identical to origin.
 
 ## Schematron — Query Binding
 
-The schematron package accepts ONLY the `queryBinding` values ISO/IEC 19757-3 defines normatively and this package implements, and refuses every other value. An absent attribute or `xslt` resolves to `QueryBindingXPath1` (Annex C's default binding, the `xpath1` engine, byte-identical to libxml2); `xslt3` (2020 Annex J, XSLT 3.0, whose query language is XPath 3.1) and `xpath3` (2020 Annex K, XPath 3.0, which XPath 3.1 is a superset of) resolve to `QueryBindingXPath3` (the `xpath3` engine). Everything else fails compilation with `ErrUnsupportedQueryBinding`: the 2.0 bindings (Annexes H and I) are defined but unimplemented, and `xpath`/`xquery`/`exslt`/`stx` are reserved by clause 6.4's NOTE without any definition, so a schema naming one says nothing about what its expressions mean. Do NOT invent names the standard does not define (`xslt1`, `xpath1`, `xpath31`). Matching is case-insensitive because each annex says "in any mix of upper and lower case letters", and the value is trimmed because the attribute is declared `xsd:token`. `resolveQueryBinding` (`querybinding.go`) resolves in order: a forced `Compiler.QueryBinding()` (always wins, and skips the attribute) → the schema attribute → `Compiler.DefaultQueryBinding(b)` → `QueryBindingXPath1`. The resolved binding is frozen onto the compiled `Schema`.
+The schematron package accepts ONLY the `queryBinding` values ISO/IEC 19757-3 defines normatively and this package
+implements, and refuses every other value. An absent attribute or `xslt` resolves to `QueryBindingXPath1` (Annex C's
+default binding, the `xpath1` engine, byte-identical to libxml2); `xslt3` (2020 Annex J, XSLT 3.0, whose query language
+is XPath 3.1) and `xpath3` (2020 Annex K, XPath 3.0, which XPath 3.1 is a superset of) resolve to `QueryBindingXPath3`
+(the `xpath3` engine). Everything else fails compilation with `ErrUnsupportedQueryBinding`: the 2.0 bindings (Annexes H
+and I) are defined but unimplemented, and `xpath`/`xquery`/`exslt`/`stx` are reserved by clause 6.4's NOTE without any
+definition, so a schema naming one says nothing about what its expressions mean. Do NOT invent names the standard does
+not define (`xslt1`, `xpath1`, `xpath31`). Matching is case-insensitive because each annex says "in any mix of upper and
+lower case letters", and the value is trimmed because the attribute is declared `xsd:token`. `resolveQueryBinding`
+(`querybinding.go`) resolves in order: a forced `Compiler.QueryBinding()` (always wins, and skips the attribute) → the
+schema attribute → `Compiler.DefaultQueryBinding(b)` → `QueryBindingXPath1`. The resolved binding is frozen onto the
+compiled `Schema`.
 
-`engine`/`runner`/`value` (`engine.go`) is the seam the two engines implement, so `parse.go` and `validate.go` never name an XPath package. The `value` methods carry the per-binding semantics: `effectiveBoolean` cannot fail under 1.0 but raises FORG0006 for a multi-item atomic sequence under 3.1 (reported, test treated as false); `stringValue` (`<value-of>`) takes the first node's string-value under 1.0 and space-joins every atomized item under 3.1; `<let>` binds a sequence under 3.1. Rule contexts go through `contextToXPath` in both bindings, so an XSLT match pattern that is not an expression (`key('k','v')`) is unsupported. The 3.1 engine passes no URI resolver and no HTTP client, so `fn:doc`/`fn:collection`/`fn:unparsed-text` retrieve nothing.
+`engine`/`runner`/`value` (`engine.go`) is the seam the two engines implement, so `parse.go` and `validate.go` never
+name an XPath package. The `value` methods carry the per-binding semantics: `effectiveBoolean` cannot fail under 1.0 but
+raises FORG0006 for a multi-item atomic sequence under 3.1 (reported, test treated as false); `stringValue`
+(`<value-of>`) takes the first node's string-value under 1.0 and space-joins every atomized item under 3.1; `<let>`
+binds a sequence under 3.1. Rule contexts go through `contextToXPath` in both bindings, so an XSLT match pattern that is
+not an expression (`key('k','v')`) is unsupported. The 3.1 engine passes no URI resolver and no HTTP client, so
+`fn:doc`/`fn:collection`/`fn:unparsed-text` retrieve nothing.
 
-Both engines build ONE document-order cache per validation run and share it across every expression (`xpath1Runner.docOrder` threaded through `ixpath.WithDocOrderCache`, `xpath3.Evaluator.DocOrderCache`). Without it each evaluation indexes the whole instance again, which makes validation quadratic in document size. Keep the cache per run: a cache outliving the run would go stale against a mutated document.
+Both engines build ONE document-order cache per validation run and share it across every expression
+(`xpath1Runner.docOrder` threaded through `ixpath.WithDocOrderCache`, `xpath3.Evaluator.DocOrderCache`). Without it each
+evaluation indexes the whole instance again, which makes validation quadratic in document size. Keep the cache per run:
+a cache outliving the run would go stale against a mutated document.
 
 Do NOT change the XPath 1.0 path — it must stay byte-identical to libxml2.
 
 ## XSLT 3.0 — Conformance Scope
 
-The xslt3 package targets **Basic XSLT 3.0** conformance (W3C spec Section 27). The spec defines 8 conformance levels; only "Basic XSLT Processor" is required. The remaining 7 are optional features:
+The xslt3 package targets **Basic XSLT 3.0** conformance (W3C spec Section 27). The spec defines 8 conformance levels;
+only "Basic XSLT Processor" is required. The remaining 7 are optional features:
 
 | Feature | Status | Notes |
 |---------|--------|-------|
@@ -53,17 +94,78 @@ The xslt3 package targets **Basic XSLT 3.0** conformance (W3C spec Section 27). 
 | Dynamic Evaluation | Implemented | `xsl:evaluate` |
 | Backwards-Compatible Processing | Implemented | XSLT 1.0 behavior + XPath 1.0 compatibility mode |
 
-Schemas imported via `xsl:import-schema` (and a source-document schema) default to **XSD 1.1** (`compile_schema.go`/`source_schema.go` build the `xsd.Compiler` with `.DefaultVersion(xsd.Version11)`), so a schema silent on version compiles with 1.1 semantics (CTA/xs:alternative, unions, etc.) while an explicit `Compiler.Version()` or a schema `vc:minVersion` hint still wins. xslt3 validates a constructed element/subtree through `schemaRegistry.ValidateDoc` with `xsd.Validator.SkipDatatypeIntegrityChecks(true)`: content/type/CTA validation runs at 1.1 but the XSD 1.1 document-wide xs:ID/IDREF/ENTITY integrity walks are suppressed, because element-level validation (`xsl:validation="strict"` on an LRE) must not enforce whole-document ID uniqueness — xslt3 applies document-scope ID/IDREF integrity itself via `validateDocIDConstraints` at the true document/result-document scope (XTTE1555), matching the W3C validation-16xx semantics.
+Schemas imported via `xsl:import-schema` (and a source-document schema) default to **XSD 1.1**
+(`compile_schema.go`/`source_schema.go` build the `xsd.Compiler` with `.DefaultVersion(xsd.Version11)`), so a schema
+silent on version compiles with 1.1 semantics (CTA/xs:alternative, unions, etc.) while an explicit `Compiler.Version()`
+or a schema `vc:minVersion` hint still wins. xslt3 validates a constructed element/subtree through
+`schemaRegistry.ValidateDoc` with `xsd.Validator.SkipDatatypeIntegrityChecks(true)`: content/type/CTA validation runs at
+1.1 but the XSD 1.1 document-wide xs:ID/IDREF/ENTITY integrity walks are suppressed, because element-level validation
+(`xsl:validation="strict"` on an LRE) must not enforce whole-document ID uniqueness — xslt3 applies document-scope
+ID/IDREF integrity itself via `validateDocIDConstraints` at the true document/result-document scope (XTTE1555), matching
+the W3C validation-16xx semantics.
 
 ## XSLT — Backwards-Compatible Processing
 
-Backwards-compatible processing (XSLT 3.0 §3.10) is enabled per element when its **effective version < 2.0** — the nearest-in-scope `[xsl:]version` (on the element, an ancestor, an included/imported module root, a global variable/param, or a literal result element's `xsl:version`; a `_version` shadow attribute takes precedence over the literal). Effective version in `[2.0, 3.0)` is identical to 3.0, so there is no separate "XSLT 2.0 compatibility" behavior. The one exception is the **`xsl:output` boolean serialization-parameter value space** (`compile_formats.go` `compileOutput`/`serializationYesNoOnly`): Serialization 3.0 widened the boolean parameters (indent, omit-xml-declaration, byte-order-mark, escape-uri-attributes, include-content-type, undeclare-prefixes, allow-duplicate-names, build-tree — and standalone's boolean synonyms) to the full xs:boolean lexical space `{yes, no, true, false, 1, 0}`, but an effective XSLT version below 3.0 (the module's in-scope `c.effectiveVersion`, NOT the xsl:output element's own `@version`, which is the serialization output-version parameter) restricts them to `{yes, no}` (standalone: `{yes, no, omit}`) — any other lexical form, including `true`/`false`/`1`/`0`, is an SEPM0016 static error (W3C output-0197/0198/0199/0280/0281/0282/0283, all `version="2.0"`). Uppercase forms (`TRUE`/`YES`) are invalid in every version (xs:boolean is lowercase-only). An absent/unparseable version defaults to 3.0 (permissive).
+Backwards-compatible processing (XSLT 3.0 §3.10) is enabled per element when its **effective version < 2.0** — the
+nearest-in-scope `[xsl:]version` (on the element, an ancestor, an included/imported module root, a global
+variable/param, or a literal result element's `xsl:version`; a `_version` shadow attribute takes precedence over the
+literal). Effective version in `[2.0, 3.0)` is identical to 3.0, so there is no separate "XSLT 2.0 compatibility"
+behavior. The one exception is the **`xsl:output` boolean serialization-parameter value space** (`compile_formats.go`
+`compileOutput`/`serializationYesNoOnly`): Serialization 3.0 widened the boolean parameters (indent,
+omit-xml-declaration, byte-order-mark, escape-uri-attributes, include-content-type, undeclare-prefixes,
+allow-duplicate-names, build-tree — and standalone's boolean synonyms) to the full xs:boolean lexical space `{yes, no,
+true, false, 1, 0}`, but an effective XSLT version below 3.0 (the module's in-scope `c.effectiveVersion`, NOT the
+xsl:output element's own `@version`, which is the serialization output-version parameter) restricts them to `{yes, no}`
+(standalone: `{yes, no, omit}`) — any other lexical form, including `true`/`false`/`1`/`0`, is an SEPM0016 static error
+(W3C output-0197/0198/0199/0280/0281/0282/0283, all `version="2.0"`). Uppercase forms (`TRUE`/`YES`) are invalid in
+every version (xs:boolean is lowercase-only). An absent/unparseable version defaults to 3.0 (permissive).
 
-The core is **XPath 1.0 compatibility mode**, a runtime flag on the xpath3 evaluator (`Evaluator.XPath10Compat()`, default off, so xsd/relaxng/schematron and ordinary xpath3/xslt3 are unchanged). xslt3 records every expression compiled under an effective version < 2.0 by pointer identity (`Stylesheet.compatExprs`, set in `compiler.compileXPath`) and evaluates it in compat mode (`execContext.evalXPath`/`withCompat`). XPath 1.0 mode (`internal xpath10_compat.go`): a single-item function parameter given >1 items keeps only the first; an `xs:string(?)` parameter coerces via `fn:string` and an `xs:double(?)`/`xs:numeric` parameter via `fn:number` (invalid/empty → NaN); arithmetic operands convert to `xs:double` (÷0 → ±INF); general comparisons apply the 1.0 boolean/numeric/string rules, and the relational operators (`<`,`<=`,`>`,`>=`) always convert both operands to number. Functions/operators that bypass signature coercion (`format-number` value+picture, `subsequence` position/length, `string-join` separator, `fn:number`-family node args, the `to` range operator) consult the flag directly. Runtime-compiled expressions not in `compatExprs` are covered by a context flag instead: match-pattern predicates (`execContext.patternCompat`, set from `pattern.compat` at the match entry, honored in `evalXPath` and the predicate evaluators) and `xsl:evaluate`'s dynamic expression (compat when its static `xpath` attribute is compat-marked). Backwards-compatible processing is NOT applied to the compile-time static context — `use-when`, `static="yes"` variables/params, and shadow attributes are evaluated version-independently.
+The core is **XPath 1.0 compatibility mode**, a runtime flag on the xpath3 evaluator (`Evaluator.XPath10Compat()`,
+default off, so xsd/relaxng/schematron and ordinary xpath3/xslt3 are unchanged). xslt3 records every expression compiled
+under an effective version < 2.0 by pointer identity (`Stylesheet.compatExprs`, set in `compiler.compileXPath`) and
+evaluates it in compat mode (`execContext.evalXPath`/`withCompat`). XPath 1.0 mode (`internal xpath10_compat.go`): a
+single-item function parameter given >1 items keeps only the first; an `xs:string(?)` parameter coerces via `fn:string`
+and an `xs:double(?)`/`xs:numeric` parameter via `fn:number` (invalid/empty → NaN); arithmetic operands convert to
+`xs:double` (÷0 → ±INF); general comparisons apply the 1.0 boolean/numeric/string rules, and the relational operators
+(`<`,`<=`,`>`,`>=`) always convert both operands to number. Functions/operators that bypass signature coercion
+(`format-number` value+picture, `subsequence` position/length, `string-join` separator, `fn:number`-family node args,
+the `to` range operator) consult the flag directly. Runtime-compiled expressions not in `compatExprs` are covered by a
+context flag instead: match-pattern predicates (`execContext.patternCompat`, set from `pattern.compat` at the match
+entry, honored in `evalXPath` and the predicate evaluators) and `xsl:evaluate`'s dynamic expression (compat when its
+static `xpath` attribute is compat-marked). Backwards-compatible processing is NOT applied to the compile-time static
+context — `use-when`, `static="yes"` variables/params, and shadow attributes are evaluated version-independently.
 
-XSLT-level 1.0 behaviors (keyed off the compat-marked expression or an instruction `Compat` flag): `xsl:value-of` and AVTs discard all but the first item; `xsl:number/@value` uses the first atom and outputs `"NaN"` for an empty or non-integer value (no XTDE0980); `xsl:sort` uses the first sort-key item; `xsl:call-template` silently ignores a surplus `with-param` (no XTSE0680); `xsl:key`/`key()` compare values as `xs:string`; `system-property('xsl:supports-backwards-compatibility')` is `"yes"`. Known gaps (skipped in `expectations/xslt30.json` with specific reasons): the 1.0-only default output method (xhtml→xml for an implicit 1.0 result tree); `base-uri()` fixture dependence; and XPath **1.0 grammar** differences (`div`/`mod` as a name after an operator, unprefixed `function` as a name test, empty function arguments) — compat mode changes semantics, not the grammar, so these stay out of scope.
+XSLT-level 1.0 behaviors (keyed off the compat-marked expression or an instruction `Compat` flag): `xsl:value-of` and
+AVTs discard all but the first item; `xsl:number/@value` uses the first atom and outputs `"NaN"` for an empty or
+non-integer value (no XTDE0980); `xsl:sort` uses the first sort-key item; `xsl:call-template` silently ignores a surplus
+`with-param` (no XTSE0680); `xsl:key`/`key()` compare values as `xs:string`;
+`system-property('xsl:supports-backwards-compatibility')` is `"yes"`. Known gaps (skipped in `expectations/xslt30.json`
+with specific reasons): the 1.0-only default output method (xhtml→xml for an implicit 1.0 result tree); `base-uri()`
+fixture dependence; and XPath **1.0 grammar** differences (`div`/`mod` as a name after an operator, unprefixed
+`function` as a name test, empty function arguments) — compat mode changes semantics, not the grammar, so these stay out
+of scope.
 
-The `spec="XSLT20"`/`spec="XSLT10"` version-specific test bucket (~1120 cases) is **in scope** and un-gated: `specSupported` in the helium-w3c-tests generator treats `XSLT10`/`XSLT20` like their `+` forms, so a conformant 3.0 processor runs them. ~1015 pass as-is, plus 7 more from version-gating the `xsl:output` boolean serialization parameters (below). The ~80 remaining are documented per-case in the `w3cImplicitSkips` map (helium-w3c-tests `xslt3/w3c_helpers_test.go`), overwhelmingly as **legitimate 2.0-vs-3.0 divergences** where our 3.0 output is correct and the case asserts a 2.0-only error a 3.0 processor no longer raises: 3.0-only regex constructs the 2.0 test expects to reject with FORX0002; match/error pattern-syntax relaxations that dropped XTSE0340; `xsl:sequence` with a contained sequence constructor, no longer XTSE0010; functions/arities added in 3.0/XPath 3.1, no longer XPST0017; `apply-templates`/`for-each` `select` required-type errors XTTE0520/XTTE1120, both removed in 3.0 (a non-node population is handled by the atomic built-in template rule / never matches a pattern); initial-entry conflict errors XTDE0047/XTDE0060, removed in 3.0 (W3C bug 28418); `current-group()`/`current-grouping-key()` outside a grouping context, which 3.0 makes a dynamic error XTDE1061/XTDE1071 where 2.0 gave the empty sequence; and a conflicting `xsl:strip-space`/`xsl:preserve-space` at equal precedence/priority, a RECOVERABLE error in 1.0/2.0 but a STATIC error `XTSE0270` in 3.0 (helium correctly raises `XTSE0270` via `compile_formats.go` `checkSpaceConflicts`; the 3.0 counterpart `strip-space-019a` passes); and `format-date`/`format-time` fractional-second handling, where XPath 3.1 truncates but the 2.0 case asserts rounding (the 3.0+ variant passes). **The genuine-gaps list is now essentially empty**: every residual skip in the XSLT20/XSLT10 bucket is a legitimate 2.0-vs-3.0 divergence (a correct-skip where our 3.0 output is right), not a missing mandatory Basic 3.0 facility. `xsl:output` boolean serialization parameters are version-gated (`compile_formats.go` `serializationYesNoOnly`): under an effective XSLT version < 3.0 they accept only `yes`/`no` (raising SEPM0016 otherwise, per Serialization 1.0), while 3.0 keeps the full `xs:boolean` value space. Do NOT implement XSLT 1.0/2.0 **syntax** support — compat mode changes semantics, not the grammar.
+The `spec="XSLT20"`/`spec="XSLT10"` version-specific test bucket (~1120 cases) is **in scope** and un-gated:
+`specSupported` in the helium-w3c-tests generator treats `XSLT10`/`XSLT20` like their `+` forms, so a conformant 3.0
+processor runs them. ~1015 pass as-is, plus 7 more from version-gating the `xsl:output` boolean serialization parameters
+(below). The ~80 remaining are documented per-case in the `w3cImplicitSkips` map (helium-w3c-tests
+`xslt3/w3c_helpers_test.go`), overwhelmingly as **legitimate 2.0-vs-3.0 divergences** where our 3.0 output is correct
+and the case asserts a 2.0-only error a 3.0 processor no longer raises: 3.0-only regex constructs the 2.0 test expects
+to reject with FORX0002; match/error pattern-syntax relaxations that dropped XTSE0340; `xsl:sequence` with a contained
+sequence constructor, no longer XTSE0010; functions/arities added in 3.0/XPath 3.1, no longer XPST0017;
+`apply-templates`/`for-each` `select` required-type errors XTTE0520/XTTE1120, both removed in 3.0 (a non-node population
+is handled by the atomic built-in template rule / never matches a pattern); initial-entry conflict errors
+XTDE0047/XTDE0060, removed in 3.0 (W3C bug 28418); `current-group()`/`current-grouping-key()` outside a grouping
+context, which 3.0 makes a dynamic error XTDE1061/XTDE1071 where 2.0 gave the empty sequence; and a conflicting
+`xsl:strip-space`/`xsl:preserve-space` at equal precedence/priority, a RECOVERABLE error in 1.0/2.0 but a STATIC error
+`XTSE0270` in 3.0 (helium correctly raises `XTSE0270` via `compile_formats.go` `checkSpaceConflicts`; the 3.0
+counterpart `strip-space-019a` passes); and `format-date`/`format-time` fractional-second handling, where XPath 3.1
+truncates but the 2.0 case asserts rounding (the 3.0+ variant passes). **The genuine-gaps list is now essentially
+empty**: every residual skip in the XSLT20/XSLT10 bucket is a legitimate 2.0-vs-3.0 divergence (a correct-skip where our
+3.0 output is right), not a missing mandatory Basic 3.0 facility. `xsl:output` boolean serialization parameters are
+version-gated (`compile_formats.go` `serializationYesNoOnly`): under an effective XSLT version < 3.0 they accept only
+`yes`/`no` (raising SEPM0016 otherwise, per Serialization 1.0), while 3.0 keeps the full `xs:boolean` value space. Do
+NOT implement XSLT 1.0/2.0 **syntax** support — compat mode changes semantics, not the grammar.
 
 ## Generated Files
 
@@ -108,7 +210,13 @@ These docs cache repository state. Still read source before modifying code.
 
 1. When your changes affect a doc below, update it in the same commit.
 2. If you notice any doc is wrong or stale — even on an unrelated task — fix it immediately.
-3. **Write current state, not history.** These are caches of what the code *is*, not a changelog of how it got there. State what the code does now; never append "was X, now Y", "no longer / previously / used to", "the regression where…", "fixes #NNN", "round-N", or resolved "KNOWN RESIDUAL / deferred" notes — that framing rots into staleness the moment the state changes. When you fix a gap, delete its gap note (don't rewrite it to "now fixed"); when you change behavior, describe the new behavior in the present tense. Keep design rationale (spec citations, version-gating / byte-identical constraints, genuine *current* gaps) — that is current state; the journey belongs in git history.
+3. **Write current state, not history.** These are caches of what the code *is*, not a changelog of how it got there.
+   State what the code does now; never append "was X, now Y", "no longer / previously / used to", "the regression
+   where…", "fixes #NNN", "round-N", or resolved "KNOWN RESIDUAL / deferred" notes — that framing rots into staleness
+   the moment the state changes. When you fix a gap, delete its gap note (don't rewrite it to "now fixed"); when you
+   change behavior, describe the new behavior in the present tense. Keep design rationale (spec citations,
+   version-gating / byte-identical constraints, genuine *current* gaps) — that is current state; the journey belongs in
+   git history.
 
 | Doc | Update trigger |
 |-----|----------------|

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # helium
 
 [![CI](https://github.com/lestrrat-go/helium/actions/workflows/ci.yml/badge.svg)](https://github.com/lestrrat-go/helium/actions/workflows/ci.yml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/lestrrat-go/helium.svg)](https://pkg.go.dev/github.com/lestrrat-go/helium)
+[![Go
+Reference](https://pkg.go.dev/badge/github.com/lestrrat-go/helium.svg)](https://pkg.go.dev/github.com/lestrrat-go/helium)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/lestrrat-go/helium)
 
 Helium is a fast XML toolkit for Go covering XML parsing, SAX2-style streaming,
@@ -59,7 +60,8 @@ func Example_helium_parse() {
   // <root><child>hello</child></root>
 }
 ```
-source: [examples/helium_parse_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/helium_parse_example_test.go)
+source:
+[examples/helium_parse_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/helium_parse_example_test.go)
 <!-- END INCLUDE -->
 
 # Packages
@@ -223,7 +225,8 @@ stdlib token benchmark on all three corpora, it now edges past libxml2 on the
 medium corpus, and it is clearly ahead on the largest corpus.
 
 Benchmarks parse real-world XML files of varying sizes (AMD Ryzen 9 7900X3D,
-Go 1.26.1, `go test -run '^$' -bench 'Benchmark(HeliumParse|StdlibXMLDecode|Libxml2Parse)$' -benchmem -count=5 -tags libxml2bench ./bench`,
+Go 1.26.1, `go test -run '^$' -bench 'Benchmark(HeliumParse|StdlibXMLDecode|Libxml2Parse)$' -benchmem -count=5 -tags
+libxml2bench ./bench`,
 median shown):
 
 | File | Helium | `encoding/xml` | libxml2 (cgo) |
@@ -246,10 +249,14 @@ go test -tags cgo,libxml2bench -bench=. -benchmem ./bench/
 
 # Current status
 
-* **Implemented:** XML/HTML parsing, DOM building, SAX2, XPath 1.0, XPath 3.1, Basic XSLT 3.0, XInclude, C14N, RELAX NG, Schematron, XSD, XML Catalog, streaming XML writer, and `encoding/xml` compatibility (`shim` package).
-* **Scoped production support:** W3C XML Digital Signatures 1.1 (`xmldsig1`) for explicit same-document verification profiles. External references and XSLT are opt-in advanced features with caller-owned resource and execution policy.
-* **Scoped production support:** W3C XML Encryption 1.1 (`xmlenc1`) with a documented security exception for retired cryptography. Triple DES is refused, so block encryption and key wrapping are AES only.
-* **CLI:** the `helium` command provides `lint`, `xpath`, `xslt`, `xsd validate`, `relaxng validate`, and `schematron validate` subcommands.
+* **Implemented:** XML/HTML parsing, DOM building, SAX2, XPath 1.0, XPath 3.1, Basic XSLT 3.0, XInclude, C14N, RELAX NG,
+  Schematron, XSD, XML Catalog, streaming XML writer, and `encoding/xml` compatibility (`shim` package).
+* **Scoped production support:** W3C XML Digital Signatures 1.1 (`xmldsig1`) for explicit same-document verification
+  profiles. External references and XSLT are opt-in advanced features with caller-owned resource and execution policy.
+* **Scoped production support:** W3C XML Encryption 1.1 (`xmlenc1`) with a documented security exception for retired
+  cryptography. Triple DES is refused, so block encryption and key wrapping are AES only.
+* **CLI:** the `helium` command provides `lint`, `xpath`, `xslt`, `xsd validate`, `relaxng validate`, and `schematron
+  validate` subcommands.
 
 Some edge cases and parity gaps are still being iterated on; contributions and issue reports are welcome.
 
@@ -280,7 +287,9 @@ expected-failure (documented known gap) breakdowns where applicable.
 
 ## Scope
 
-XSLT support is intentionally scoped to Basic XSLT 3.0. Backwards-compatible processing (XSLT 1.0 semantics + XPath 1.0 compatibility mode, enabled per element when the effective version is below 2.0) is implemented and in scope; only XSLT 1.0/2.0 *syntax* support is out of scope.
+XSLT support is intentionally scoped to Basic XSLT 3.0. Backwards-compatible processing (XSLT 1.0 semantics + XPath 1.0
+compatibility mode, enabled per element when the effective version is below 2.0) is implemented and in scope; only XSLT
+1.0/2.0 *syntax* support is out of scope.
 
 # For coding agents
 
@@ -319,7 +328,8 @@ please open a GitHub Discussion first.
 
 If this project is useful to you or your company, please consider sponsoring:
 
-[![Sponsor lestrrat](https://img.shields.io/badge/Sponsor-lestrrat-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/lestrrat)
+[![Sponsor
+lestrrat](https://img.shields.io/badge/Sponsor-lestrrat-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/lestrrat)
 
 Sponsorship funds continued maintenance, conformance work, and support for the
 people who rely on this library. Both individual and corporate sponsorships are

--- a/c14n/README.md
+++ b/c14n/README.md
@@ -47,5 +47,6 @@ func Example_c14n_canonicalize() {
   // <root a="1" b="2"><child></child></root>
 }
 ```
-source: [examples/c14n_canonicalize_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/c14n_canonicalize_example_test.go)
+source:
+[examples/c14n_canonicalize_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/c14n_canonicalize_example_test.go)
 <!-- END INCLUDE -->

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -74,5 +74,6 @@ func Example_catalog_load() {
   // unknown: ""
 }
 ```
-source: [examples/catalog_load_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/catalog_load_example_test.go)
+source:
+[examples/catalog_load_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/catalog_load_example_test.go)
 <!-- END INCLUDE -->

--- a/html/README.md
+++ b/html/README.md
@@ -43,5 +43,6 @@ func Example_html_parse() {
   // Hello
 }
 ```
-source: [examples/html_parse_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/html_parse_example_test.go)
+source:
+[examples/html_parse_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/html_parse_example_test.go)
 <!-- END INCLUDE -->

--- a/relaxng/README.md
+++ b/relaxng/README.md
@@ -57,7 +57,8 @@ func Example_relaxng_validate() {
   // Output:
 }
 ```
-source: [examples/relaxng_validate_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/relaxng_validate_example_test.go)
+source:
+[examples/relaxng_validate_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/relaxng_validate_example_test.go)
 <!-- END INCLUDE -->
 
 ## Loading external schemas (`include` / `externalRef`)

--- a/sax/README.md
+++ b/sax/README.md
@@ -69,5 +69,6 @@ func Example_sax_parse() {
   // </library>
 }
 ```
-source: [examples/sax_parse_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/sax_parse_example_test.go)
+source:
+[examples/sax_parse_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/sax_parse_example_test.go)
 <!-- END INCLUDE -->

--- a/schematron/README.md
+++ b/schematron/README.md
@@ -57,7 +57,8 @@ func Example_schematron_validate() {
   // Output:
 }
 ```
-source: [examples/schematron_validate_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/schematron_validate_example_test.go)
+source:
+[examples/schematron_validate_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/schematron_validate_example_test.go)
 <!-- END INCLUDE -->
 
 ## Query language bindings
@@ -171,5 +172,6 @@ func Example_schematron_query_binding() {
   // schematron: unsupported query language binding "xslt2" (supported: xslt, xslt3, xpath3)
 }
 ```
-source: [examples/schematron_query_binding_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/schematron_query_binding_example_test.go)
+source:
+[examples/schematron_query_binding_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/schematron_query_binding_example_test.go)
 <!-- END INCLUDE -->

--- a/shim/README.md
+++ b/shim/README.md
@@ -40,7 +40,8 @@ func Example_shim_marshal() {
   // <person><name>Alice</name><age>30</age></person>
 }
 ```
-source: [examples/shim_marshal_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/shim_marshal_example_test.go)
+source:
+[examples/shim_marshal_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/shim_marshal_example_test.go)
 <!-- END INCLUDE -->
 
 ## Notes

--- a/stream/README.md
+++ b/stream/README.md
@@ -63,5 +63,6 @@ func Example_stream_basic() {
   // <greeting>hello world</greeting>
 }
 ```
-source: [examples/stream_basic_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/stream_basic_example_test.go)
+source:
+[examples/stream_basic_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/stream_basic_example_test.go)
 <!-- END INCLUDE -->

--- a/xinclude/README.md
+++ b/xinclude/README.md
@@ -155,7 +155,8 @@ func Example_xinclude_process() {
   // </doc>
 }
 ```
-source: [examples/xinclude_process_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xinclude_process_example_test.go)
+source:
+[examples/xinclude_process_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xinclude_process_example_test.go)
 <!-- END INCLUDE -->
 
 ## Options

--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -85,7 +85,8 @@ func Example_xmldsig1_sign_verify() {
   // signature valid
 }
 ```
-source: [examples/xmldsig1_sign_verify_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xmldsig1_sign_verify_example_test.go)
+source:
+[examples/xmldsig1_sign_verify_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xmldsig1_sign_verify_example_test.go)
 <!-- END INCLUDE -->
 
 ## Reference processing
@@ -435,7 +436,8 @@ func Example_xmldsig1_sha1_optin() {
   // legacy SHA-1 signature valid
 }
 ```
-source: [examples/xmldsig1_sha1_optin_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xmldsig1_sha1_optin_example_test.go)
+source:
+[examples/xmldsig1_sha1_optin_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xmldsig1_sha1_optin_example_test.go)
 <!-- END INCLUDE -->
 
 > **Note (breaking default change):** earlier versions accepted SHA-1

--- a/xmldsig1/transforms_nodeset_internal_test.go
+++ b/xmldsig1/transforms_nodeset_internal_test.go
@@ -503,8 +503,9 @@ var deadlineOverrunBudget = ctxPollInterval*10*time.Microsecond + deadlineClockS
 // deadline pass until the next tick, and time.Since quantizes the elapsed
 // reading at that same tick, so two ticks — about 31 ms — is what the platform
 // can charge on its own. A budget under one tick measures the interrupt period
-// and not the collector, and no amount of promptness can meet it. Thirty-two
-// milliseconds covers both ticks.
+// and not the collector, and no amount of promptness can meet it. Forty
+// milliseconds covers both ticks and ordinary scheduler handoff on hosted
+// Windows runners.
 //
 // Everywhere else the monotonic clock is nanosecond-resolution
 // (clock_gettime, mach_absolute_time) and the runtime wakes off epoll or
@@ -513,7 +514,7 @@ var deadlineOverrunBudget = ctxPollInterval*10*time.Microsecond + deadlineClockS
 // scheduler noise and nothing else.
 func deadlineClockSlack() time.Duration {
 	if runtime.GOOS == "windows" {
-		return 32 * time.Millisecond
+		return 40 * time.Millisecond
 	}
 	return 10 * time.Millisecond
 }

--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -474,7 +474,8 @@ one without `AllowUnauthenticatedCBC(true)` with `ErrCBCRequiresOptIn`,
 whatever its `ds:KeyInfo` holds. It does not arise at all when the caller
 supplies the key as a pre-shared `SessionKey`, whose early return precedes key
 resolution;
-`xenc:CarriedKeyName` (§3.5.1), which the parse steps over unread; and `xenc:EncryptionProperties` (§3.7), which is advisory metadata.
+`xenc:CarriedKeyName` (§3.5.1), which the parse steps over unread; and `xenc:EncryptionProperties` (§3.7), which is
+advisory metadata.
 
 ## Choosing how the session key is protected
 
@@ -601,7 +602,8 @@ func Example_xmlenc1_encrypt_decrypt() {
   // true
 }
 ```
-source: [examples/xmlenc1_encrypt_decrypt_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xmlenc1_encrypt_decrypt_example_test.go)
+source:
+[examples/xmlenc1_encrypt_decrypt_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xmlenc1_encrypt_decrypt_example_test.go)
 <!-- END INCLUDE -->
 
 ## W3C interop conformance

--- a/xpath1/README.md
+++ b/xpath1/README.md
@@ -46,5 +46,6 @@ func Example_xpath_find() {
   //   book: XML
 }
 ```
-source: [examples/xpath_find_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xpath_find_example_test.go)
+source:
+[examples/xpath_find_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xpath_find_example_test.go)
 <!-- END INCLUDE -->

--- a/xpath3/README.md
+++ b/xpath3/README.md
@@ -102,5 +102,6 @@ func Example_xpath3_find() {
   //   book: XML
 }
 ```
-source: [examples/xpath3_find_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xpath3_find_example_test.go)
+source:
+[examples/xpath3_find_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xpath3_find_example_test.go)
 <!-- END INCLUDE -->

--- a/xpointer/README.md
+++ b/xpointer/README.md
@@ -45,5 +45,6 @@ func Example_xpointer_evaluate() {
   // section: second
 }
 ```
-source: [examples/xpointer_evaluate_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xpointer_evaluate_example_test.go)
+source:
+[examples/xpointer_evaluate_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xpointer_evaluate_example_test.go)
 <!-- END INCLUDE -->

--- a/xsd/README.md
+++ b/xsd/README.md
@@ -106,5 +106,6 @@ func Example_xsd_validate() {
   // Output:
 }
 ```
-source: [examples/xsd_validate_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xsd_validate_example_test.go)
+source:
+[examples/xsd_validate_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xsd_validate_example_test.go)
 <!-- END INCLUDE -->

--- a/xslt3/README.md
+++ b/xslt3/README.md
@@ -61,7 +61,8 @@ func Example_xslt3_transform_string() {
   // <?xml version="1.0" encoding="UTF-8"?><greeting>Hello, World!</greeting>
 }
 ```
-source: [examples/xslt3_transform_string_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xslt3_transform_string_example_test.go)
+source:
+[examples/xslt3_transform_string_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xslt3_transform_string_example_test.go)
 <!-- END INCLUDE -->
 
 ## Security
@@ -340,7 +341,8 @@ var (
   errOutputTooLarge = errors.New("output exceeds maximum allowed size")
 )
 ```
-source: [examples/xslt3_untrusted_service_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xslt3_untrusted_service_example_test.go)
+source:
+[examples/xslt3_untrusted_service_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xslt3_untrusted_service_example_test.go)
 <!-- END INCLUDE -->
 
 ## Conformance


### PR DESCRIPTION
- Keep repository documentation readable at narrow line lengths.
- Make maintenance guidance easier to review and update.
