### PR TITLE
fix interleave matching for composite branches

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -1878,9 +1878,9 @@ Pattern-matching engine with backtracking:
    - **Attribute**: match against instance attrs
    - **Group**: sequential with backtracking
    - **Choice**: try alternatives, prefer branches making progress
-   - **Interleave**: unordered member-by-member matching; a repeatable member-group (zeroOrMore/oneOrMore of group)
-     restarts its members each iteration so a sibling branch can consume elements between group members across
-     iterations
+   - **Interleave**: unordered member-by-member matching over an expanded branch list (see Interleave Branch
+     Expansion); a repeatable member-group (zeroOrMore/oneOrMore of group) restarts its members each iteration so a
+     sibling branch can consume elements between group members across iterations
    - **ZeroOrMore/OneOrMore/Optional**: repetition with suppressed errors
    - **Ref/ParentRef**: follow the compile-time-resolved `pattern.resolved` scoped pointer and recurse (no by-name
      lookup)
@@ -1888,6 +1888,53 @@ Pattern-matching engine with backtracking:
    - **List**: split text, validate items
 3. Element validation: match name, validate attrs, build child list (skip non-content: EntityRef/PI/Comment), validate
    content, check all attrs+content consumed
+
+### Interleave Branch Expansion (`validateInterleaveContent` / `expandInterleaveBranches`)
+
+RELAX NG lets each interleave branch's members appear anywhere among the other branches' members, so a branch whose
+content is a **composite** — a group or interleave of more than one member — must be matched member-by-member rather
+than atomically, or its members would have to be contiguous in the document. `interleaveMatch`'s `groupStates`
+machinery does that member-by-member tracking, but only for a branch that `resolveToGroup` reaches (a `<group>`, or a
+`zeroOrMore`/`oneOrMore` wrapping one). Two spec identities bring every other composite shape into that same form, and
+`expandInterleaveBranches` applies both to enumerate candidate branch lists:
+
+- **Associativity** — `interleave(interleave(a, b), c)` accepts exactly what `interleave(a, b, c)` accepts, so
+  `flattenInterleaveBranches`/`appendInterleaveBranch` splice a nested interleave (through `<ref>`, via
+  `resolveToInterleave`) into its parent's branch list.
+- **Distributivity over choice** — `interleave(P, choice(Q1, Q2))` accepts exactly what
+  `choice(interleave(P, Q1), interleave(P, Q2))` accepts, and `optional(Q)` is `choice(Q, empty)`, so
+  `interleaveBranchAlternatives` replaces such a branch by each of its arms in turn (`interleaveEmptyBranch` is the
+  singleton absent arm; it is a singleton because branch identity is part of the group-memoization key).
+
+A branch is expanded ONLY when at least one alternative is composite (`isCompositeBranch`). A single-element
+alternative already matches atomically, so an interleave over many `optional(element)` branches — the common shape —
+contributes no factor of two each and is matched on its own unexpanded branch list. When nothing expands, the single
+candidate IS `pat.children` and the path reduces to one `interleaveMatch` call, so any grammar without a composite
+branch is matched exactly as it would be without expansion (verified by
+`relaxng/group_backtrack_differential_test.go`: byte-identical verdicts and error text across the golden
+cross-product and 20000 random grammars).
+
+`maxInterleaveExpansions` (256 candidate lists) and `maxInterleaveExpandDepth` (12 levels) bound the enumeration;
+exhausting the budget falls back to matching the unexpanded list, which keeps validation linear in the grammar at the
+cost of rejecting some documents that interleave a composite branch's members with its siblings.
+
+**Candidate selection.** An interleave reports success as soon as its required branches are satisfied — it does NOT
+require the content to be exhausted, because the caller may have further patterns to apply. A candidate whose branches
+are all nullable (a choice arm of nothing but optionals) therefore succeeds while consuming nothing, and would shadow
+the arm that actually describes the content if arms were taken in grammar order. `validateInterleaveContent` takes the
+first candidate that leaves nothing unconsumed, and otherwise keeps the closest fit (fewest remaining nodes).
+
+**Completion of a partial member-group.** A member-group that stops mid-iteration with a non-nullable remaining member
+is incomplete content — `zeroOrMore(group(a, b))` fed an unpaired trailing `a`, or `group(a, b)` fed only `a`. The
+consumed/nullable check cannot catch it, because the group DID consume its earlier members and so counts as consumed;
+`interleaveMatch` checks every `groupStates` entry left with `0 < pos < len(members)` instead.
+
+**Diagnostics.** A branch that matches the head element by NAME but fails on its own content appends definitive errors
+(`validateElement` clears suppression once it has consumed the element), and the other branches are then unconsumed
+only because that branch blocked the sequence. `interleaveMatch` keeps those errors (`captureBlocked`, retaining the
+attempt that got furthest) and reports them in place of `Expecting an element X, got nothing` for a branch the document
+never reaches. A branch that simply does not match by name appends nothing (`elementMatchesWithErrors` returns false
+silently on a name mismatch), so only genuine inner failures are captured.
 
 ### Backtracking Strategy (`backtrackGroupFlexible` / `backtrackGroupNaive`)
 

--- a/relaxng/interleave_split_test.go
+++ b/relaxng/interleave_split_test.go
@@ -1,0 +1,208 @@
+package relaxng_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInterleaveSplitCompositeBranch covers an <interleave> branch whose content
+// is a COMPOSITE — a nested interleave, or a choice/optional over a group or
+// interleave. RELAX NG lets each branch's members appear anywhere among the
+// other branches' members, so such a branch's members need not be contiguous in
+// the document.
+//
+// The matcher reaches those documents through two spec identities (see
+// validateInterleaveContent): interleave is associative, so a nested interleave
+// is spliced into its parent, and interleave distributes over choice — with
+// optional(Q) being choice(Q, empty) — so a choice branch is tried arm by arm.
+// Only a bare <group> branch used to support splitting, which rejected valid
+// documents for every other composite shape.
+func TestInterleaveSplitCompositeBranch(t *testing.T) {
+	t.Parallel()
+
+	a := benchElementA
+	b := `<element name="b"><empty/></element>`
+	s := `<element name="s"><empty/></element>`
+	content := func(branch string) string {
+		return `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start>` +
+			`<element name="r"><interleave>` + branch + s + `</interleave></element></start></grammar>`
+	}
+	grp := func(p ...string) string { return `<group>` + strings.Join(p, "") + `</group>` }
+	ilv := func(p ...string) string { return `<interleave>` + strings.Join(p, "") + `</interleave>` }
+	opt := func(p string) string { return `<optional>` + p + `</optional>` }
+	cho := func(p ...string) string { return `<choice>` + strings.Join(p, "") + `</choice>` }
+	zz := func(p string) string { return `<zeroOrMore>` + p + `</zeroOrMore>` }
+
+	// split places s between a and b, so the branch's two members are not
+	// adjacent in the document.
+	const split = `<r><a/><s/><b/></r>`
+
+	cases := []struct {
+		name   string
+		schema string
+		doc    string
+		valid  bool
+	}{
+		{"group split", content(grp(a, b)), split, true},
+		{"zeroOrMore group split", content(zz(grp(a, b))), split, true},
+		{"nested interleave split", content(ilv(a, b)), split, true},
+		{"optional group split", content(opt(grp(a, b))), split, true},
+		{"optional interleave split", content(opt(ilv(a, b))), split, true},
+		{"choice of group split", content(cho(grp(a, b))), split, true},
+		{"choice of interleave split", content(cho(ilv(a, b))), split, true},
+		{"choice group-or-element split", content(cho(grp(a, b), a)), split, true},
+
+		// The same shapes must still reject what the grammar does not allow.
+		{"nested interleave missing member", content(ilv(a, b)), `<r><a/><s/></r>`, false},
+		{"nested interleave undeclared element", content(ilv(a, b)), `<r><a/><s/><b/><c/></r>`, false},
+		{"nested interleave duplicate member", content(ilv(a, b)), `<r><a/><s/><b/><a/></r>`, false},
+		{"nested interleave missing sibling", content(ilv(a, b)), `<r><a/><b/></r>`, false},
+
+		// optional(composite) is all-or-nothing: absent is fine, half is not.
+		{"optional group absent", content(opt(grp(a, b))), `<r><s/></r>`, true},
+		{"optional group half rejects", content(opt(grp(a, b))), `<r><a/><s/></r>`, false},
+		{"optional interleave absent", content(opt(ilv(a, b))), `<r><s/></r>`, true},
+		{"optional interleave half rejects", content(opt(ilv(a, b))), `<r><b/><s/></r>`, false},
+
+		// A bare group branch is likewise all-or-nothing.
+		{"group half rejects", content(grp(a, b)), `<r><a/><s/></r>`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			grammar := compileGrammar(t, tc.schema)
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.doc))
+			require.NoError(t, err)
+			verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+			if tc.valid {
+				require.NoError(t, verr, "%s should validate", tc.name)
+				return
+			}
+			require.Error(t, verr, "%s should be rejected", tc.name)
+		})
+	}
+}
+
+// TestInterleaveChoiceArmPrefersConsuming pins the arm-selection rule in
+// validateInterleaveContent. An interleave signals success as soon as its
+// required branches are satisfied — it does NOT require the content to be
+// exhausted, since the caller may have further patterns to apply. So a choice
+// arm made up entirely of optionals succeeds while consuming nothing, and would
+// shadow the arm that actually describes the content if arms were taken in
+// grammar order. The candidate that consumes the most content must win.
+func TestInterleaveChoiceArmPrefersConsuming(t *testing.T) {
+	t.Parallel()
+
+	// allOptional comes FIRST in the choice and matches the empty sequence, so
+	// taking arms in order would accept it and strand <x/> and <y/>.
+	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start>` +
+		`<element name="r"><interleave>` +
+		`<element name="keep"><empty/></element>` +
+		`<choice>` +
+		`<interleave><optional><element name="p"><empty/></element></optional>` +
+		`<optional><element name="q"><empty/></element></optional></interleave>` +
+		`<interleave><element name="x"><empty/></element><element name="y"><empty/></element></interleave>` +
+		`</choice>` +
+		`</interleave></element></start></grammar>`
+
+	cases := []struct {
+		name  string
+		doc   string
+		valid bool
+	}{
+		{"consuming arm wins over vacuous arm", `<r><x/><keep/><y/></r>`, true},
+		{"vacuous arm still matches its own content", `<r><keep/><p/></r>`, true},
+		{"vacuous arm with nothing to consume", `<r><keep/></r>`, true},
+		{"partial consuming arm rejects", `<r><x/><keep/></r>`, false},
+		{"arms may not be mixed", `<r><p/><keep/><x/><y/></r>`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			grammar := compileGrammar(t, schema)
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.doc))
+			require.NoError(t, err)
+			verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+			if tc.valid {
+				require.NoError(t, verr, "%s should validate", tc.name)
+				return
+			}
+			require.Error(t, verr, "%s should be rejected", tc.name)
+		})
+	}
+}
+
+// TestInterleaveSplitReportsRealCause covers the interleave diagnostic. When one
+// branch matches the head element by NAME but fails on its own content, the
+// remaining branches are left unconsumed only because that branch blocked the
+// sequence. Blaming one of them ("Expecting an element X, got nothing" for an
+// element the document never even reaches) points away from the real cause, so
+// the blocked branch's own errors are reported instead.
+func TestInterleaveSplitReportsRealCause(t *testing.T) {
+	t.Parallel()
+
+	// <first> requires an <inner> child. Given <first/> empty, the interleave
+	// must report first's content failure, not "Expecting an element second".
+	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start>` +
+		`<element name="r"><interleave>` +
+		`<element name="first"><element name="inner"><empty/></element></element>` +
+		`<element name="second"><empty/></element>` +
+		`</interleave></element></start></grammar>`
+
+	grammar := compileGrammar(t, schema)
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<r><first/><second/></r>`))
+	require.NoError(t, err)
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelError)
+	verr := relaxng.NewValidator(grammar).ErrorHandler(collector).Validate(t.Context(), doc)
+	require.Error(t, verr)
+
+	var report strings.Builder
+	for _, e := range collector.Errors() {
+		report.WriteString(e.Error())
+	}
+	got := report.String()
+	require.Contains(t, got, "element first: Relax-NG validity error : Element first failed to validate content",
+		"the blocked branch's own failure must be reported")
+	require.NotContains(t, got, "Expecting an element second",
+		"an unreached branch must not be blamed")
+}
+
+// TestInterleaveSplitExpansionBounded guards the candidate-expansion cap. An
+// interleave over many optional single elements must NOT be expanded (a single
+// element already matches atomically), so validation stays fast instead of
+// enumerating 2^n arms.
+func TestInterleaveSplitExpansionBounded(t *testing.T) {
+	t.Parallel()
+
+	const n = 22
+	var branches, body strings.Builder
+	for i := range n {
+		name := "e" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+		branches.WriteString(`<optional><element name="`)
+		branches.WriteString(name)
+		branches.WriteString(`"><empty/></element></optional>`)
+		body.WriteString("<")
+		body.WriteString(name)
+		body.WriteString("/>")
+	}
+	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start>` +
+		`<element name="r"><interleave>` + branches.String() + `</interleave></element></start></grammar>`
+
+	grammar := compileGrammar(t, schema)
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<r>`+body.String()+`</r>`))
+	require.NoError(t, err)
+
+	start := time.Now()
+	require.NoError(t, relaxng.NewValidator(grammar).Validate(t.Context(), doc))
+	// 2^22 candidates would take minutes; the un-expanded match is microseconds.
+	require.Less(t, time.Since(start), 5*time.Second,
+		"an interleave of optional single elements must not be expanded")
+}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -556,216 +556,7 @@ func (v *validator) validateContentPat(pat *pattern, elem *helium.Element,
 		if len(pat.children) == 0 {
 			return 0
 		}
-		// Determine which children are repeatable (zeroOrMore/oneOrMore/text).
-		// Text is inherently repeatable in interleave (text nodes appear between elements).
-		isRepeatable := make([]bool, len(pat.children))
-		for i, child := range pat.children {
-			isRepeatable[i] = child.kind == patternZeroOrMore || child.kind == patternOneOrMore || child.kind == patternText
-		}
-
-		// For children that resolve to groups, track per-member progress.
-		// This allows group members to be matched one-by-one with other
-		// interleave children consuming elements between them. A repeatable
-		// child wrapping a group (zeroOrMore/oneOrMore of group(a,b)) is tracked
-		// the same way, with repeat=true so a completed iteration restarts at the
-		// first member — letting another interleave branch consume between group
-		// members across iterations.
-		type groupState struct {
-			members      []*pattern
-			pos          int
-			repeat       bool // member-group wrapped in zeroOrMore/oneOrMore
-			iterConsumed bool // current iteration consumed at least one item
-		}
-		groupStates := make([]*groupState, len(pat.children))
-		for i, child := range pat.children {
-			if grp := v.resolveToGroup(child); grp != nil {
-				groupStates[i] = &groupState{members: grp.children, pos: 0}
-				continue
-			}
-			if child.kind == patternZeroOrMore || child.kind == patternOneOrMore {
-				if grp := v.resolveToGroup(wrapChildren(child.children)); grp != nil {
-					groupStates[i] = &groupState{members: grp.children, pos: 0, repeat: true}
-				}
-			}
-		}
-
-		// Track which children ever consumed something.
-		consumed := make([]bool, len(pat.children))
-		// Track which single-use children are "done" (already matched once).
-		done := make([]bool, len(pat.children))
-		progress := true
-		var extraElemNode *helium.Element // node of the extra (duplicate) element
-		for progress {
-			progress = false
-			for i, child := range pat.children {
-				if done[i] {
-					// Single-use pattern already consumed. Check if the next element
-					// would match it again (= "Extra element in interleave").
-					if extraElemNode == nil {
-						remaining := skipIgnored(state.seq)
-						if len(remaining) > 0 {
-							if e, ok := remaining[0].(*helium.Element); ok {
-								savedState := state.clone()
-								savedAttrUsed := make([]bool, len(attrUsed))
-								copy(savedAttrUsed, attrUsed)
-								savedLen := len(v.pendingErrors)
-								savedValid := v.valid
-								v.suppressDepth++
-								ret := v.validateContentPat(child, elem, attrs, attrUsed, state)
-								v.suppressDepth--
-								if ret == 0 && !seqEqual(state.seq, savedState.seq) {
-									extraElemNode = e
-								}
-								*state = *savedState
-								copy(attrUsed, savedAttrUsed)
-								v.pendingErrors = v.pendingErrors[:savedLen]
-								v.valid = savedValid
-							}
-						}
-					}
-					continue
-				}
-
-				// Group children: match member-by-member so other interleave
-				// children can consume elements between group members. For a
-				// repeatable member-group, a completed iteration that consumed
-				// something restarts at the first member (a fresh group iteration).
-				if gs := groupStates[i]; gs != nil {
-					for {
-						gs.iterConsumed = false
-						blocked := false
-						for gs.pos < len(gs.members) {
-							member := gs.members[gs.pos]
-							savedState := state.clone()
-							savedAttrUsed := make([]bool, len(attrUsed))
-							copy(savedAttrUsed, attrUsed)
-							savedLen := len(v.pendingErrors)
-							savedValid := v.valid
-							v.suppressDepth++
-							ret := v.validateContentPat(member, elem, attrs, attrUsed, state)
-							v.suppressDepth--
-							if ret == 0 && (!seqEqual(state.seq, savedState.seq) || !boolSliceEqual(attrUsed, savedAttrUsed)) {
-								// Member consumed something — advance.
-								consumed[i] = true
-								progress = true
-								gs.iterConsumed = true
-								gs.pos++
-								v.pendingErrors = v.pendingErrors[:savedLen]
-								v.valid = savedValid
-								// Continue trying next members in same round
-								// (they might also match immediately).
-							} else {
-								// Member didn't consume. If nullable, skip it
-								// and try the next member.
-								*state = *savedState
-								copy(attrUsed, savedAttrUsed)
-								v.pendingErrors = v.pendingErrors[:savedLen]
-								v.valid = savedValid
-								if v.isNullable(member) {
-									gs.pos++
-									continue
-								}
-								// Not nullable — stop trying this group for now.
-								// Other interleave children may consume first.
-								blocked = true
-								break
-							}
-						}
-						// Restart a repeatable member-group only after a full
-						// iteration that consumed something; otherwise stop.
-						if gs.repeat && !blocked && gs.pos >= len(gs.members) && gs.iterConsumed {
-							gs.pos = 0
-							continue
-						}
-						break
-					}
-					if gs.pos >= len(gs.members) {
-						if !isRepeatable[i] {
-							done[i] = true
-						}
-					}
-					continue
-				}
-
-				// Non-group children: try atomic matching.
-				savedState := state.clone()
-				savedAttrUsed := make([]bool, len(attrUsed))
-				copy(savedAttrUsed, attrUsed)
-				savedLen := len(v.pendingErrors)
-				savedValid := v.valid
-				v.suppressDepth++
-				ret := v.validateContentPat(child, elem, attrs, attrUsed, state)
-				v.suppressDepth--
-				if ret == 0 && (!seqEqual(state.seq, savedState.seq) || !boolSliceEqual(attrUsed, savedAttrUsed)) {
-					consumed[i] = true
-					progress = true
-					if !isRepeatable[i] {
-						done[i] = true
-					}
-					v.pendingErrors = v.pendingErrors[:savedLen]
-					v.valid = savedValid
-				} else {
-					*state = *savedState
-					copy(attrUsed, savedAttrUsed)
-					v.pendingErrors = v.pendingErrors[:savedLen]
-					v.valid = savedValid
-				}
-			}
-		}
-		if extraElemNode != nil {
-			v.addBareError(fmt.Sprintf("Extra element %s in interleave", extraElemNode.LocalName()))
-			v.addError(extraElemNode, fmt.Sprintf("Element %s failed to validate content", elem.LocalName()))
-			return -1
-		}
-		// Check for required children that were never consumed.
-		for i, child := range pat.children {
-			if !consumed[i] && !v.isNullable(child) {
-				// For group children with partial progress, check if remaining members are all nullable.
-				if gs := groupStates[i]; gs != nil && gs.pos > 0 {
-					allNullable := true
-					for j := gs.pos; j < len(gs.members); j++ {
-						if !v.isNullable(gs.members[j]) {
-							allNullable = false
-							break
-						}
-					}
-					if allNullable {
-						continue
-					}
-				}
-				isAttr := child.kind == patternAttribute
-				if !isAttr {
-					eName := v.patternElementName(child)
-					if eName != "" {
-						v.addError(elem, fmt.Sprintf("Expecting an element %s, got nothing", eName))
-					}
-				}
-				v.addError(elem, "Invalid sequence in interleave")
-				if isAttr {
-					v.addError(elem, fmt.Sprintf("Element %s failed to validate attributes", elem.LocalName()))
-				} else {
-					v.addError(elem, fmt.Sprintf("Element %s failed to validate content", elem.LocalName()))
-				}
-				return -1
-			}
-		}
-		// A repeatable member-group that ends mid-iteration with a non-nullable
-		// remaining member has a dangling partial group (e.g. zeroOrMore(group(a,b))
-		// fed an unpaired trailing a): that is incomplete content.
-		for i := range pat.children {
-			gs := groupStates[i]
-			if gs == nil || !gs.repeat || gs.pos <= 0 || gs.pos >= len(gs.members) {
-				continue
-			}
-			for j := gs.pos; j < len(gs.members); j++ {
-				if !v.isNullable(gs.members[j]) {
-					v.addError(elem, "Invalid sequence in interleave")
-					v.addError(elem, fmt.Sprintf("Element %s failed to validate content", elem.LocalName()))
-					return -1
-				}
-			}
-		}
-		return 0
+		return v.validateInterleaveContent(pat, elem, attrs, attrUsed, state)
 
 	case patternRef, patternParentRef:
 		def := pat.resolved
@@ -1709,17 +1500,38 @@ func (v *validator) validateChoice(pat *pattern, state *validState) int {
 	return -1
 }
 
+// validateInterleave runs the naive interleave path (the bare-pattern path
+// reached from validatePattern, with no element/attribute context). It applies
+// the same associativity flattening and choice distribution as
+// validateInterleaveContent — see there for the identities — so a composite
+// branch's members may interleave with the sibling branches here too.
 func (v *validator) validateInterleave(pat *pattern, state *validState) int {
 	if len(pat.children) == 0 {
 		return 0
 	}
 
-	matched := make([]bool, len(pat.children))
+	budget := maxInterleaveExpansions
+	candidates := v.expandInterleaveBranches(pat.children, &budget, 0)
+	if len(candidates) == 0 {
+		return v.interleaveMatchNaive(pat.children, state)
+	}
+	saved := state.clone()
+	for _, branches := range candidates {
+		if ret := v.interleaveMatchNaive(branches, state); ret == 0 {
+			return 0
+		}
+		*state = *saved
+	}
+	return -1
+}
+
+func (v *validator) interleaveMatchNaive(branches []*pattern, state *validState) int {
+	matched := make([]bool, len(branches))
 	progress := true
 
 	for progress {
 		progress = false
-		for i, child := range pat.children {
+		for i, child := range branches {
 			if matched[i] {
 				continue
 			}
@@ -1735,7 +1547,7 @@ func (v *validator) validateInterleave(pat *pattern, state *validState) int {
 	}
 
 	// Check all non-nullable children were matched
-	for i, child := range pat.children {
+	for i, child := range branches {
 		if !matched[i] && !v.isNullable(child) {
 			return -1
 		}
@@ -2655,4 +2467,504 @@ func findDocElement(doc *helium.Document) *helium.Element {
 		}
 	}
 	return nil
+}
+
+// maxInterleaveExpansions caps how many expanded branch lists
+// validateInterleaveContent will try for one interleave. Distributing choice out
+// of interleave multiplies the alternatives of every expanded branch, so a
+// pathological grammar could otherwise generate an exponential number of lists.
+// When the cap is hit the expansion is abandoned and the unexpanded branch list
+// is matched on its own, which is the pre-expansion behavior: some documents that
+// interleave a composite branch's members with its siblings are then rejected,
+// but validation stays linear in the grammar.
+const maxInterleaveExpansions = 256
+
+// maxInterleaveExpandDepth bounds the recursion in expandInterleaveBranches, so
+// a grammar whose choice alternatives keep resolving to further choices cannot
+// recurse without end.
+const maxInterleaveExpandDepth = 12
+
+// interleaveEmptyBranch stands in for the absent arm of an expanded
+// optional(...) interleave branch. It is a singleton, because a branch pattern's
+// identity is part of the group-memoization key.
+var interleaveEmptyBranch = &pattern{kind: patternEmpty}
+
+// validateInterleaveContent matches an interleave against element content.
+//
+// A branch that is a nested interleave, or a choice/optional over a composite
+// (a group or interleave of more than one member), cannot be matched atomically:
+// RELAX NG lets an interleave branch's members appear anywhere among the other
+// branches' members, so the composite's members need not be contiguous in the
+// document. Two spec identities make that reachable without a general derivative
+// engine, and expandInterleaveBranches applies both to enumerate the candidate
+// branch lists:
+//
+//   - Associativity: interleave(interleave(a, b), c) accepts exactly what
+//     interleave(a, b, c) accepts, so a nested interleave is spliced into its
+//     parent.
+//   - Distributivity over choice: interleave(P, choice(Q1, Q2)) accepts exactly
+//     what choice(interleave(P, Q1), interleave(P, Q2)) accepts — and
+//     optional(Q) is choice(Q, empty) — so a choice branch is replaced by each
+//     of its alternatives in turn.
+//
+// When nothing expands, the single candidate IS pat.children and this reduces to
+// one interleaveMatch call on the original branch list, leaving every grammar
+// without such a branch matched exactly as before.
+func (v *validator) validateInterleaveContent(pat *pattern, elem *helium.Element,
+	attrs []*helium.Attribute, attrUsed []bool, state *validState) int {
+	budget := maxInterleaveExpansions
+	candidates := v.expandInterleaveBranches(pat.children, &budget, 0)
+	if len(candidates) <= 1 {
+		branches := pat.children
+		if len(candidates) == 1 {
+			branches = candidates[0]
+		}
+		return v.interleaveMatch(branches, elem, attrs, attrUsed, state)
+	}
+
+	savedState := state.clone()
+	savedAttrUsed := make([]bool, len(attrUsed))
+	copy(savedAttrUsed, attrUsed)
+	savedLen := len(v.pendingErrors)
+	savedValid := v.valid
+
+	// An interleave reports success once its required branches are satisfied; it
+	// does not require the content to be exhausted, because the caller may have
+	// more patterns to apply after it. So a candidate whose branches are ALL
+	// nullable — a choice arm of nothing but optionals — succeeds vacuously
+	// while consuming nothing, and would shadow the arm that actually describes
+	// this content. Prefer the candidate that consumes the most: take the first
+	// that leaves nothing behind, and otherwise keep the closest fit.
+	var (
+		okState     *validState
+		okAttrUsed  []bool
+		okRemaining = -1
+		fail        = 0
+		failClosest = -1
+	)
+	for i, branches := range candidates {
+		v.suppressDepth++
+		ret := v.interleaveMatch(branches, elem, attrs, attrUsed, state)
+		v.suppressDepth--
+		remaining := len(skipIgnored(state.seq))
+		switch {
+		case ret == 0 && remaining == 0:
+			v.pendingErrors = v.pendingErrors[:savedLen]
+			v.valid = savedValid
+			return 0
+		case ret == 0 && (okRemaining < 0 || remaining < okRemaining):
+			okRemaining = remaining
+			okState = state.clone()
+			okAttrUsed = append([]bool(nil), attrUsed...)
+		case ret != 0 && (failClosest < 0 || remaining < failClosest):
+			fail, failClosest = i, remaining
+		}
+		*state = *savedState
+		copy(attrUsed, savedAttrUsed)
+		v.pendingErrors = v.pendingErrors[:savedLen]
+		v.valid = savedValid
+	}
+
+	if okState != nil {
+		*state = *okState
+		copy(attrUsed, okAttrUsed)
+		return 0
+	}
+
+	// Every candidate failed. Replay the closest-fitting one with diagnostics
+	// enabled so the reported error describes the content that is actually
+	// there, instead of whichever arm the grammar happens to list first.
+	return v.interleaveMatch(candidates[fail], elem, attrs, attrUsed, state)
+}
+
+// expandInterleaveBranches enumerates the fully expanded branch lists for an
+// interleave: nested interleaves spliced in, and every choice/optional over a
+// composite replaced by each of its alternatives. See validateInterleaveContent
+// for the identities that make this sound. The first list returned is the one
+// reached by taking each expanded branch's first alternative, so an unexpandable
+// interleave yields exactly its own branch list.
+//
+// budget is decremented per emitted list and bounds the total; it returns nil
+// once exhausted, and the caller falls back to matching the unexpanded list.
+func (v *validator) expandInterleaveBranches(branches []*pattern, budget *int, depth int) [][]*pattern {
+	flat := v.flattenInterleaveBranches(branches, depth)
+
+	idx, alts := -1, []*pattern(nil)
+	if depth < maxInterleaveExpandDepth {
+		for i, branch := range flat {
+			if a := v.interleaveBranchAlternatives(branch); a != nil {
+				idx, alts = i, a
+				break
+			}
+		}
+	}
+	if idx < 0 {
+		if *budget <= 0 {
+			return nil
+		}
+		*budget--
+		return [][]*pattern{flat}
+	}
+
+	var out [][]*pattern
+	for _, alt := range alts {
+		next := make([]*pattern, 0, len(flat)+1)
+		next = append(next, flat[:idx]...)
+		next = append(next, alt)
+		next = append(next, flat[idx+1:]...)
+		sub := v.expandInterleaveBranches(next, budget, depth+1)
+		out = append(out, sub...)
+		if *budget <= 0 {
+			break
+		}
+	}
+	return out
+}
+
+// flattenInterleaveBranches splices any branch that resolves to a nested
+// interleave into the branch list, recursively. It returns branches unchanged
+// when there is nothing to splice, so the common case allocates nothing and
+// preserves the caller's slice identity.
+func (v *validator) flattenInterleaveBranches(branches []*pattern, depth int) []*pattern {
+	nested := false
+	for _, branch := range branches {
+		if resolveToInterleave(branch) != nil {
+			nested = true
+			break
+		}
+	}
+	if !nested {
+		return branches
+	}
+	out := make([]*pattern, 0, len(branches)+1)
+	for _, branch := range branches {
+		out = v.appendInterleaveBranch(out, branch, depth)
+	}
+	return out
+}
+
+func (v *validator) appendInterleaveBranch(dst []*pattern, branch *pattern, depth int) []*pattern {
+	if depth < maxInterleaveExpandDepth {
+		if inner := resolveToInterleave(branch); inner != nil {
+			for _, member := range inner.children {
+				dst = v.appendInterleaveBranch(dst, member, depth+1)
+			}
+			return dst
+		}
+	}
+	return append(dst, branch)
+}
+
+// interleaveBranchAlternatives returns the alternatives an interleave branch
+// distributes into, or nil when the branch needs no expansion. A choice
+// distributes into its arms and an optional into {content, empty} — but only when
+// at least one alternative is composite, since a single-element alternative
+// already matches atomically. That restriction is what keeps the candidate count
+// small for the common shape of an interleave over many optional single
+// elements, which would otherwise contribute a factor of two each.
+func (v *validator) interleaveBranchAlternatives(branch *pattern) []*pattern {
+	if branch == nil {
+		return nil
+	}
+	switch branch.kind {
+	case patternChoice:
+		if len(branch.children) == 0 || !v.anyCompositeBranch(branch.children) {
+			return nil
+		}
+		return branch.children
+	case patternOptional:
+		if len(branch.children) == 0 {
+			return nil
+		}
+		content := wrapChildren(branch.children)
+		if !v.isCompositeBranch(content) {
+			return nil
+		}
+		return []*pattern{content, interleaveEmptyBranch}
+	default:
+		return nil
+	}
+}
+
+func (v *validator) anyCompositeBranch(branches []*pattern) bool {
+	return slices.ContainsFunc(branches, v.isCompositeBranch)
+}
+
+// isCompositeBranch reports whether pat contributes more than one member to an
+// interleave, so its members may need to interleave with sibling branches
+// instead of matching contiguously.
+func (v *validator) isCompositeBranch(pat *pattern) bool {
+	return v.resolveToGroup(pat) != nil || resolveToInterleave(pat) != nil
+}
+
+// resolveToInterleave follows ref/parentRef links to a nested interleave of more
+// than one member, mirroring resolveToGroup. It returns nil for anything else.
+// The hop count is bounded because a ref chain is resolved at compile time and a
+// non-element ref cycle is a compile error, so this only guards against a
+// malformed grammar reaching the validator.
+func resolveToInterleave(pat *pattern) *pattern {
+	for hop := 0; pat != nil && hop <= maxInterleaveExpandDepth; hop++ {
+		switch pat.kind {
+		case patternRef, patternParentRef:
+			pat = pat.resolved
+		case patternInterleave:
+			if len(pat.children) > 1 {
+				return pat
+			}
+			return nil
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+// interleaveMatch matches one fully expanded interleave branch list against the
+// element content in state. branches is the owning interleave's branch list
+// after associativity flattening and choice distribution — see
+// validateInterleaveContent.
+func (v *validator) interleaveMatch(branches []*pattern, elem *helium.Element,
+	attrs []*helium.Attribute, attrUsed []bool, state *validState) int {
+	// Determine which children are repeatable (zeroOrMore/oneOrMore/text).
+	// Text is inherently repeatable in interleave (text nodes appear between elements).
+	isRepeatable := make([]bool, len(branches))
+	for i, child := range branches {
+		isRepeatable[i] = child.kind == patternZeroOrMore || child.kind == patternOneOrMore || child.kind == patternText
+	}
+
+	// For children that resolve to groups, track per-member progress.
+	// This allows group members to be matched one-by-one with other
+	// interleave children consuming elements between them. A repeatable
+	// child wrapping a group (zeroOrMore/oneOrMore of group(a,b)) is tracked
+	// the same way, with repeat=true so a completed iteration restarts at the
+	// first member — letting another interleave branch consume between group
+	// members across iterations.
+	type groupState struct {
+		members      []*pattern
+		pos          int
+		repeat       bool // member-group wrapped in zeroOrMore/oneOrMore
+		iterConsumed bool // current iteration consumed at least one item
+	}
+	groupStates := make([]*groupState, len(branches))
+	for i, child := range branches {
+		if grp := v.resolveToGroup(child); grp != nil {
+			groupStates[i] = &groupState{members: grp.children, pos: 0}
+			continue
+		}
+		if child.kind == patternZeroOrMore || child.kind == patternOneOrMore {
+			if grp := v.resolveToGroup(wrapChildren(child.children)); grp != nil {
+				groupStates[i] = &groupState{members: grp.children, pos: 0, repeat: true}
+			}
+		}
+	}
+
+	// Track which children ever consumed something.
+	consumed := make([]bool, len(branches))
+	// Track which single-use children are "done" (already matched once).
+	done := make([]bool, len(branches))
+	progress := true
+	var extraElemNode *helium.Element // node of the extra (duplicate) element
+	// A branch that matched the head element by NAME but failed deeper appends
+	// definitive errors — validateElement clears suppression once it has consumed
+	// the element — and the per-attempt rollback below would otherwise discard
+	// them, leaving only the generic "Expecting an element X, got nothing" for
+	// some other branch that was never even reached. Keep the errors from the
+	// attempt that got furthest, so a failing interleave can report the real
+	// cause. A branch that simply does not match by name appends nothing
+	// (elementMatchesWithErrors returns false silently on a name mismatch), so
+	// this captures only genuine inner failures.
+	var blockedErrs []error
+	blockedRemaining := -1
+	captureBlocked := func(from int, at *validState) {
+		if len(v.pendingErrors) <= from {
+			return
+		}
+		if blockedRemaining >= 0 && len(at.seq) >= blockedRemaining {
+			return
+		}
+		blockedErrs = append([]error(nil), v.pendingErrors[from:]...)
+		blockedRemaining = len(at.seq)
+	}
+	for progress {
+		progress = false
+		for i, child := range branches {
+			if done[i] {
+				// Single-use pattern already consumed. Check if the next element
+				// would match it again (= "Extra element in interleave").
+				if extraElemNode == nil {
+					remaining := skipIgnored(state.seq)
+					if len(remaining) > 0 {
+						if e, ok := remaining[0].(*helium.Element); ok {
+							savedState := state.clone()
+							savedAttrUsed := make([]bool, len(attrUsed))
+							copy(savedAttrUsed, attrUsed)
+							savedLen := len(v.pendingErrors)
+							savedValid := v.valid
+							v.suppressDepth++
+							ret := v.validateContentPat(child, elem, attrs, attrUsed, state)
+							v.suppressDepth--
+							if ret == 0 && !seqEqual(state.seq, savedState.seq) {
+								extraElemNode = e
+							}
+							*state = *savedState
+							copy(attrUsed, savedAttrUsed)
+							v.pendingErrors = v.pendingErrors[:savedLen]
+							v.valid = savedValid
+						}
+					}
+				}
+				continue
+			}
+
+			// Group children: match member-by-member so other interleave
+			// children can consume elements between group members. For a
+			// repeatable member-group, a completed iteration that consumed
+			// something restarts at the first member (a fresh group iteration).
+			if gs := groupStates[i]; gs != nil {
+				for {
+					gs.iterConsumed = false
+					blocked := false
+					for gs.pos < len(gs.members) {
+						member := gs.members[gs.pos]
+						savedState := state.clone()
+						savedAttrUsed := make([]bool, len(attrUsed))
+						copy(savedAttrUsed, attrUsed)
+						savedLen := len(v.pendingErrors)
+						savedValid := v.valid
+						v.suppressDepth++
+						ret := v.validateContentPat(member, elem, attrs, attrUsed, state)
+						v.suppressDepth--
+						if ret == 0 && (!seqEqual(state.seq, savedState.seq) || !boolSliceEqual(attrUsed, savedAttrUsed)) {
+							// Member consumed something — advance.
+							consumed[i] = true
+							progress = true
+							gs.iterConsumed = true
+							gs.pos++
+							v.pendingErrors = v.pendingErrors[:savedLen]
+							v.valid = savedValid
+							// Continue trying next members in same round
+							// (they might also match immediately).
+						} else {
+							// Member didn't consume. If nullable, skip it
+							// and try the next member.
+							captureBlocked(savedLen, state)
+							*state = *savedState
+							copy(attrUsed, savedAttrUsed)
+							v.pendingErrors = v.pendingErrors[:savedLen]
+							v.valid = savedValid
+							if v.isNullable(member) {
+								gs.pos++
+								continue
+							}
+							// Not nullable — stop trying this group for now.
+							// Other interleave children may consume first.
+							blocked = true
+							break
+						}
+					}
+					// Restart a repeatable member-group only after a full
+					// iteration that consumed something; otherwise stop.
+					if gs.repeat && !blocked && gs.pos >= len(gs.members) && gs.iterConsumed {
+						gs.pos = 0
+						continue
+					}
+					break
+				}
+				if gs.pos >= len(gs.members) {
+					if !isRepeatable[i] {
+						done[i] = true
+					}
+				}
+				continue
+			}
+
+			// Non-group children: try atomic matching.
+			savedState := state.clone()
+			savedAttrUsed := make([]bool, len(attrUsed))
+			copy(savedAttrUsed, attrUsed)
+			savedLen := len(v.pendingErrors)
+			savedValid := v.valid
+			v.suppressDepth++
+			ret := v.validateContentPat(child, elem, attrs, attrUsed, state)
+			v.suppressDepth--
+			if ret == 0 && (!seqEqual(state.seq, savedState.seq) || !boolSliceEqual(attrUsed, savedAttrUsed)) {
+				consumed[i] = true
+				progress = true
+				if !isRepeatable[i] {
+					done[i] = true
+				}
+				v.pendingErrors = v.pendingErrors[:savedLen]
+				v.valid = savedValid
+			} else {
+				captureBlocked(savedLen, state)
+				*state = *savedState
+				copy(attrUsed, savedAttrUsed)
+				v.pendingErrors = v.pendingErrors[:savedLen]
+				v.valid = savedValid
+			}
+		}
+	}
+	if extraElemNode != nil {
+		v.addBareError(fmt.Sprintf("Extra element %s in interleave", extraElemNode.LocalName()))
+		v.addError(extraElemNode, fmt.Sprintf("Element %s failed to validate content", elem.LocalName()))
+		return -1
+	}
+	// Check for required children that were never consumed.
+	for i, child := range branches {
+		if !consumed[i] && !v.isNullable(child) {
+			// For group children with partial progress, check if remaining members are all nullable.
+			if gs := groupStates[i]; gs != nil && gs.pos > 0 {
+				allNullable := true
+				for j := gs.pos; j < len(gs.members); j++ {
+					if !v.isNullable(gs.members[j]) {
+						allNullable = false
+						break
+					}
+				}
+				if allNullable {
+					continue
+				}
+			}
+			isAttr := child.kind == patternAttribute
+			if len(blockedErrs) > 0 {
+				// A branch failed on its own content rather than for want of
+				// input. Report that, not this branch: this one is unconsumed
+				// only because the blocked branch left the head element in
+				// place, so naming it would point away from the real cause.
+				v.pendingErrors = append(v.pendingErrors, blockedErrs...)
+				v.valid = false
+			} else if !isAttr {
+				eName := v.patternElementName(child)
+				if eName != "" {
+					v.addError(elem, fmt.Sprintf("Expecting an element %s, got nothing", eName))
+				}
+			}
+			v.addError(elem, "Invalid sequence in interleave")
+			if isAttr {
+				v.addError(elem, fmt.Sprintf("Element %s failed to validate attributes", elem.LocalName()))
+			} else {
+				v.addError(elem, fmt.Sprintf("Element %s failed to validate content", elem.LocalName()))
+			}
+			return -1
+		}
+	}
+	// A member-group that stops mid-iteration with a non-nullable remaining
+	// member has a dangling partial group — zeroOrMore(group(a, b)) fed an
+	// unpaired trailing a, or group(a, b) fed only a — and that is incomplete
+	// content. The consumed/nullable loop above cannot catch it: the group DID
+	// consume its earlier members, so its branch counts as consumed.
+	for i := range branches {
+		gs := groupStates[i]
+		if gs == nil || gs.pos <= 0 || gs.pos >= len(gs.members) {
+			continue
+		}
+		for j := gs.pos; j < len(gs.members); j++ {
+			if !v.isNullable(gs.members[j]) {
+				v.addError(elem, "Invalid sequence in interleave")
+				v.addError(elem, fmt.Sprintf("Element %s failed to validate content", elem.LocalName()))
+				return -1
+			}
+		}
+	}
+	return 0
 }


### PR DESCRIPTION
Fixes #1474.

## What

An `<interleave>` branch whose content is a composite — a `<group>` or `<interleave>`
of more than one member, possibly behind `<choice>`, `<optional>` or `<ref>` — had to
consume its members contiguously, so valid documents were rejected. Only a bare
`<group>` branch (what `resolveToGroup` reaches) supported splitting, via
`interleaveMatch`'s `groupStates` member-by-member tracking.

`expandInterleaveBranches` brings the other shapes into that same form using two spec
identities:

- **associativity** — `interleave(interleave(a, b), c)` accepts exactly what
  `interleave(a, b, c)` accepts, so a nested interleave (also through `<ref>`) is
  spliced into its parent's branch list.
- **distributivity over choice** — `interleave(P, choice(Q1, Q2))` accepts exactly
  what `choice(interleave(P, Q1), interleave(P, Q2))` accepts, and `optional(Q)` is
  `choice(Q, empty)`, so such a branch is tried arm by arm.

jing arrives at the same semantics for free: its derivative rule
(`StartTagOpenDerivFunction.caseInterleave`) routes each element to *either* operand
with the other left as-is, and `PatternBuilder.makeOptional(p)` is literally
`makeChoice(p, empty)`. Rewriting is needed here only because this matcher is
round-robin rather than derivative-based.

## Cost control

A branch is expanded **only when at least one alternative is composite**
(`isCompositeBranch`), since a single-element alternative already matches atomically.
That is what keeps an interleave over many `optional(element)` branches — the common
shape — on its own unexpanded list instead of contributing a factor of two each;
`TestInterleaveSplitExpansionBounded` guards it with 22 such branches.
`maxInterleaveExpansions` (256 lists) and `maxInterleaveExpandDepth` (12) bound the
enumeration, falling back to the unexpanded list.

**When nothing expands, the single candidate IS `pat.children`**, so the path reduces
to one `interleaveMatch` call on the original slice and any grammar without a
composite branch is matched exactly as before.

## Also in this change

- **Candidate selection.** An interleave signals success once its required branches
  are satisfied; it does not require the content to be exhausted, since the caller may
  have further patterns to apply. A candidate whose branches are all nullable — a
  choice arm of nothing but optionals — therefore succeeds while consuming nothing and
  would shadow the arm that describes the content. Now the first candidate that leaves
  nothing behind wins, else the closest fit.

- **Behavior tightening.** Dropped the `!gs.repeat` gate on the dangling-member-group
  check. A group that stops mid-iteration with a non-nullable remaining member is
  incomplete content whether or not a repetition wraps it. Previously
  `interleave(group(a, b), s)` **accepted** `<r><a/><s/></r>` — the group consumed its
  earlier members, so its branch counted as consumed and nothing checked completion.
  This is the one place where a document accepted before is now rejected; jing rejects
  it too.

- **Diagnostics.** When a branch matches the head element by name but fails on its own
  content, the other branches are unconsumed only because that branch blocked the
  sequence. Reporting `Expecting an element X, got nothing` for an element the document
  never reaches points away from the failure, so the blocked branch's own errors are
  reported instead.

## Compatibility evidence

`relaxng/group_backtrack_differential_test.go` output is **byte identical** before and
after — verdicts *and* exact error text — across:

- the golden schema cross-product, 16143 cases
- 20000 seeded random grammars

```
go test ./relaxng -run '^TestGroupBacktrackDifferential$' -timeout 30m \
    -relaxng.differential.out=/tmp/head.txt -relaxng.differential.cases=20000
# same on the merge base -> diff is empty
```

So no grammar without a composite interleave branch decides or words anything
differently, and the 159 libxml2 `.err` goldens are untouched.

Against **jing 20241231**, over a corpus of 14 interleave branch shapes × 11
documents: agreement rises from **140/154 to 153/154**, with **no case regressing**.

## Known remaining divergence

Not addressed here. A `group` branch whose nullable member's content appears *after* a
sibling branch's element is still rejected:

| branch | document | jing | this PR |
|---|---|---|---|
| `group(a, optional(b))` | `<r><a/><s/><b/></r>` | accept | reject |
| `group(a, zeroOrMore(b))` | `<r><a/><s/><b/></r>` | accept | reject |

The member loop skips a nullable member permanently instead of keeping it available.
Fixing it means pushing the same distributivity one level into group members
(`group(a, optional(b))` ≡ `choice(group(a, b), group(a))`), which brings its own
`2^k` expansion — worth a separate change and a separate discussion about the cap.
Noted in the commit message so it is not re-diagnosed later.

## Tests

`relaxng/interleave_split_test.go`, new:

- `TestInterleaveSplitCompositeBranch` — 8 split composite shapes must validate, 9
  genuinely invalid documents must be rejected (missing member, undeclared element,
  duplicate member, missing sibling, half-present optional/bare group).
- `TestInterleaveChoiceArmPrefersConsuming` — pins the candidate-selection rule.
- `TestInterleaveSplitReportsRealCause` — pins the diagnostic.
- `TestInterleaveSplitExpansionBounded` — 22 `optional(element)` branches must not be
  expanded.

`.claude/docs/validation-pipeline.md` gains an *Interleave Branch Expansion* section
per the repo's doc-cache rules.

`go test ./...` is clean apart from `TestConfinedFS/a_dir_FS_follows_a_symlink...`,
which fails on my machine for want of the Windows symlink privilege and also fails on
`main`.
