### PR TITLE
add relax ng interleave §7.4 conflict checks

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -979,10 +979,15 @@ RELAX NG schema compilation and validation.
   mixed, notAllowed
 - Supports: include with override, externalRef, parentRef, anyName/nsName/ncName, data types
 - Group backtracking for greedy pattern over-consumption
+- Interleave is compile-time partitioned into a routing table per branch (`interleave.go`); every `<interleave>`
+  is checked against RELAX NG §7.4 (branches' element/text/attribute name classes must be pairwise disjoint) —
+  a violating grammar is a fatal compile error (`Element or text conflicts in interleave` /
+  `Attributes conflicts in interleave`), matching libxml2
 - `ValidateError.Output` — libxml2-compatible error string; `ValidateError.Errors` — structured `[]ValidationError`
 - `ValidationError{Filename, Line, Element, Message}` — per-error structured type
 - Files: `relaxng.go` (API + config), `doc.go`, `grammar.go` (data model), `parse.go` (compiler), `parse_check.go`
-  (compile checks), `validate.go` (engine), `errors.go` (error types + formatting)
+  (compile checks), `interleave.go` (interleave partition tables + §7.4 conflict checks), `validate.go` (engine),
+  `errors.go` (error types + formatting)
 - Imports: helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xsdregex,
   internal/xmlchar, internal/uripath
 - Status: 159/159 golden tests passing

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -112,6 +112,8 @@ bug that prompted it.
 | `c14n_test.go` | c14n | C14N golden file tests |
 | `xsd_test.go` | xsd | Schema validation golden tests |
 | `relaxng_test.go` | relaxng | RELAX NG golden tests |
+| `interleave_test.go` | relaxng | Interleave §7.4 conflict checks and golden-schema conflict coverage |
+| `interleave_internal_test.go` | relaxng | Interleave partition/routing table (internal package) |
 | `group_backtrack_differential_test.go` | relaxng | Flag-gated group-backtracking differential harness |
 | `schematron_test.go` | schematron | Schematron golden tests |
 | `utf8cursor_test.go` | internal/strcursor | UTF-8 cursor boundary/normalization and ASCII QName scanner regression coverage |

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -1813,7 +1813,8 @@ IDConstraint { Kind (Unique|Key|KeyRef), Selector/Fields XPath, Refer, Namespace
 
 ## RELAX NG
 
-Files: `relaxng/relaxng.go` (API), `parse.go` (compiler), `validate.go` (engine), `grammar.go` (model)
+Files: `relaxng/relaxng.go` (API), `parse.go` (compiler), `validate.go` (engine), `grammar.go` (model),
+`interleave.go` (compile-time interleave partition tables and RELAX NG §7.4 conflict checks)
 
 ### Compile: Document → Grammar
 
@@ -1842,6 +1843,22 @@ Files: `relaxng/relaxng.go` (API), `parse.go` (compiler), `validate.go` (engine)
 6. **Rule checks** — compile-time semantic validation (`checkPattern` also follows `pattern.resolved`; visited
    set keyed by `{define pattern, ruleFlags}` so a define reached under a new ancestor context — e.g. once
    normally and once under `<list>` — is re-checked in each context)
+6a. **Interleave partitioning & §7.4 checks** — `checkInterleaves` (`interleave.go`, runs right after step 6, over
+   `compiler.interleaves`: every `interleave`/`mixed` pattern created plus every `<start>`/`<define>` merge whose
+   combined result is an interleave) computes each interleave's compile-time routing table
+   (`computeInterleavePartition`, libxml2: `xmlRelaxNGComputeInterleaves`) and stores it on `pattern.partition`.
+   For each branch, `collectInterleaveLeaves` walks group/choice/interleave/optional/zeroOrMore/oneOrMore
+   children and follows each resolved `<ref>`/`<parentRef>` once per branch, without crossing an element or
+   attribute boundary, collecting the branch's element and attribute name classes and whether it accepts
+   text/data/value/list. An element leaf whose name class is a finite union of names is entered into the
+   partition's `byName` map; a leaf whose name class is not finite (`nsName`/`anyName`) marks the branch `wild`.
+   Every branch pair is then checked for a RELAX NG §7.4 conflict via the existing `nameClassesOverlap`: an
+   overlapping element name class (or text/data/value/list in two branches) is `Element or text conflicts in
+   interleave`; an overlapping attribute name class is `Attributes conflicts in interleave` — both fatal compile
+   errors (`c.addPatternError`, libxml2 `{file}:{line}: element interleave: Relax-NG parser error : {msg}`
+   format), reported at most once each per interleave and only when the grammar has no earlier compile error
+   (`c.errorCount == 0`, the same gate libxml2 uses). Because §7.4 holds for every compiled grammar, routing a
+   node to the one branch whose leaves accept it (`interleavePartition.route`, validation-time) is exact.
 7. **Content-type checks (§7.2)** — `checkContentTypes` (runs AFTER scoped-ref resolution, so it follows
    `<ref>`/`<parentRef>` into their resolved define body) checks every `<element>` body reachable in the LIVE
    grammar. The live element bodies are gathered by `collectLiveElements` walking ONLY from the resolved start

--- a/relaxng/grammar.go
+++ b/relaxng/grammar.go
@@ -53,6 +53,9 @@ type pattern struct {
 	// by-name lookup in a single flat global define map, so nested grammars
 	// that reuse a define name keep distinct scopes.
 	resolved *pattern
+	// partition is the compile-time interleave routing table (patternInterleave
+	// only), computed by checkInterleaves.
+	partition *interleavePartition
 }
 
 // dataType identifies a datatype from a datatype library.

--- a/relaxng/group_backtrack_test.go
+++ b/relaxng/group_backtrack_test.go
@@ -38,21 +38,24 @@ import (
 //	diff /tmp/base.txt /tmp/head.txt
 //
 // Result: the diff is empty and both files hash to sha256
-// 1389c877613206c349dc2c4ebeddce2e4d36ab3df92bb3bd972a738b562c8498. Each run
-// takes well under a minute and writes 36,143 lines.
+// 171fc1e474859abe156923f8cd753746b1df91d3cd56e64679b750c3c8a24fb5. Each run
+// takes well under a minute and writes 35,819 lines.
 //
 // Corpus 1, the golden cross-product. Every schema in
 // testdata/libxml2-compat/relaxng/test validated against every instance in the
-// same directory. 6 of the 105 schemas do not compile and are recorded once
-// each as SCHEMA-ERROR, leaving 99 schemas x 163 instances = 16,137 validated
-// pairs, 16,143 lines in all: 527 VALID, 15,610 INVALID.
+// same directory. 8 of the 105 schemas do not compile and are recorded once
+// each as SCHEMA-ERROR (6 pre-existing plus interleave0_0.rng and
+// tutor14_1.rng, which violate RELAX NG §7.4's interleave name-class
+// disjointness), leaving 97 schemas x 163 instances = 15,811 validated pairs,
+// 15,819 lines in all: 517 VALID, 15,294 INVALID.
 //
 // Corpus 2, randomized group grammars. 20,000 seeded random grammars (seed 1)
 // over three shapes, including a bare <group> under <start>, which is the only
 // shape that reaches the naive backtracker: 2,889 VALID, 17,111 INVALID
-// spanning 184 distinct error texts.
+// spanning 184 distinct error texts. This half exercises no interleave shape,
+// so it is unchanged by the interleave partitioning engine.
 //
-// 13,451 of the 32,721 INVALID lines carry diagnostic text. The rest are
+// 13,429 of the 32,405 INVALID lines carry diagnostic text. The rest are
 // failures the validator reports only through the returned error without
 // emitting anything to the error handler, which is identical on both
 // revisions.

--- a/relaxng/interleave.go
+++ b/relaxng/interleave.go
@@ -1,0 +1,209 @@
+package relaxng
+
+import (
+	"context"
+
+	helium "github.com/lestrrat-go/helium"
+)
+
+// interleavePartition is the compile-time routing table of one <interleave>
+// (libxml2: xmlRelaxNGPartition). Every child node of the validated element is
+// routed to the one branch whose reachable name classes accept it; RELAX NG
+// §7.4 guarantees the branches are pairwise disjoint, so the route is exact.
+type interleavePartition struct {
+	branches []*interleaveBranch
+	byName   map[ncQName]int // exact element names → branch index
+	wild     []int           // branches carrying a non-finite element name class, scanned in order
+	text     int             // branch accepting text nodes, or -1
+}
+
+// interleaveBranch is the set of leaves one branch can start with, reachable
+// without crossing an element or attribute boundary (libxml2:
+// xmlRelaxNGGetElements with eora 2 and 1).
+type interleaveBranch struct {
+	elems []*nameClass
+	attrs []*nameClass
+	text  bool // a text, data, value or list leaf
+}
+
+// elementNameClass returns the name class an element pattern matches with.
+func elementNameClass(p *pattern) *nameClass {
+	if p.nameClass != nil {
+		return p.nameClass
+	}
+	if p.name == "" {
+		return &nameClass{kind: ncNoMatch}
+	}
+	return &nameClass{kind: ncName, name: p.name, ns: p.ns}
+}
+
+// collectInterleaveLeaves gathers the leaves of one interleave branch. It
+// descends through the composite patterns and through resolved refs (each
+// define once per branch), and stops at element and attribute boundaries.
+func collectInterleaveLeaves(p *pattern, b *interleaveBranch, visited map[*pattern]struct{}) {
+	if p == nil {
+		return
+	}
+	switch p.kind {
+	case patternElement:
+		b.elems = append(b.elems, elementNameClass(p))
+	case patternAttribute:
+		if p.nameClass != nil {
+			b.attrs = append(b.attrs, p.nameClass)
+		}
+	case patternText, patternData, patternValue, patternList:
+		b.text = true
+	case patternRef, patternParentRef:
+		def := p.resolved
+		if def == nil {
+			return
+		}
+		if _, seen := visited[def]; seen {
+			return
+		}
+		visited[def] = struct{}{}
+		collectInterleaveLeaves(def, b, visited)
+	case patternGroup, patternChoice, patternInterleave, patternOptional, patternZeroOrMore, patternOneOrMore:
+		for _, child := range p.children {
+			collectInterleaveLeaves(child, b, visited)
+		}
+	}
+}
+
+// interleaveBranchesConflict reports whether two branches violate RELAX NG
+// §7.4: an element name class in common, or text in both. It uses
+// nameClassesOverlap, which is sound (it never reports "disjoint" for classes
+// that can share a name) — this is what makes routing exact — but
+// conservative on exotic <except> shapes, which could reject a grammar
+// libxml2 accepts.
+func interleaveBranchesConflict(a, b *interleaveBranch) bool {
+	if a.text && b.text {
+		return true
+	}
+	for _, x := range a.elems {
+		for _, y := range b.elems {
+			if nameClassesOverlap(x, y) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// interleaveAttrsConflict reports whether two branches claim an overlapping
+// attribute name class.
+func interleaveAttrsConflict(a, b *interleaveBranch) bool {
+	for _, x := range a.attrs {
+		for _, y := range b.attrs {
+			if nameClassesOverlap(x, y) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// computeInterleavePartition builds the routing table for one interleave
+// pattern. For each branch, an element leaf whose name class is a finite
+// union of names is entered into byName (first writer wins — a duplicate can
+// only happen on a conflicting grammar, which fails to compile); a leaf whose
+// name class is not a finite union (nsName/anyName) marks the branch wild.
+func computeInterleavePartition(p *pattern) *interleavePartition {
+	part := &interleavePartition{byName: make(map[ncQName]int), text: -1}
+	for i, child := range p.children {
+		b := &interleaveBranch{}
+		collectInterleaveLeaves(child, b, make(map[*pattern]struct{}))
+		part.branches = append(part.branches, b)
+		if b.text && part.text < 0 {
+			part.text = i
+		}
+		wild := false
+		for _, nc := range b.elems {
+			if nc.kind == ncNoMatch {
+				continue
+			}
+			names, ok := collectFiniteNames(nc)
+			if !ok {
+				wild = true
+				continue
+			}
+			for _, n := range names {
+				if _, dup := part.byName[n]; !dup {
+					part.byName[n] = i
+				}
+			}
+		}
+		if wild {
+			part.wild = append(part.wild, i)
+		}
+	}
+	return part
+}
+
+// checkInterleaves computes every recorded interleave's partition and reports
+// RELAX NG §7.4 conflicts (libxml2: xmlRelaxNGComputeInterleaves). Conflicts
+// are reported only on a grammar with no earlier compile error, matching
+// libxml2's gate.
+func (c *compiler) checkInterleaves(ctx context.Context) {
+	report := c.errorCount == 0
+	for _, p := range c.interleaves {
+		part := computeInterleavePartition(p)
+		p.partition = part
+		if !report {
+			continue
+		}
+		elemConflict, attrConflict := false, false
+		for i := range part.branches {
+			for j := i + 1; j < len(part.branches); j++ {
+				if interleaveBranchesConflict(part.branches[i], part.branches[j]) {
+					elemConflict = true
+				}
+				if interleaveAttrsConflict(part.branches[i], part.branches[j]) {
+					attrConflict = true
+				}
+			}
+		}
+		if elemConflict {
+			c.addPatternError(ctx, p, "Element or text conflicts in interleave")
+		}
+		if attrConflict {
+			c.addPatternError(ctx, p, "Attributes conflicts in interleave")
+		}
+	}
+}
+
+// route returns the branch index for node, -1 when no branch accepts it, or
+// -2 for a node that is dropped without being routed (a comment, or a
+// whitespace-only text node when no branch accepts text).
+func (p *interleavePartition) route(node helium.Node) int {
+	switch node.Type() {
+	case helium.CommentNode:
+		return -2
+	case helium.TextNode, helium.CDATASectionNode:
+		if p.text >= 0 {
+			return p.text
+		}
+		if t, ok := node.(*helium.Text); ok && isXMLSpaceOnly(string(t.Content())) {
+			return -2
+		}
+		return -1
+	case helium.ElementNode:
+		e, ok := node.(*helium.Element)
+		if !ok {
+			return -1
+		}
+		local, ns := e.LocalName(), elemNS(e)
+		if i, ok := p.byName[ncQName{name: local, ns: ns}]; ok {
+			return i
+		}
+		for _, i := range p.wild {
+			for _, nc := range p.branches[i].elems {
+				if nameClassMatches(nc, local, ns) {
+					return i
+				}
+			}
+		}
+		return -1
+	}
+	return -1
+}

--- a/relaxng/interleave_internal_test.go
+++ b/relaxng/interleave_internal_test.go
@@ -1,0 +1,60 @@
+package relaxng
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInterleavePartitionRoute builds the routing table of
+// interleave(group(a, optional(b)), zeroOrMore(element nsName "urn:x"), text,
+// attribute k) directly (bypassing the parser) and checks both the compiled
+// table (6.4) and route (6.6) against a handful of representative nodes.
+func TestInterleavePartitionRoute(t *testing.T) {
+	t.Parallel()
+
+	elemA := &pattern{kind: patternElement, name: "a", nameClass: &nameClass{kind: ncName, name: "a"}}
+	elemB := &pattern{kind: patternElement, name: "b", nameClass: &nameClass{kind: ncName, name: "b"}}
+	group := &pattern{kind: patternGroup, children: []*pattern{
+		elemA,
+		{kind: patternOptional, children: []*pattern{elemB}},
+	}}
+
+	wildElem := &pattern{kind: patternElement, nameClass: &nameClass{kind: ncNsName, ns: "urn:x"}}
+	zeroOrMoreWild := &pattern{kind: patternZeroOrMore, children: []*pattern{wildElem}}
+
+	textPat := &pattern{kind: patternText}
+
+	attrK := &pattern{kind: patternAttribute, name: "k", nameClass: &nameClass{kind: ncName, name: "k"}}
+
+	part := computeInterleavePartition(&pattern{
+		kind:     patternInterleave,
+		children: []*pattern{group, zeroOrMoreWild, textPat, attrK},
+	})
+
+	require.Equal(t, 0, part.byName[ncQName{name: "a"}], "group branch owns a")
+	require.Equal(t, 0, part.byName[ncQName{name: "b"}], "group branch owns b")
+	require.Equal(t, []int{1}, part.wild, "only the nsName branch is wild")
+	require.Equal(t, 2, part.text, "the text branch is index 2")
+	require.Empty(t, part.branches[3].elems, "the attribute branch has no element leaves")
+	require.Len(t, part.branches[3].attrs, 1, "the attribute branch has one attribute leaf")
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(
+		`<r xmlns:p="urn:x"><a/><p:q/>text<!--c--><zz/></r>`))
+	require.NoError(t, err)
+	root := findDocElement(doc)
+	require.NotNil(t, root)
+
+	var nodes []helium.Node
+	for child := range helium.Children(root) {
+		nodes = append(nodes, child)
+	}
+	require.Len(t, nodes, 5, "a, p:q, text, comment, zz")
+
+	require.Equal(t, 0, part.route(nodes[0]), "<a/> routes to the group branch")
+	require.Equal(t, 1, part.route(nodes[1]), "<p:q/> routes to the wild nsName branch")
+	require.Equal(t, 2, part.route(nodes[2]), "the text node routes to the text branch")
+	require.Equal(t, -2, part.route(nodes[3]), "a comment is dropped, never routed")
+	require.Equal(t, -1, part.route(nodes[4]), "<zz/> matches no branch")
+}

--- a/relaxng/interleave_test.go
+++ b/relaxng/interleave_test.go
@@ -1,0 +1,229 @@
+package relaxng_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+const rngNS = "http://relaxng.org/ns/structure/1.0"
+
+// compileInterleave compiles schema and returns the concatenated fatal
+// compile-error text.
+func compileInterleave(t *testing.T, schema string) string {
+	t.Helper()
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+	require.NoError(t, err)
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	_, err = relaxng.NewCompiler().Label("test.rng").ErrorHandler(collector).Compile(t.Context(), doc)
+	require.NoError(t, err)
+	_ = collector.Close()
+	_, compileErrors := partitionCompileErrors(collector.Errors())
+	return compileErrors
+}
+
+// TestInterleaveNameClassConflict covers the compile-time RELAX NG §7.4
+// interleave conflict check: overlapping element/text name classes and
+// overlapping attribute name classes across interleave branches are fatal
+// compile errors, reported in libxml2's exact wording.
+func TestInterleaveNameClassConflict(t *testing.T) {
+	t.Parallel()
+
+	const elemConflictMsg = "element interleave: Relax-NG parser error : Element or text conflicts in interleave"
+	const attrConflictMsg = "element interleave: Relax-NG parser error : Attributes conflicts in interleave"
+
+	t.Run("two same-name element branches conflict", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<element name="root" xmlns="`+rngNS+`">
+  <interleave>
+    <element name="a"><empty/></element>
+    <element name="a"><text/></element>
+  </interleave>
+</element>`)
+		require.Contains(t, errs, elemConflictMsg)
+	})
+
+	t.Run("text in two branches conflicts", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<element name="root" xmlns="`+rngNS+`">
+  <interleave>
+    <text/>
+    <text/>
+  </interleave>
+</element>`)
+		require.Contains(t, errs, elemConflictMsg)
+	})
+
+	t.Run("mixed whose group contains text conflicts", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<element name="root" xmlns="`+rngNS+`">
+  <mixed>
+    <element name="a"><empty/></element>
+    <text/>
+  </mixed>
+</element>`)
+		require.Contains(t, errs, elemConflictMsg)
+	})
+
+	t.Run("anyName element vs named element conflicts", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<element name="root" xmlns="`+rngNS+`">
+  <interleave>
+    <element><anyName/><empty/></element>
+    <element name="a"><empty/></element>
+  </interleave>
+</element>`)
+		require.Contains(t, errs, elemConflictMsg)
+	})
+
+	t.Run("conflict reached through ref", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<grammar xmlns="`+rngNS+`">
+  <start>
+    <element name="root">
+      <interleave>
+        <element name="a"><empty/></element>
+        <ref name="optA"/>
+      </interleave>
+    </element>
+  </start>
+  <define name="optA">
+    <optional><element name="a"><text/></element></optional>
+  </define>
+</grammar>`)
+		require.Contains(t, errs, elemConflictMsg)
+	})
+
+	t.Run("combine interleave defines flags second define's line", func(t *testing.T) {
+		t.Parallel()
+		// The second <define> below starts on line 6.
+		errs := compileInterleave(t, `<grammar xmlns="`+rngNS+`">
+  <start><ref name="foo"/></start>
+  <define name="foo" combine="interleave">
+    <element name="a"><empty/></element>
+  </define>
+  <define name="foo" combine="interleave">
+    <element name="a"><text/></element>
+  </define>
+</grammar>`)
+		require.Contains(t, errs, elemConflictMsg)
+		require.Contains(t, errs, ":6: "+elemConflictMsg)
+	})
+
+	t.Run("two attribute branches through refs conflict", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<grammar xmlns="`+rngNS+`">
+  <start>
+    <element name="root">
+      <interleave>
+        <ref name="attrA"/>
+        <ref name="attrB"/>
+      </interleave>
+    </element>
+  </start>
+  <define name="attrA"><attribute name="x"/></define>
+  <define name="attrB"><attribute name="x"/></define>
+</grammar>`)
+		require.Contains(t, errs, attrConflictMsg)
+	})
+
+	t.Run("no conflict for anyName-except vs the excluded name", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<element name="root" xmlns="`+rngNS+`">
+  <interleave>
+    <element><anyName><except><name>a</name></except></anyName><empty/></element>
+    <element name="a"><empty/></element>
+  </interleave>
+</element>`)
+		require.Empty(t, errs)
+	})
+
+	t.Run("no conflict for nsName in a different namespace than a plain name", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<element name="root" xmlns="`+rngNS+`">
+  <interleave>
+    <element><nsName ns="urn:x"/><empty/></element>
+    <element name="a"><empty/></element>
+  </interleave>
+</element>`)
+		require.Empty(t, errs)
+	})
+
+	t.Run("no conflict between text and elements", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<element name="root" xmlns="`+rngNS+`">
+  <interleave>
+    <text/>
+    <element name="a"><empty/></element>
+  </interleave>
+</element>`)
+		require.Empty(t, errs)
+	})
+
+	t.Run("mixed(a, b) has no conflict", func(t *testing.T) {
+		t.Parallel()
+		errs := compileInterleave(t, `<element name="root" xmlns="`+rngNS+`">
+  <mixed>
+    <element name="a"><empty/></element>
+    <element name="b"><empty/></element>
+  </mixed>
+</element>`)
+		require.Empty(t, errs)
+	})
+}
+
+// TestGoldenSchemasInterleaveConflicts checks every committed RELAX NG golden
+// schema for §7.4 interleave conflicts: every schema except interleave0_0.rng
+// and tutor14_1.rng must compile without an interleave-conflict diagnostic,
+// and those two must produce exactly the "Element or text conflicts in
+// interleave" line at the line their <interleave> starts on (libxml2 parity;
+// see the design's section 2.2).
+func TestGoldenSchemasInterleaveConflicts(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(testdataBase, "test")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	expected := map[string]string{
+		"interleave0_0.rng": "interleave0_0.rng:4: element interleave: Relax-NG parser error : " +
+			"Element or text conflicts in interleave\n",
+		"tutor14_1.rng": "tutor14_1.rng:21: element interleave: Relax-NG parser error : " +
+			"Element or text conflicts in interleave\n",
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".rng" {
+			continue
+		}
+		name := entry.Name()
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			data, err := os.ReadFile(filepath.Join(dir, name))
+			require.NoError(t, err)
+			doc, err := helium.NewParser().Parse(t.Context(), data)
+			if err != nil {
+				// Not well-formed XML (e.g. broken-xml.rng), irrelevant to the
+				// §7.4 interleave-conflict check this test covers.
+				return
+			}
+
+			collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+			_, err = relaxng.NewCompiler().Label(name).ErrorHandler(collector).Compile(t.Context(), doc)
+			require.NoError(t, err)
+			_ = collector.Close()
+			_, compileErrors := partitionCompileErrors(collector.Errors())
+
+			if want, ok := expected[name]; ok {
+				require.Equal(t, want, compileErrors)
+				return
+			}
+			require.NotContains(t, compileErrors, "conflicts in interleave")
+		})
+	}
+}

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -64,6 +64,10 @@ type compiler struct {
 	// replaced by an <include> override is never checked even though its node is
 	// still recorded here.
 	elementNodes map[*pattern]*helium.Element
+	// interleaves records every interleave pattern created (including one
+	// produced by combining <start>/<define> via combine="interleave"), for
+	// checkInterleaves to partition and §7.4-check after refs are resolved.
+	interleaves []*pattern
 }
 
 // pendingRef is a ref/parentRef node awaiting compile-time resolution against
@@ -164,6 +168,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 
 	c.grammar.start = startPat
 	c.checkRules(ctx)
+	c.checkInterleaves(ctx)
 
 	// Fail closed: if compilation produced any fatal errors (e.g. an unbound
 	// namespace prefix), the grammar must not validate any instance. A poisoned
@@ -421,7 +426,10 @@ func (c *compiler) parseStart(ctx context.Context, elem *helium.Element) {
 	if combineMode == "" {
 		combineMode = existing.combine
 	}
-	existing.pattern = combinePatterns(existing.pattern, pat, combineMode)
+	existing.pattern = combinePatterns(existing.pattern, pat, combineMode, elem.Line())
+	if existing.pattern.kind == patternInterleave {
+		c.interleaves = append(c.interleaves, existing.pattern)
+	}
 	if combineMode != "" {
 		existing.combine = combineMode
 	}
@@ -468,7 +476,10 @@ func (c *compiler) parseDefine(ctx context.Context, elem *helium.Element) {
 	if combineMode == "" {
 		combineMode = existing.combine
 	}
-	existing.pattern = combinePatterns(existing.pattern, pat, combineMode)
+	existing.pattern = combinePatterns(existing.pattern, pat, combineMode, elem.Line())
+	if existing.pattern.kind == patternInterleave {
+		c.interleaves = append(c.interleaves, existing.pattern)
+	}
 	if combineMode != "" {
 		existing.combine = combineMode
 	}
@@ -489,13 +500,16 @@ func (c *compiler) validateCombineValue(ctx context.Context, combine string) {
 	c.addBareSchemaError(ctx, msg)
 }
 
-// combinePatterns combines two patterns with the given combine mode.
-func combinePatterns(existing, incoming *pattern, mode string) *pattern {
+// combinePatterns combines two patterns with the given combine mode. line is
+// the source line of the <start>/<define> element being combined, recorded on
+// an interleave result so a §7.4 conflict error can point at it.
+func combinePatterns(existing, incoming *pattern, mode string, line int) *pattern {
 	switch mode {
 	case combineInterleave:
 		return &pattern{
 			kind:     patternInterleave,
 			children: []*pattern{existing, incoming},
+			line:     line,
 		}
 	case combineChoice:
 		return &pattern{
@@ -848,11 +862,13 @@ func (c *compiler) parsePattern(ctx context.Context, node *helium.Element) *patt
 	case "interleave":
 		p := &pattern{kind: patternInterleave, line: node.Line()}
 		p.children = c.parsePatternChildren(ctx, node)
+		c.interleaves = append(c.interleaves, p)
 		return p
 	case "mixed":
 		// mixed is interleave with text
 		p := &pattern{kind: patternInterleave, line: node.Line()}
 		children := c.parsePatternChildren(ctx, node)
+		c.interleaves = append(c.interleaves, p)
 		textPat := &pattern{kind: patternText}
 		if len(children) > 1 {
 			groupPat := &pattern{kind: patternGroup, children: children}


### PR DESCRIPTION
- enforce RELAX NG §7.4 interleave name-class disjointness at compile time, matching libxml2 (issue #1474)
- lay compile-time interleave partition tables for the follow-up validation-engine rewrite
